### PR TITLE
MCP write path: durable inbox, approval-gated and replay-safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ See `.claude/rules/tdd.md` for the full workflow.
 
 ## Key Conventions
 
+- **Simulator**: match the real device — Evan carries an **iPhone 13 Pro Max on iOS 26.5.x**. Do not substitute whatever simulator ships newest; on 2026-07-27 an iPhone 17 run produced a false `ChatCoachTests` failure that did not reproduce on the real hardware. The previously documented `iPhone 16e` no longer exists in Xcode.
+
 - **Architecture**: MVVM with `@Observable` ViewModels
 - **DI**: Protocol-based. Every service/repository has a protocol. Tests inject mocks.
 - **Testing**: Swift Testing (`@Test`, `#expect`) — NOT XCTest (`XCTAssert*`)
@@ -84,11 +86,15 @@ See `.claude/rules/` for detailed guidance on each area.
 ```bash
 # Build
 xcodebuild -scheme ClaudeLifter \
-  -destination 'platform=iOS Simulator,name=iPhone 16e' build
+  -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max' build
 
 # Test
 xcodebuild -scheme ClaudeLifter \
-  -destination 'platform=iOS Simulator,name=iPhone 16e' test
+  -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max' test
+
+# Test on the real device (highest fidelity; UI tests run in-memory, real data untouched)
+xcodebuild -scheme ClaudeLifter \
+  -destination 'platform=iOS,name=Evan DeLord'\''s iPhone' test
 
 # Skills (when available)
 /build    # Build the project
@@ -138,6 +144,8 @@ ClaudeLifterTests/
 
 ## Key Files
 
+- `HANDOFF.md` — **Read this first if it exists.** Pickup state for work in flight: what is verified vs assumed, what remains, and how to check it.
+- `infra/MCP_WRITE_PATH.md` — MCP inbox write-path design (#88): why direct Cosmos writes cannot work, and why exercises are referenced by `externalId` not UUID
 - `SPEC.md` — Full product specification (features, data model, architecture, phasing)
 - `.claude/rules/` — Code style, TDD, SwiftData, AI service patterns
 - `.claude/agents/` — Agent definitions with file ownership

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,21 +47,31 @@ Full specification: @SPEC.md
 
 ## Current Phase
 
-**Phase 2 — Cloud Sync + Images** (Phase 1 complete: 166/166 tests passing)
+**Phases 1–2 complete. Phase 3 all but Live Activities.** The app is deployed and in
+daily use; work is now issue-driven, not phase-driven — **the open GitHub issues are
+the real backlog**, not this list.
 
-- [ ] Azure Bicep infrastructure (Cosmos DB, Storage, Function App)
-- [ ] Azure Functions API (sync/pull, sync/push, images/sas, chat proxy, insights, health)
-- [ ] Model updates (syncStatus/lastModified on WorkoutTemplate, ProactiveInsight, TrainingPreference)
-- [ ] Sync DTOs + SyncMapper (Codable model ↔ JSON conversion)
-- [ ] NetworkService (URLSession wrapper with auth)
-- [ ] SyncManager (NWPathMonitor, pull/push, BGAppRefreshTask, last-write-wins)
-- [ ] API key proxy (Anthropic key moves from device to Azure Function)
-- [ ] Calendar heatmap (monthly view with workout intensity shading)
-- [ ] Photo capture (PhotosPicker + Azure Blob upload via SAS tokens)
-- [ ] InsightRepository (ProactiveInsight CRUD)
-- [ ] Settings updates (server URL, sync status indicator)
+Phase 2 — Cloud Sync + Images: **done and deployed** (Bicep infra; Functions API;
+sync DTOs + `SyncMapper`; `NetworkService`; `SyncManager`; Anthropic key proxied via
+`ProxiedAnthropicService`; `CalendarHeatmapView`; `PhotoCaptureView` + SAS upload;
+`InsightRepository`; Settings server URL + sync status).
 
-See SPEC.md §7 for Azure Backend details, §11 for Phase 2 scope.
+Phase 3 — MCP + Advanced AI: **done** except Live Activities. MCP server ships read
+tools (#79) and inbox-based writes (#88); proactive insights, 15 chat tools incl.
+template/program generation, `PRDetectionService`, and `ChartsView` all exist.
+Also shipped beyond the original plan: body-weight tracking + HealthKit (#80),
+backup export/import (#72), crash recovery (#75), rest-timer notifications (#77).
+
+- [ ] **Live Activities** — rest timer on Lock Screen / Dynamic Island. No
+      `ActivityKit` usage in the codebase; the only unstarted phase item.
+
+> **SPEC.md §7 and §11 are stale on sync.** They describe bidirectional
+> last-write-wins with `/sync/pull` and `/sync/push`. That design was replaced in
+> #78 by a **one-way snapshot mirror**: the phone is authoritative, pushes complete
+> state, and the server reconciles by deleting anything absent. `syncPull.ts` and
+> `syncPush.ts` still exist but no client calls them (#92 tracks removal). Trust
+> `infra/functions/src/functions/syncSnapshot.ts` and `infra/MCP_WRITE_PATH.md`
+> over the SPEC here.
 
 ## Development Methodology
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,10 @@ See `.claude/rules/tdd.md` for the full workflow.
 
 ## Key Conventions
 
-- **Simulator**: match the real device — Evan carries an **iPhone 13 Pro Max on iOS 26.5.x**. Do not substitute whatever simulator ships newest; on 2026-07-27 an iPhone 17 run produced a false `ChatCoachTests` failure that did not reproduce on the real hardware. The previously documented `iPhone 16e` no longer exists in Xcode.
+- **Simulator**: match the real device — Evan carries an **iPhone 13 Pro Max on iOS 26.5.x**. Do not substitute whatever simulator ships newest; on 2026-07-27 an iPhone 17 run produced a false `ChatCoachTests` failure that did not reproduce on the real hardware. The previously documented `iPhone 16e` no longer exists in Xcode. If the destination is missing, **create it** rather than substituting:
+  `xcrun simctl create "iPhone 13 Pro Max" com.apple.CoreSimulator.SimDeviceType.iPhone-13-Pro-Max com.apple.CoreSimulator.SimRuntime.iOS-26-5`
+
+- **Typechecking is not testing.** A clean `tsc`/`swiftc` parse says nothing about behavior — on 2026-07-27 two rounds of write-path work typechecked cleanly and still failed the simulator suite. Run `xcodebuild test` before claiming a change works, and beware piping it through `tail` without `set -o pipefail`, which masks the real exit code.
 
 - **Architecture**: MVVM with `@Observable` ViewModels
 - **DI**: Protocol-based. Every service/repository has a protocol. Tests inject mocks.

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		7FCB344C018E65A2B3F68ADB /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B1A9F545D493DBBC868FA7 /* NetworkService.swift */; };
 		FB0247EC69FD3FB4F904EC26 /* NetworkServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED2D3A491B300D7F75FB92 /* NetworkServiceProtocol.swift */; };
 		85EF683A8D5CD5A5463743F9 /* SyncDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BCD31C7FFC0403D006A026 /* SyncDTOs.swift */; };
+		88A200000000000000000003 /* InboxDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B200000000000000000003 /* InboxDTOs.swift */; };
+		88A200000000000000000004 /* InboxApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B200000000000000000004 /* InboxApplier.swift */; };
 		367E44EFD711971EE9F26E88 /* SyncError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF8ADEB5FD7877F7B7421B6 /* SyncError.swift */; };
 		9E26B7F9F296082858EC69A4 /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE7D363C6D2F123079F0F22 /* SyncManager.swift */; };
 		713C33F9CEAFFD78A9316763 /* SyncMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FB222B5EBDBA88E426695A /* SyncMapper.swift */; };
@@ -177,6 +179,7 @@
 		A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */; };
 		74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */; };
 		AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A31E123184E639F96BB6D /* SyncMapperTests.swift */; };
+		88A100000000000000000001 /* InboxApplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B100000000000000000001 /* InboxApplierTests.swift */; };
 		DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */; };
 		ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */; };
 		BD88CA8763EA48B6DF5EA1C0 /* BodyWeightViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A754765C32959052E27AC76D /* BodyWeightViewModelTests.swift */; };
@@ -292,6 +295,8 @@
 		F9B1A9F545D493DBBC868FA7 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		2CED2D3A491B300D7F75FB92 /* NetworkServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceProtocol.swift; sourceTree = "<group>"; };
 		C9BCD31C7FFC0403D006A026 /* SyncDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDTOs.swift; sourceTree = "<group>"; };
+		88B200000000000000000003 /* InboxDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDTOs.swift; sourceTree = "<group>"; };
+		88B200000000000000000004 /* InboxApplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxApplier.swift; sourceTree = "<group>"; };
 		4FF8ADEB5FD7877F7B7421B6 /* SyncError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncError.swift; sourceTree = "<group>"; };
 		4AE7D363C6D2F123079F0F22 /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
 		16FB222B5EBDBA88E426695A /* SyncMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMapper.swift; sourceTree = "<group>"; };
@@ -400,6 +405,7 @@
 		063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDTOTests.swift; sourceTree = "<group>"; };
 		1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManagerTests.swift; sourceTree = "<group>"; };
 		980A31E123184E639F96BB6D /* SyncMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMapperTests.swift; sourceTree = "<group>"; };
+		88B100000000000000000001 /* InboxApplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxApplierTests.swift; sourceTree = "<group>"; };
 		F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModelTests.swift; sourceTree = "<group>"; };
 		BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		A754765C32959052E27AC76D /* BodyWeightViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightViewModelTests.swift; sourceTree = "<group>"; };
@@ -602,6 +608,8 @@
 				F9B1A9F545D493DBBC868FA7,
 				2CED2D3A491B300D7F75FB92,
 				C9BCD31C7FFC0403D006A026,
+				88B200000000000000000003,
+				88B200000000000000000004,
 				4FF8ADEB5FD7877F7B7421B6,
 				4AE7D363C6D2F123079F0F22,
 				16FB222B5EBDBA88E426695A,
@@ -836,6 +844,7 @@
 				063A59D9339A3ED9F05E1365,
 				1C0617F4620F537F4CD40042,
 				980A31E123184E639F96BB6D,
+				88B100000000000000000001,
 			);
 			path = ServiceTests;
 			sourceTree = "<group>";
@@ -1059,6 +1068,8 @@
 				7FCB344C018E65A2B3F68ADB /* NetworkService.swift in Sources */,
 				FB0247EC69FD3FB4F904EC26 /* NetworkServiceProtocol.swift in Sources */,
 				85EF683A8D5CD5A5463743F9 /* SyncDTOs.swift in Sources */,
+				88A200000000000000000003 /* InboxDTOs.swift in Sources */,
+				88A200000000000000000004 /* InboxApplier.swift in Sources */,
 				367E44EFD711971EE9F26E88 /* SyncError.swift in Sources */,
 				9E26B7F9F296082858EC69A4 /* SyncManager.swift in Sources */,
 				713C33F9CEAFFD78A9316763 /* SyncMapper.swift in Sources */,
@@ -1174,6 +1185,7 @@
 				A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */,
 				74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */,
 				AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */,
+				88A100000000000000000001 /* InboxApplierTests.swift in Sources */,
 				DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */,
 				ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */,
 				BD88CA8763EA48B6DF5EA1C0 /* BodyWeightViewModelTests.swift in Sources */,

--- a/ClaudeLifter/App/DependencyContainer.swift
+++ b/ClaudeLifter/App/DependencyContainer.swift
@@ -18,6 +18,7 @@ final class DependencyContainer {
     let insightGenerationService: any InsightGenerationServiceProtocol
     let backupService: any BackupServiceProtocol
     let bodyWeightRepository: any BodyWeightRepository
+    let inboxApplier: InboxApplier
     let healthKitService: any HealthKitServiceProtocol
     /// Shared rest-timer tick source — one instance for the app instead of
     /// per-view instantiation (issue #77).
@@ -64,6 +65,11 @@ final class DependencyContainer {
         self.imageUploadService = ImageUploadService(networkService: network)
         let bodyWeightRepo = SwiftDataBodyWeightRepository(context: modelContext)
         self.bodyWeightRepository = bodyWeightRepo
+        let inboxApplier = InboxApplier(
+            templateRepository: templateRepo,
+            exerciseRepository: exerciseRepo
+        )
+        self.inboxApplier = inboxApplier
         self.healthKitService = HealthKitService()
         self.restTimerService = RestTimerService()
         self.notificationScheduler = UserNotificationScheduler()
@@ -89,7 +95,8 @@ final class DependencyContainer {
             exerciseRepository: exerciseRepo,
             bodyWeightRepository: bodyWeightRepo,
             networkService: network,
-            settings: settings
+            settings: settings,
+            inboxApplier: inboxApplier
         )
     }
 }

--- a/ClaudeLifter/Services/Sync/InboxApplier.swift
+++ b/ClaudeLifter/Services/Sync/InboxApplier.swift
@@ -3,9 +3,11 @@ import Foundation
 enum InboxApplyError: Error, LocalizedError {
     case malformedPayload(String)
     case unknownOperation(String)
+    case invalidOperationId(String)
     case invalidTemplateId(String)
     case templateNotFound(String)
     case unresolvedExerciseIds([String])
+    case invalidCustomExternalId(String)
 
     var errorDescription: String? {
         switch self {
@@ -13,12 +15,16 @@ enum InboxApplyError: Error, LocalizedError {
             return "Malformed inbox payload: \(reason)"
         case .unknownOperation(let operation):
             return "Unknown inbox operation: \(operation)"
+        case .invalidOperationId(let id):
+            return "Invalid inbox operation id: \(id)"
         case .invalidTemplateId(let id):
             return "Invalid template id: \(id)"
         case .templateNotFound(let id):
             return "Template not found: \(id)"
         case .unresolvedExerciseIds(let ids):
             return "Unresolved exercise externalIds: \(ids.joined(separator: ", "))"
+        case .invalidCustomExternalId(let id):
+            return "Invalid custom exercise externalId: \(id)"
         }
     }
 }
@@ -62,51 +68,130 @@ final class InboxApplier {
         return results
     }
 
+    /// Applies one server-durable approval after an explicit user decision.
+    func approve(_ operation: InboxOperationDTO) async -> InboxAckResult {
+        do {
+            let approvalRequired = try approvalRequirement(for: operation.op)
+            try validateApprovalFlag(
+                operation,
+                expected: approvalRequired
+            )
+            guard approvalRequired else {
+                throw InboxApplyError.malformedPayload(
+                    "Operation does not require approval"
+                )
+            }
+            guard operation.status == "awaitingApproval" else {
+                throw InboxApplyError.malformedPayload(
+                    "Expected awaitingApproval status, got \(operation.status)"
+                )
+            }
+            try await apply(operation)
+            return InboxAckResult(id: operation.id, status: .applied)
+        } catch {
+            return InboxAckResult(
+                id: operation.id,
+                status: .failed,
+                error: error.localizedDescription
+            )
+        }
+    }
+
+    /// Declining an approval is intentionally repository-free.
+    func decline(_ operation: InboxOperationDTO) -> InboxAckResult {
+        do {
+            let approvalRequired = try approvalRequirement(for: operation.op)
+            try validateApprovalFlag(
+                operation,
+                expected: approvalRequired
+            )
+            guard approvalRequired,
+                  operation.status == "awaitingApproval" else {
+                throw InboxApplyError.malformedPayload(
+                    "Expected an approval-required awaitingApproval operation"
+                )
+            }
+            return InboxAckResult(id: operation.id, status: .rejected)
+        } catch {
+            return InboxAckResult(
+                id: operation.id,
+                status: .failed,
+                error: error.localizedDescription
+            )
+        }
+    }
+
     private func process(_ operation: InboxOperationDTO) async throws -> InboxAckResult {
         guard operation.status == "pending" else {
             throw InboxApplyError.malformedPayload(
                 "Expected pending status, got \(operation.status)"
             )
         }
+        let approvalRequired = try approvalRequirement(for: operation.op)
+        try validateApprovalFlag(operation, expected: approvalRequired)
+        guard !approvalRequired else {
+            return InboxAckResult(
+                id: operation.id,
+                status: .awaitingApproval
+            )
+        }
 
+        try await apply(operation)
+        return InboxAckResult(id: operation.id, status: .applied)
+    }
+
+    private func apply(_ operation: InboxOperationDTO) async throws {
         switch operation.op {
         case "createTemplate":
             let payload = try decode(CreateTemplatePayload.self, from: operation.payload)
-            try await createTemplate(payload)
-            return InboxAckResult(id: operation.id, status: .applied)
+            try await createTemplate(
+                payload,
+                id: try entityID(for: operation)
+            )
 
         case "createCustomExercise":
             let payload = try decode(CreateCustomExercisePayload.self, from: operation.payload)
-            try await createCustomExercise(payload)
-            return InboxAckResult(id: operation.id, status: .applied)
+            try await createCustomExercise(
+                payload,
+                id: try entityID(for: operation)
+            )
 
         case "updateTemplate":
             let payload = try decode(UpdateTemplatePayload.self, from: operation.payload)
             try validateUpdatePayload(payload)
             try await updateTemplate(payload)
-            return InboxAckResult(id: operation.id, status: .applied)
 
         case "deleteTemplate":
             let payload = try decode(DeleteTemplatePayload.self, from: operation.payload)
             try validateDeletePayload(payload)
             try await deleteTemplate(payload)
-            return InboxAckResult(id: operation.id, status: .applied)
 
         default:
             throw InboxApplyError.unknownOperation(operation.op)
         }
     }
 
-    private func createTemplate(_ payload: CreateTemplatePayload) async throws {
+    private func createTemplate(
+        _ payload: CreateTemplatePayload,
+        id: UUID
+    ) async throws {
         try validateTemplatePayload(name: payload.name, exercises: payload.exercises)
+        guard try await templateRepository.fetch(id: id) == nil else {
+            return
+        }
         let resolved = try await resolve(payload.exercises)
-        let template = WorkoutTemplate(name: payload.name, notes: payload.notes)
+        let template = WorkoutTemplate(
+            id: id,
+            name: payload.name,
+            notes: payload.notes
+        )
         template.exercises = makeTemplateExercises(from: resolved)
         try await templateRepository.save(template)
     }
 
     private func createCustomExercise(
-        _ payload: CreateCustomExercisePayload
+        _ payload: CreateCustomExercisePayload,
+        id: UUID
     ) async throws {
         let name = payload.name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else {
@@ -114,17 +199,71 @@ final class InboxApplier {
                 "Custom exercise name must not be empty"
             )
         }
+        guard let externalId = payload.externalId,
+              isValidCustomExternalId(externalId, operationId: id) else {
+            throw InboxApplyError.invalidCustomExternalId(
+                payload.externalId ?? "<missing>"
+            )
+        }
+        guard try await exerciseRepository.fetch(id: id) == nil else {
+            return
+        }
         let exercise = Exercise(
+            id: id,
             name: name,
             equipment: payload.equipment,
             instructions: payload.instructions ?? [],
             primaryMuscles: payload.primaryMuscles ?? [],
             secondaryMuscles: payload.secondaryMuscles ?? [],
             isCustom: true,
-            externalId: "custom:\(slug(name))",
+            externalId: externalId,
             notes: payload.notes
         )
         try await exerciseRepository.save(exercise)
+    }
+
+    private func approvalRequirement(for operation: String) throws -> Bool {
+        switch operation {
+        case "updateTemplate", "deleteTemplate":
+            return true
+        case "createTemplate", "createCustomExercise":
+            return false
+        default:
+            throw InboxApplyError.unknownOperation(operation)
+        }
+    }
+
+    private func validateApprovalFlag(
+        _ operation: InboxOperationDTO,
+        expected: Bool
+    ) throws {
+        guard operation.requiresApproval == expected else {
+            throw InboxApplyError.malformedPayload(
+                "\(operation.op) approval flag mismatch: "
+                    + "stored \(operation.requiresApproval), expected \(expected)"
+            )
+        }
+    }
+
+    private func isValidCustomExternalId(
+        _ externalId: String,
+        operationId: UUID
+    ) -> Bool {
+        let parts = externalId.split(
+            separator: ":",
+            omittingEmptySubsequences: false
+        )
+        guard parts.count == 3,
+              parts[0] == "custom",
+              (1...64).contains(parts[1].count),
+              parts[1].range(
+                of: #"^[a-z0-9]+(?:-[a-z0-9]+)*$"#,
+                options: .regularExpression
+              ) != nil,
+              let suffix = UUID(uuidString: String(parts[2])) else {
+            return false
+        }
+        return suffix == operationId
     }
 
     private func updateTemplate(_ payload: UpdateTemplatePayload) async throws {
@@ -296,19 +435,11 @@ final class InboxApplier {
         }
     }
 
-    private func slug(_ name: String) -> String {
-        let folded = name.folding(
-            options: [.caseInsensitive, .diacriticInsensitive],
-            locale: Locale(identifier: "en_US_POSIX")
-        )
-        let pieces = folded.unicodeScalars.split {
-            !CharacterSet.alphanumerics.contains($0)
+    private func entityID(for operation: InboxOperationDTO) throws -> UUID {
+        guard let id = UUID(uuidString: operation.id) else {
+            throw InboxApplyError.invalidOperationId(operation.id)
         }
-        let slug = pieces
-            .map { String(String.UnicodeScalarView($0)) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "-")
-            .lowercased()
-        return slug.isEmpty ? "exercise" : slug
+        return id
     }
+
 }

--- a/ClaudeLifter/Services/Sync/InboxApplier.swift
+++ b/ClaudeLifter/Services/Sync/InboxApplier.swift
@@ -1,0 +1,314 @@
+import Foundation
+
+enum InboxApplyError: Error, LocalizedError {
+    case malformedPayload(String)
+    case unknownOperation(String)
+    case invalidTemplateId(String)
+    case templateNotFound(String)
+    case unresolvedExerciseIds([String])
+
+    var errorDescription: String? {
+        switch self {
+        case .malformedPayload(let reason):
+            return "Malformed inbox payload: \(reason)"
+        case .unknownOperation(let operation):
+            return "Unknown inbox operation: \(operation)"
+        case .invalidTemplateId(let id):
+            return "Invalid template id: \(id)"
+        case .templateNotFound(let id):
+            return "Template not found: \(id)"
+        case .unresolvedExerciseIds(let ids):
+            return "Unresolved exercise externalIds: \(ids.joined(separator: ", "))"
+        }
+    }
+}
+
+/// Applies durable inbox operations to phone-owned repositories.
+///
+/// This service has no networking and no ModelContext dependency. Every
+/// operation is decoded and handled independently, and all exercise references
+/// are resolved before a template is mutated or saved.
+@MainActor
+final class InboxApplier {
+    private let templateRepository: any TemplateRepository
+    private let exerciseRepository: any ExerciseRepository
+
+    init(
+        templateRepository: any TemplateRepository,
+        exerciseRepository: any ExerciseRepository
+    ) {
+        self.templateRepository = templateRepository
+        self.exerciseRepository = exerciseRepository
+    }
+
+    /// Process every operation even when an earlier one is malformed or fails.
+    func process(_ operations: [InboxOperationDTO]) async -> [InboxAckResult] {
+        var results: [InboxAckResult] = []
+        results.reserveCapacity(operations.count)
+
+        for operation in operations {
+            do {
+                results.append(try await process(operation))
+            } catch {
+                results.append(
+                    InboxAckResult(
+                        id: operation.id,
+                        status: .failed,
+                        error: error.localizedDescription
+                    )
+                )
+            }
+        }
+        return results
+    }
+
+    private func process(_ operation: InboxOperationDTO) async throws -> InboxAckResult {
+        guard operation.status == "pending" else {
+            throw InboxApplyError.malformedPayload(
+                "Expected pending status, got \(operation.status)"
+            )
+        }
+
+        switch operation.op {
+        case "createTemplate":
+            let payload = try decode(CreateTemplatePayload.self, from: operation.payload)
+            try await createTemplate(payload)
+            return InboxAckResult(id: operation.id, status: .applied)
+
+        case "createCustomExercise":
+            let payload = try decode(CreateCustomExercisePayload.self, from: operation.payload)
+            try await createCustomExercise(payload)
+            return InboxAckResult(id: operation.id, status: .applied)
+
+        case "updateTemplate":
+            let payload = try decode(UpdateTemplatePayload.self, from: operation.payload)
+            try validateUpdatePayload(payload)
+            try await updateTemplate(payload)
+            return InboxAckResult(id: operation.id, status: .applied)
+
+        case "deleteTemplate":
+            let payload = try decode(DeleteTemplatePayload.self, from: operation.payload)
+            try validateDeletePayload(payload)
+            try await deleteTemplate(payload)
+            return InboxAckResult(id: operation.id, status: .applied)
+
+        default:
+            throw InboxApplyError.unknownOperation(operation.op)
+        }
+    }
+
+    private func createTemplate(_ payload: CreateTemplatePayload) async throws {
+        try validateTemplatePayload(name: payload.name, exercises: payload.exercises)
+        let resolved = try await resolve(payload.exercises)
+        let template = WorkoutTemplate(name: payload.name, notes: payload.notes)
+        template.exercises = makeTemplateExercises(from: resolved)
+        try await templateRepository.save(template)
+    }
+
+    private func createCustomExercise(
+        _ payload: CreateCustomExercisePayload
+    ) async throws {
+        let name = payload.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw InboxApplyError.malformedPayload(
+                "Custom exercise name must not be empty"
+            )
+        }
+        let exercise = Exercise(
+            name: name,
+            equipment: payload.equipment,
+            instructions: payload.instructions ?? [],
+            primaryMuscles: payload.primaryMuscles ?? [],
+            secondaryMuscles: payload.secondaryMuscles ?? [],
+            isCustom: true,
+            externalId: "custom:\(slug(name))",
+            notes: payload.notes
+        )
+        try await exerciseRepository.save(exercise)
+    }
+
+    private func updateTemplate(_ payload: UpdateTemplatePayload) async throws {
+        guard let id = UUID(uuidString: payload.id) else {
+            throw InboxApplyError.invalidTemplateId(payload.id)
+        }
+        guard let template = try await templateRepository.fetch(id: id) else {
+            throw InboxApplyError.templateNotFound(payload.id)
+        }
+
+        var replacementExercises: [TemplateExercise]?
+        if let exercises = payload.exercises {
+            try validateTemplatePayload(name: payload.name ?? template.name, exercises: exercises)
+            replacementExercises = makeTemplateExercises(
+                from: try await resolve(exercises)
+            )
+        }
+
+        if let name = payload.name {
+            template.name = name
+        }
+        if let notes = payload.notes {
+            template.notes = notes
+        }
+        if let replacementExercises {
+            template.exercises = replacementExercises
+        }
+        template.updatedAt = .now
+        template.recordChange()
+        try await templateRepository.save(template)
+    }
+
+    private func deleteTemplate(_ payload: DeleteTemplatePayload) async throws {
+        guard let id = UUID(uuidString: payload.id) else {
+            throw InboxApplyError.invalidTemplateId(payload.id)
+        }
+        // Desired state is already reached if a prior apply succeeded but its
+        // acknowledgement response was lost.
+        guard let template = try await templateRepository.fetch(id: id) else {
+            return
+        }
+        try await templateRepository.delete(template)
+    }
+
+    private typealias ResolvedExercise = (
+        payload: InboxTemplateExercisePayload,
+        exercise: Exercise
+    )
+
+    private func resolve(
+        _ payloads: [InboxTemplateExercisePayload]
+    ) async throws -> [ResolvedExercise] {
+        var resolved: [ResolvedExercise] = []
+        var unresolved: [String] = []
+
+        for payload in payloads {
+            if let exercise = try await exerciseRepository.fetchByExternalId(
+                payload.externalId
+            ) {
+                resolved.append((payload, exercise))
+            } else {
+                unresolved.append(payload.externalId)
+            }
+        }
+
+        guard unresolved.isEmpty else {
+            throw InboxApplyError.unresolvedExerciseIds(unresolved)
+        }
+        return resolved.sorted { $0.payload.order < $1.payload.order }
+    }
+
+    private func makeTemplateExercises(
+        from resolved: [ResolvedExercise]
+    ) -> [TemplateExercise] {
+        resolved.map { item in
+            TemplateExercise(
+                order: item.payload.order,
+                exercise: item.exercise,
+                defaultSets: item.payload.defaultSets,
+                defaultReps: item.payload.defaultReps,
+                defaultWeight: item.payload.defaultWeight,
+                defaultRestSeconds: item.payload.defaultRestSeconds ?? 90,
+                notes: item.payload.notes
+            )
+        }
+    }
+
+    private func validateTemplatePayload(
+        name: String,
+        exercises: [InboxTemplateExercisePayload]
+    ) throws {
+        guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InboxApplyError.malformedPayload(
+                "Template name must not be empty"
+            )
+        }
+
+        var orders = Set<Int>()
+        for exercise in exercises {
+            guard !exercise.externalId.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty else {
+                throw InboxApplyError.malformedPayload(
+                    "Exercise externalId must not be empty"
+                )
+            }
+            guard exercise.order >= 0, orders.insert(exercise.order).inserted else {
+                throw InboxApplyError.malformedPayload(
+                    "Exercise orders must be unique non-negative integers"
+                )
+            }
+            guard exercise.defaultSets > 0, exercise.defaultReps > 0 else {
+                throw InboxApplyError.malformedPayload(
+                    "Exercise sets and reps must be positive"
+                )
+            }
+            if let weight = exercise.defaultWeight, !weight.isFinite {
+                throw InboxApplyError.malformedPayload(
+                    "Exercise defaultWeight must be finite"
+                )
+            }
+            if let rest = exercise.defaultRestSeconds, rest < 0 {
+                throw InboxApplyError.malformedPayload(
+                    "Exercise defaultRestSeconds must be non-negative"
+                )
+            }
+        }
+    }
+
+    private func validateUpdatePayload(
+        _ payload: UpdateTemplatePayload
+    ) throws {
+        guard !payload.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InboxApplyError.malformedPayload(
+                "Template id must not be empty"
+            )
+        }
+        if let name = payload.name,
+           name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw InboxApplyError.malformedPayload(
+                "Template name must not be empty"
+            )
+        }
+    }
+
+    private func validateDeletePayload(
+        _ payload: DeleteTemplatePayload
+    ) throws {
+        guard !payload.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InboxApplyError.malformedPayload(
+                "Template id must not be empty"
+            )
+        }
+        guard !payload.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw InboxApplyError.malformedPayload(
+                "Template name must not be empty"
+            )
+        }
+    }
+
+    private func decode<Payload: Decodable>(
+        _ type: Payload.Type,
+        from payload: InboxJSONValue
+    ) throws -> Payload {
+        do {
+            return try payload.decode(type)
+        } catch {
+            throw InboxApplyError.malformedPayload(error.localizedDescription)
+        }
+    }
+
+    private func slug(_ name: String) -> String {
+        let folded = name.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+        let pieces = folded.unicodeScalars.split {
+            !CharacterSet.alphanumerics.contains($0)
+        }
+        let slug = pieces
+            .map { String(String.UnicodeScalarView($0)) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+            .lowercased()
+        return slug.isEmpty ? "exercise" : slug
+    }
+}

--- a/ClaudeLifter/Services/Sync/InboxDTOs.swift
+++ b/ClaudeLifter/Services/Sync/InboxDTOs.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// A lossless Codable representation of an arbitrary JSON value.
+///
+/// Inbox payloads stay generic at the batch boundary so one malformed
+/// operation can be failed independently instead of making the entire GET
+/// response undecodable. `InboxApplier` decodes each payload into its
+/// operation-specific type.
+enum InboxJSONValue: Codable, Sendable, Equatable {
+    case object([String: InboxJSONValue])
+    case array([InboxJSONValue])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([InboxJSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: InboxJSONValue].self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .number(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    func decode<Payload: Decodable>(_ type: Payload.Type) throws -> Payload {
+        let data = try JSONEncoder().encode(self)
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+}
+
+struct InboxTemplateExercisePayload: Codable, Sendable, Equatable {
+    let externalId: String
+    let order: Int
+    let defaultSets: Int
+    let defaultReps: Int
+    let defaultWeight: Double?
+    let defaultRestSeconds: Int?
+    let notes: String?
+}
+
+struct CreateTemplatePayload: Codable, Sendable, Equatable {
+    let name: String
+    let notes: String?
+    let exercises: [InboxTemplateExercisePayload]
+}
+
+struct UpdateTemplatePayload: Codable, Sendable, Equatable {
+    let id: String
+    let name: String?
+    let notes: String?
+    let exercises: [InboxTemplateExercisePayload]?
+}
+
+struct DeleteTemplatePayload: Codable, Sendable, Equatable {
+    let id: String
+    let name: String
+}
+
+struct CreateCustomExercisePayload: Codable, Sendable, Equatable {
+    let name: String
+    let equipment: String?
+    let primaryMuscles: [String]?
+    let secondaryMuscles: [String]?
+    let instructions: [String]?
+    let notes: String?
+}
+
+/// GET /api/inbox operation envelope. `op` and `status` remain raw strings so
+/// an unknown value is isolated to this operation by the applier.
+struct InboxOperationDTO: Codable, Sendable, Equatable {
+    let id: String
+    let createdAt: String
+    let op: String
+    let payload: InboxJSONValue
+    let requiresApproval: Bool
+    let status: String
+    let appliedAt: String?
+    let error: String?
+}
+
+struct InboxListResponse: Codable, Sendable, Equatable {
+    let operations: [InboxOperationDTO]
+}
+
+enum InboxAckStatus: String, Codable, Sendable, Equatable {
+    case applied
+    case failed
+}
+
+struct InboxAckResult: Codable, Sendable, Equatable {
+    let id: String
+    let status: InboxAckStatus
+    let error: String?
+
+    init(id: String, status: InboxAckStatus, error: String? = nil) {
+        self.id = id
+        self.status = status
+        self.error = error
+    }
+}
+
+struct InboxAckRequest: Codable, Sendable, Equatable {
+    let results: [InboxAckResult]
+}
+
+struct InboxAckCounts: Codable, Sendable, Equatable {
+    let updated: Int
+    let unchanged: Int
+    let notFound: Int
+    let invalid: Int
+}
+
+struct InboxAckResponse: Codable, Sendable, Equatable {
+    let counts: InboxAckCounts
+}

--- a/ClaudeLifter/Services/Sync/InboxDTOs.swift
+++ b/ClaudeLifter/Services/Sync/InboxDTOs.swift
@@ -86,6 +86,7 @@ struct DeleteTemplatePayload: Codable, Sendable, Equatable {
 
 struct CreateCustomExercisePayload: Codable, Sendable, Equatable {
     let name: String
+    let externalId: String?
     let equipment: String?
     let primaryMuscles: [String]?
     let secondaryMuscles: [String]?
@@ -110,8 +111,18 @@ struct InboxListResponse: Codable, Sendable, Equatable {
     let operations: [InboxOperationDTO]
 }
 
-enum InboxAckStatus: String, Codable, Sendable, Equatable {
+enum InboxOperationStatus: String, Codable, Sendable, Equatable {
+    case pending
+    case awaitingApproval
     case applied
+    case rejected
+    case failed
+}
+
+enum InboxAckStatus: String, Codable, Sendable, Equatable {
+    case awaitingApproval
+    case applied
+    case rejected
     case failed
 }
 
@@ -138,6 +149,30 @@ struct InboxAckCounts: Codable, Sendable, Equatable {
     let invalid: Int
 }
 
+enum InboxAckOutcome: String, Codable, Sendable, Equatable {
+    case updated
+    case unchanged
+    case notFound
+    case conflict
+}
+
+struct InboxAckOperationResult: Codable, Sendable, Equatable {
+    let id: String
+    let requestedStatus: InboxAckStatus
+    let resultingStatus: String?
+    let outcome: InboxAckOutcome
+    let conflict: String?
+}
+
 struct InboxAckResponse: Codable, Sendable, Equatable {
     let counts: InboxAckCounts
+    let results: [InboxAckOperationResult]
+
+    init(
+        counts: InboxAckCounts,
+        results: [InboxAckOperationResult] = []
+    ) {
+        self.counts = counts
+        self.results = results
+    }
 }

--- a/ClaudeLifter/Services/Sync/NetworkService.swift
+++ b/ClaudeLifter/Services/Sync/NetworkService.swift
@@ -147,8 +147,11 @@ final class NetworkService: NetworkServiceProtocol, @unchecked Sendable {
         try await get(endpoint: "/api/sync/snapshot", queryItems: [])
     }
 
-    func fetchInbox() async throws -> InboxListResponse {
-        try await get(endpoint: "/api/inbox", queryItems: [])
+    func fetchInbox(status: InboxOperationStatus) async throws -> InboxListResponse {
+        try await get(
+            endpoint: "/api/inbox",
+            queryItems: [URLQueryItem(name: "status", value: status.rawValue)]
+        )
     }
 
     func ackInbox(_ request: InboxAckRequest) async throws -> InboxAckResponse {

--- a/ClaudeLifter/Services/Sync/NetworkService.swift
+++ b/ClaudeLifter/Services/Sync/NetworkService.swift
@@ -147,6 +147,14 @@ final class NetworkService: NetworkServiceProtocol, @unchecked Sendable {
         try await get(endpoint: "/api/sync/snapshot", queryItems: [])
     }
 
+    func fetchInbox() async throws -> InboxListResponse {
+        try await get(endpoint: "/api/inbox", queryItems: [])
+    }
+
+    func ackInbox(_ request: InboxAckRequest) async throws -> InboxAckResponse {
+        try await post(endpoint: "/api/inbox/ack", body: request)
+    }
+
     func uploadBlob(url: URL, data: Data, contentType: String) async throws {
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"

--- a/ClaudeLifter/Services/Sync/NetworkServiceProtocol.swift
+++ b/ClaudeLifter/Services/Sync/NetworkServiceProtocol.swift
@@ -16,8 +16,8 @@ protocol NetworkServiceProtocol: Sendable {
 
     // Durable MCP write inbox (issue #88)
 
-    /// GET /api/inbox?status=pending — pending operations, oldest first.
-    func fetchInbox() async throws -> InboxListResponse
+    /// GET /api/inbox?status=... — operations in one server-durable state.
+    func fetchInbox(status: InboxOperationStatus) async throws -> InboxListResponse
     /// POST /api/inbox/ack — acknowledge independent operation results.
     func ackInbox(_ request: InboxAckRequest) async throws -> InboxAckResponse
 }

--- a/ClaudeLifter/Services/Sync/NetworkServiceProtocol.swift
+++ b/ClaudeLifter/Services/Sync/NetworkServiceProtocol.swift
@@ -13,4 +13,11 @@ protocol NetworkServiceProtocol: Sendable {
     func pushSnapshot(_ request: SnapshotPushRequest) async throws -> SnapshotPushResponse
     /// GET /api/sync/snapshot — disaster-restore read of the mirror.
     func fetchSnapshot() async throws -> SnapshotFetchResponse
+
+    // Durable MCP write inbox (issue #88)
+
+    /// GET /api/inbox?status=pending — pending operations, oldest first.
+    func fetchInbox() async throws -> InboxListResponse
+    /// POST /api/inbox/ack — acknowledge independent operation results.
+    func ackInbox(_ request: InboxAckRequest) async throws -> InboxAckResponse
 }

--- a/ClaudeLifter/Services/Sync/SyncError.swift
+++ b/ClaudeLifter/Services/Sync/SyncError.swift
@@ -12,6 +12,10 @@ enum SyncError: Error, LocalizedError {
     /// GET /api/sync/snapshot returned revision 0 — the mirror has never
     /// received a push. Restoring would wipe local data with nothing.
     case emptyMirror
+    /// The server rejected one or more inbox status transitions and preserved
+    /// their existing state.
+    case inboxAckConflict([String])
+    case inboxApplyFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -29,6 +33,10 @@ enum SyncError: Error, LocalizedError {
             return "A sync is already running. Try again in a moment."
         case .emptyMirror:
             return "The cloud has no snapshot yet — nothing to restore. Sync from this phone first."
+        case .inboxAckConflict(let details):
+            return "Inbox acknowledgement conflict: \(details.joined(separator: "; "))"
+        case .inboxApplyFailed(let reason):
+            return "Inbox operation failed: \(reason)"
         }
     }
 }

--- a/ClaudeLifter/Services/Sync/SyncManager.swift
+++ b/ClaudeLifter/Services/Sync/SyncManager.swift
@@ -26,6 +26,13 @@ enum SyncState: Equatable {
     case pending
 }
 
+@MainActor
+protocol InboxApprovalManaging: AnyObject {
+    func fetchPendingApprovals() async throws -> [InboxOperationDTO]
+    func approve(_ operation: InboxOperationDTO) async throws
+    func decline(_ operation: InboxOperationDTO) async throws
+}
+
 /// Per-collection outcome of a cloud restore, surfaced in the Settings alert.
 struct RestoreSummary: Sendable, Equatable {
     var workouts = 0
@@ -48,13 +55,14 @@ struct RestoreSummary: Sendable, Equatable {
 /// Per-record `syncStatus` survives purely as the local "is a push due" bit.
 @Observable
 @MainActor
-final class SyncManager {
+final class SyncManager: InboxApprovalManaging {
     var isSyncing = false
     var lastSyncDate: Date?
     /// Server-assigned revision of the last successful push or restore.
     var lastRevision: Int?
     var syncError: String?
     var isConnected = true
+    private(set) var pendingApprovals: [InboxOperationDTO] = []
 
     /// Derived UI state. See `SyncState` for priority rules.
     var state: SyncState {
@@ -130,25 +138,38 @@ final class SyncManager {
         defer { isSyncing = false }
 
         do {
+            var deferredInboxAckError: Error?
             // Inbox work must run before the pending guard. An idle phone has
             // no pending local records until this step creates one.
-            var inboxAppliedChange = false
-            let inbox = try await networkService.fetchInbox()
+            let inbox = try await networkService.fetchInbox(status: .pending)
             if !inbox.operations.isEmpty {
                 let results = await inboxApplier.process(inbox.operations)
-                inboxAppliedChange = results.contains { $0.status == .applied }
-                _ = try await networkService.ackInbox(
-                    InboxAckRequest(results: results)
+                if results.contains(where: { $0.status == .applied }) {
+                    settings.isSnapshotDirty = true
+                }
+                let request = InboxAckRequest(results: results)
+                let response = try await networkService.ackInbox(
+                    request
                 )
+                do {
+                    try validateInboxAck(request: request, response: response)
+                } catch {
+                    deferredInboxAckError = error
+                }
             }
+            _ = try await fetchPendingApprovals()
 
             // Any record turning .pending means a snapshot push is due. The
             // snapshot itself is always FULL state — pending is only the trigger.
             let hasPending = try await hasPendingChanges()
-            // Exercise has no per-record syncStatus, so an inbox-created custom
-            // exercise also uses the applied result as its same-cycle trigger.
-            guard inboxAppliedChange || hasPending else { return }
-            try await pushSnapshot()
+            // Exercise has no per-record syncStatus, so inbox-applied changes
+            // also set a durable trigger that survives a failed push/restart.
+            if settings.isSnapshotDirty || hasPending {
+                try await pushSnapshot()
+            }
+            if let deferredInboxAckError {
+                throw deferredInboxAckError
+            }
         } catch {
             syncError = error.localizedDescription
         }
@@ -159,6 +180,135 @@ final class SyncManager {
         if try await !templateRepository.fetchPending().isEmpty { return true }
         if try await !bodyWeightRepository.fetchPending().isEmpty { return true }
         return false
+    }
+
+    private func validateInboxAck(
+        request: InboxAckRequest,
+        response: InboxAckResponse
+    ) throws {
+        var issues: [String] = []
+        var requested: [String: InboxAckStatus] = [:]
+        for result in request.results {
+            if requested.updateValue(result.status, forKey: result.id) != nil {
+                issues.append("\(result.id): duplicate requested id")
+            }
+        }
+        let received = Dictionary(grouping: response.results, by: \.id)
+
+        for (id, requestedStatus) in requested {
+            guard let matches = received[id] else {
+                issues.append("\(id): missing result")
+                continue
+            }
+            guard matches.count == 1, let result = matches.first else {
+                issues.append("\(id): expected exactly one result")
+                continue
+            }
+            if result.requestedStatus != requestedStatus {
+                issues.append(
+                    "\(id): requested status \(result.requestedStatus.rawValue) "
+                        + "does not match \(requestedStatus.rawValue)"
+                )
+            }
+            switch result.outcome {
+            case .notFound:
+                issues.append("\(id): operation not found")
+            case .conflict:
+                issues.append(
+                    "\(id): "
+                        + (result.conflict
+                            ?? "status remained \(result.resultingStatus ?? "unknown")")
+                )
+            case .updated, .unchanged:
+                break
+            }
+        }
+        for id in received.keys where requested[id] == nil {
+            issues.append("\(id): extra result")
+        }
+        if response.counts.notFound > 0,
+           !issues.contains(where: {
+               $0.localizedCaseInsensitiveContains("not found")
+           }) {
+            issues.append(
+                "Server reported \(response.counts.notFound) not found result(s)"
+            )
+        }
+        if response.counts.invalid > 0,
+           !response.results.contains(where: { $0.outcome == .conflict }) {
+            issues.append(
+                "Server reported \(response.counts.invalid) conflict(s)"
+            )
+        }
+        guard issues.isEmpty else {
+            throw SyncError.inboxAckConflict(issues)
+        }
+    }
+
+    // MARK: - Inbox approvals
+
+    @discardableResult
+    func fetchPendingApprovals() async throws -> [InboxOperationDTO] {
+        let response = try await networkService.fetchInbox(
+            status: .awaitingApproval
+        )
+        pendingApprovals = response.operations
+        return pendingApprovals
+    }
+
+    func approve(_ operation: InboxOperationDTO) async throws {
+        try await performApprovalDecision(operation, approving: true)
+    }
+
+    func decline(_ operation: InboxOperationDTO) async throws {
+        try await performApprovalDecision(operation, approving: false)
+    }
+
+    private func performApprovalDecision(
+        _ operation: InboxOperationDTO,
+        approving: Bool
+    ) async throws {
+        guard !isSyncing else { throw SyncError.syncInProgress }
+        isSyncing = true
+        syncError = nil
+        defer { isSyncing = false }
+
+        do {
+            let result = approving
+                ? await inboxApplier.approve(operation)
+                : inboxApplier.decline(operation)
+            if result.status == .applied {
+                settings.isSnapshotDirty = true
+            }
+            let request = InboxAckRequest(results: [result])
+            let response = try await networkService.ackInbox(
+                request
+            )
+            var ackValidationError: Error?
+            do {
+                try validateInboxAck(request: request, response: response)
+            } catch {
+                ackValidationError = error
+            }
+            if ackValidationError == nil {
+                pendingApprovals.removeAll { $0.id == operation.id }
+            }
+
+            if result.status == .failed {
+                throw SyncError.inboxApplyFailed(
+                    result.error ?? "Unknown local apply error"
+                )
+            }
+            if result.status == .applied {
+                try await pushSnapshot()
+            }
+            if let ackValidationError {
+                throw ackValidationError
+            }
+        } catch {
+            syncError = error.localizedDescription
+            throw error
+        }
     }
 
     // MARK: - Push
@@ -204,6 +354,7 @@ final class SyncManager {
         }
 
         recordSuccess(revision: response.revision, serverTime: response.serverTime)
+        settings.isSnapshotDirty = false
     }
 
     // MARK: - Restore

--- a/ClaudeLifter/Services/Sync/SyncManager.swift
+++ b/ClaudeLifter/Services/Sync/SyncManager.swift
@@ -74,6 +74,7 @@ final class SyncManager {
     private let bodyWeightRepository: any BodyWeightRepository
     private let networkService: any NetworkServiceProtocol
     private let settings: SettingsManager
+    private let inboxApplier: InboxApplier
 
     private var pathMonitor: NWPathMonitor?
     private let monitorQueue = DispatchQueue(label: "com.claudelifter.sync.monitor")
@@ -84,7 +85,8 @@ final class SyncManager {
         exerciseRepository: any ExerciseRepository,
         bodyWeightRepository: any BodyWeightRepository,
         networkService: any NetworkServiceProtocol,
-        settings: SettingsManager
+        settings: SettingsManager,
+        inboxApplier: InboxApplier
     ) {
         self.workoutRepository = workoutRepository
         self.templateRepository = templateRepository
@@ -92,6 +94,7 @@ final class SyncManager {
         self.bodyWeightRepository = bodyWeightRepository
         self.networkService = networkService
         self.settings = settings
+        self.inboxApplier = inboxApplier
         self.lastSyncDate = settings.lastSyncTimestamp
         self.lastRevision = settings.lastSyncRevision
     }
@@ -127,9 +130,24 @@ final class SyncManager {
         defer { isSyncing = false }
 
         do {
+            // Inbox work must run before the pending guard. An idle phone has
+            // no pending local records until this step creates one.
+            var inboxAppliedChange = false
+            let inbox = try await networkService.fetchInbox()
+            if !inbox.operations.isEmpty {
+                let results = await inboxApplier.process(inbox.operations)
+                inboxAppliedChange = results.contains { $0.status == .applied }
+                _ = try await networkService.ackInbox(
+                    InboxAckRequest(results: results)
+                )
+            }
+
             // Any record turning .pending means a snapshot push is due. The
             // snapshot itself is always FULL state — pending is only the trigger.
-            guard try await hasPendingChanges() else { return }
+            let hasPending = try await hasPendingChanges()
+            // Exercise has no per-record syncStatus, so an inbox-created custom
+            // exercise also uses the applied result as its same-cycle trigger.
+            guard inboxAppliedChange || hasPending else { return }
             try await pushSnapshot()
         } catch {
             syncError = error.localizedDescription

--- a/ClaudeLifter/Utilities/SettingsManager.swift
+++ b/ClaudeLifter/Utilities/SettingsManager.swift
@@ -44,6 +44,7 @@ final class SettingsManager {
         static let serverURL = "serverURL"
         static let lastSyncTimestamp = "lastSyncTimestamp"
         static let lastSyncRevision = "lastSyncRevision"
+        static let isSnapshotDirty = "isSnapshotDirty"
         static let proactiveInsightsEnabled = "proactiveInsightsEnabled"
     }
 
@@ -81,6 +82,12 @@ final class SettingsManager {
         }
     }
 
+    /// Durable trigger for inbox-applied changes that have no per-record
+    /// `syncStatus` (notably custom exercises).
+    var isSnapshotDirty: Bool {
+        didSet { defaults.set(isSnapshotDirty, forKey: Key.isSnapshotDirty) }
+    }
+
     // MARK: - Init (loads from UserDefaults)
 
     init(defaults: UserDefaults = .standard, keychainKey: String? = nil) {
@@ -100,6 +107,7 @@ final class SettingsManager {
         self.serverURL = defaults.string(forKey: Key.serverURL) ?? ""
         self.lastSyncTimestamp = defaults.object(forKey: Key.lastSyncTimestamp) as? Date
         self.lastSyncRevision = defaults.object(forKey: Key.lastSyncRevision) as? Int
+        self.isSnapshotDirty = defaults.bool(forKey: Key.isSnapshotDirty)
         // Missing key → treat as enabled (legacy install default).
         if defaults.object(forKey: Key.proactiveInsightsEnabled) == nil {
             self.proactiveInsightsEnabled = true

--- a/ClaudeLifter/ViewModels/HomeViewModel.swift
+++ b/ClaudeLifter/ViewModels/HomeViewModel.swift
@@ -78,3 +78,57 @@ final class HomeViewModel {
 enum HomeViewModelError: Error {
     case noWorkoutRepository
 }
+
+@Observable
+@MainActor
+final class InboxApprovalViewModel {
+    private(set) var approvals: [InboxOperationDTO] = []
+    var errorMessage: String?
+    var isLoading = false
+
+    private let manager: any InboxApprovalManaging
+
+    init(manager: any InboxApprovalManaging) {
+        self.manager = manager
+    }
+
+    func load() async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            approvals = try await manager.fetchPendingApprovals()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func approve(_ operation: InboxOperationDTO) async {
+        await decide(operation) {
+            try await manager.approve(operation)
+        }
+    }
+
+    func decline(_ operation: InboxOperationDTO) async {
+        await decide(operation) {
+            try await manager.decline(operation)
+        }
+    }
+
+    func replaceApprovals(_ operations: [InboxOperationDTO]) {
+        approvals = operations
+    }
+
+    private func decide(
+        _ operation: InboxOperationDTO,
+        action: () async throws -> Void
+    ) async {
+        errorMessage = nil
+        do {
+            try await action()
+            approvals.removeAll { $0.id == operation.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -5,6 +5,7 @@ struct HomeView: View {
     @Environment(AppState.self) private var appState
     @State private var vm: HomeViewModel?
     @State private var bodyWeightVM: BodyWeightViewModel?
+    @State private var approvalVM: InboxApprovalViewModel?
     @State private var showTemplateEditor = false
     @State private var unreadInsights: [ProactiveInsight] = []
     @State private var path = NavigationPath()
@@ -45,6 +46,12 @@ struct HomeView: View {
                     settings: deps.settings
                 )
             }
+            if approvalVM == nil {
+                approvalVM = InboxApprovalViewModel(
+                    manager: deps.syncManager
+                )
+            }
+            await approvalVM?.load()
             // Honour the user's Settings toggle — don't even fetch insight
             // cards if they're disabled. Prevents a "pile up after weeks
             // away" cluttered Home screen.
@@ -66,6 +73,22 @@ struct HomeView: View {
                     await vm?.checkForResumableWorkout()
                 }
             }
+        }
+        .onChange(of: deps?.syncManager.pendingApprovals ?? []) { _, approvals in
+            approvalVM?.replaceApprovals(approvals)
+        }
+        .alert(
+            "Approval Error",
+            isPresented: Binding(
+                get: { approvalVM?.errorMessage != nil },
+                set: { if !$0 { approvalVM?.errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                approvalVM?.errorMessage = nil
+            }
+        } message: {
+            Text(approvalVM?.errorMessage ?? "")
         }
         .sheet(isPresented: $showTemplateEditor) {
             if let deps {
@@ -94,6 +117,19 @@ struct HomeView: View {
                     onResume: { resumeWorkout(resumable) },
                     onDiscard: { Task { await vm.discardResumableWorkout() } }
                 )
+            }
+            if let approvalVM {
+                ForEach(approvalVM.approvals, id: \.id) { operation in
+                    InboxApprovalCard(
+                        operation: operation,
+                        onApprove: {
+                            Task { await approvalVM.approve(operation) }
+                        },
+                        onDecline: {
+                            Task { await approvalVM.decline(operation) }
+                        }
+                    )
+                }
             }
             if let bodyWeightVM {
                 BodyWeightCard(vm: bodyWeightVM)
@@ -236,5 +272,103 @@ struct HomeView: View {
             .buttonStyle(.bordered)
         }
         .padding(.horizontal)
+    }
+}
+
+private struct InboxApprovalCard: View {
+    let operation: InboxOperationDTO
+    let onApprove: () -> Void
+    let onDecline: () -> Void
+
+    @State private var isReviewing = false
+
+    var body: some View {
+        cardContent
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(
+                .quaternary.opacity(0.5),
+                in: RoundedRectangle(cornerRadius: 12)
+            )
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .confirmationDialog(
+                operation.approvalTitle,
+                isPresented: $isReviewing,
+                titleVisibility: .visible
+            ) {
+                approvalActions
+            } message: {
+                Text(operation.approvalDetail)
+            }
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Approval required", systemImage: "checkmark.shield")
+                .font(.caption)
+                .foregroundStyle(BrandTheme.terracotta)
+            Text(operation.approvalTitle)
+                .font(.headline)
+            Text(operation.approvalDetail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Button("Review Change") {
+                isReviewing = true
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(BrandTheme.terracotta)
+            .accessibilityIdentifier("reviewInboxApproval")
+        }
+    }
+
+    @ViewBuilder
+    private var approvalActions: some View {
+        Button(
+            operation.op == "deleteTemplate"
+                ? "Delete Template"
+                : "Approve Change",
+            role: operation.op == "deleteTemplate" ? .destructive : nil
+        ) {
+            onApprove()
+        }
+        Button("Decline") {
+            onDecline()
+        }
+        Button("Cancel", role: .cancel) {}
+    }
+}
+
+private extension InboxOperationDTO {
+    var approvalTitle: String {
+        switch op {
+        case "deleteTemplate":
+            let payload = try? payload.decode(DeleteTemplatePayload.self)
+            return "Delete “\(payload?.name ?? "template")”?"
+        case "updateTemplate":
+            let payload = try? payload.decode(UpdateTemplatePayload.self)
+            if let name = payload?.name {
+                return "Update “\(name)”?"
+            }
+            return "Update template?"
+        default:
+            return "Apply proposed change?"
+        }
+    }
+
+    var approvalDetail: String {
+        switch op {
+        case "deleteTemplate":
+            return "This removes the template from this phone and the next cloud snapshot."
+        case "updateTemplate":
+            let payload = try? payload.decode(UpdateTemplatePayload.self)
+            let count = payload?.exercises?.count
+            if let count {
+                return "This replaces the template details and its exercise list (\(count) exercise\(count == 1 ? "" : "s"))."
+            }
+            return "This changes the template details."
+        default:
+            return "Review this inbox operation before it changes local data."
+        }
     }
 }

--- a/ClaudeLifterTests/Helpers/MockNetworkService.swift
+++ b/ClaudeLifterTests/Helpers/MockNetworkService.swift
@@ -96,6 +96,35 @@ final class MockNetworkService: NetworkServiceProtocol, @unchecked Sendable {
         return result
     }
 
+    // MARK: - MCP write inbox (issue #88)
+
+    var fetchInboxCallCount = 0
+    var fetchInboxResult = InboxListResponse(operations: [])
+
+    func fetchInbox() async throws -> InboxListResponse {
+        fetchInboxCallCount += 1
+        if let error = errorToThrow { throw error }
+        return fetchInboxResult
+    }
+
+    var ackInboxCallCount = 0
+    var lastInboxAckRequest: InboxAckRequest?
+    var ackInboxResult = InboxAckResponse(
+        counts: InboxAckCounts(
+            updated: 0,
+            unchanged: 0,
+            notFound: 0,
+            invalid: 0
+        )
+    )
+
+    func ackInbox(_ request: InboxAckRequest) async throws -> InboxAckResponse {
+        ackInboxCallCount += 1
+        lastInboxAckRequest = request
+        if let error = errorToThrow { throw error }
+        return ackInboxResult
+    }
+
     func uploadBlob(url: URL, data: Data, contentType: String) async throws {
         uploadBlobCallCount += 1
         if let error = errorToThrow { throw error }

--- a/ClaudeLifterTests/Helpers/MockNetworkService.swift
+++ b/ClaudeLifterTests/Helpers/MockNetworkService.swift
@@ -69,6 +69,7 @@ final class MockNetworkService: NetworkServiceProtocol, @unchecked Sendable {
     var pushSnapshotCallCount = 0
     var lastSnapshotRequest: SnapshotPushRequest?
     var pushSnapshotResult: SnapshotPushResponse?
+    var pushSnapshotError: Error?
     /// Runs mid-request, after the request is recorded and before the response
     /// is returned — lets tests simulate edits made while the POST is in flight.
     var onPushSnapshot: (@MainActor () -> Void)?
@@ -77,6 +78,7 @@ final class MockNetworkService: NetworkServiceProtocol, @unchecked Sendable {
         pushSnapshotCallCount += 1
         lastSnapshotRequest = request
         if let onPushSnapshot { await onPushSnapshot() }
+        if let pushSnapshotError { throw pushSnapshotError }
         if let error = errorToThrow { throw error }
         guard let result = pushSnapshotResult else {
             throw SyncError.serverError(500)
@@ -100,29 +102,47 @@ final class MockNetworkService: NetworkServiceProtocol, @unchecked Sendable {
 
     var fetchInboxCallCount = 0
     var fetchInboxResult = InboxListResponse(operations: [])
+    var awaitingApprovalInboxResult = InboxListResponse(operations: [])
+    var fetchedInboxStatuses: [InboxOperationStatus] = []
 
-    func fetchInbox() async throws -> InboxListResponse {
+    func fetchInbox(status: InboxOperationStatus) async throws -> InboxListResponse {
         fetchInboxCallCount += 1
+        fetchedInboxStatuses.append(status)
         if let error = errorToThrow { throw error }
-        return fetchInboxResult
+        switch status {
+        case .awaitingApproval:
+            return awaitingApprovalInboxResult
+        default:
+            return fetchInboxResult
+        }
     }
 
     var ackInboxCallCount = 0
     var lastInboxAckRequest: InboxAckRequest?
-    var ackInboxResult = InboxAckResponse(
-        counts: InboxAckCounts(
-            updated: 0,
-            unchanged: 0,
-            notFound: 0,
-            invalid: 0
-        )
-    )
+    var ackInboxResult: InboxAckResponse?
 
     func ackInbox(_ request: InboxAckRequest) async throws -> InboxAckResponse {
         ackInboxCallCount += 1
         lastInboxAckRequest = request
         if let error = errorToThrow { throw error }
-        return ackInboxResult
+        if let ackInboxResult { return ackInboxResult }
+        return InboxAckResponse(
+            counts: InboxAckCounts(
+                updated: request.results.count,
+                unchanged: 0,
+                notFound: 0,
+                invalid: 0
+            ),
+            results: request.results.map {
+                InboxAckOperationResult(
+                    id: $0.id,
+                    requestedStatus: $0.status,
+                    resultingStatus: $0.status.rawValue,
+                    outcome: .updated,
+                    conflict: nil
+                )
+            }
+        )
     }
 
     func uploadBlob(url: URL, data: Data, contentType: String) async throws {

--- a/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
+++ b/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
@@ -1,0 +1,535 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import ClaudeLifter
+
+/// Retains the ModelContainer for every context-backed inbox test. A context
+/// outliving its container traps on-device, so these tests use the shared
+/// factory and keep both alive in one environment value.
+@MainActor
+private struct InboxTestEnv {
+    let container: ModelContainer
+    let context: ModelContext
+    let workoutRepository: SwiftDataWorkoutRepository
+    let templateRepository: SwiftDataTemplateRepository
+    let exerciseRepository: SwiftDataExerciseRepository
+    let bodyWeightRepository: SwiftDataBodyWeightRepository
+    let applier: InboxApplier
+    let network: MockNetworkService
+    let settings: SettingsManager
+    let manager: SyncManager
+
+    init() throws {
+        container = try makeTestContainer()
+        context = container.mainContext
+        workoutRepository = SwiftDataWorkoutRepository(context: context)
+        templateRepository = SwiftDataTemplateRepository(context: context)
+        exerciseRepository = SwiftDataExerciseRepository(context: context)
+        bodyWeightRepository = SwiftDataBodyWeightRepository(context: context)
+        applier = InboxApplier(
+            templateRepository: templateRepository,
+            exerciseRepository: exerciseRepository
+        )
+        network = MockNetworkService()
+        settings = SettingsManager(
+            defaults: UserDefaults(suiteName: "inbox-tests-\(UUID().uuidString)")!
+        )
+        settings.serverURL = "https://example.com"
+        manager = SyncManager(
+            workoutRepository: workoutRepository,
+            templateRepository: templateRepository,
+            exerciseRepository: exerciseRepository,
+            bodyWeightRepository: bodyWeightRepository,
+            networkService: network,
+            settings: settings,
+            inboxApplier: applier
+        )
+    }
+}
+
+private func makeOperation<Payload: Encodable>(
+    id: String = UUID().uuidString,
+    op: String,
+    payload: Payload,
+    requiresApproval: Bool = false
+) throws -> InboxOperationDTO {
+    let data = try JSONEncoder().encode(payload)
+    let payloadJSON = try JSONDecoder().decode(InboxJSONValue.self, from: data)
+    return InboxOperationDTO(
+        id: id,
+        createdAt: "2026-07-27T12:00:00.000Z",
+        op: op,
+        payload: payloadJSON,
+        requiresApproval: requiresApproval,
+        status: "pending",
+        appliedAt: nil,
+        error: nil
+    )
+}
+
+private func makeInboxPushResponse() -> SnapshotPushResponse {
+    SnapshotPushResponse(
+        revision: 1,
+        serverTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+        counts: [
+            "workouts": SnapshotCollectionCounts(upserted: 0, deleted: 0),
+            "templates": SnapshotCollectionCounts(upserted: 1, deleted: 0),
+            "customExercises": SnapshotCollectionCounts(upserted: 0, deleted: 0),
+            "bodyWeightEntries": SnapshotCollectionCounts(upserted: 0, deleted: 0),
+        ]
+    )
+}
+
+@Suite("InboxApplier")
+@MainActor
+struct InboxApplierTests {
+    @Test("createTemplate resolves external ids and preserves ordered targets")
+    func createsResolvedTemplateInOrder() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let squat = Exercise(name: "Squat", externalId: "squat")
+        let bench = Exercise(name: "Bench Press", externalId: "bench")
+        try await env.exerciseRepository.save(squat)
+        try await env.exerciseRepository.save(bench)
+        let payload = CreateTemplatePayload(
+            name: "Strength A",
+            notes: "Heavy day",
+            exercises: [
+                InboxTemplateExercisePayload(
+                    externalId: "bench",
+                    order: 1,
+                    defaultSets: 4,
+                    defaultReps: 6,
+                    defaultWeight: 80,
+                    defaultRestSeconds: 120,
+                    notes: "pause"
+                ),
+                InboxTemplateExercisePayload(
+                    externalId: "squat",
+                    order: 0,
+                    defaultSets: 5,
+                    defaultReps: 5,
+                    defaultWeight: 100,
+                    defaultRestSeconds: 180,
+                    notes: nil
+                ),
+            ]
+        )
+        let operation = try makeOperation(
+            op: "createTemplate",
+            payload: payload,
+            requiresApproval: true
+        )
+
+        // Act
+        let results = await env.applier.process([operation])
+
+        // Assert
+        let template = try #require(try await env.templateRepository.fetchAll().first)
+        let exercises = template.exercises.sorted { $0.order < $1.order }
+        #expect(results.first?.status == .applied)
+        #expect(template.name == "Strength A")
+        #expect(template.notes == "Heavy day")
+        #expect(exercises.map { $0.exercise?.externalId } == ["squat", "bench"])
+        #expect(exercises.map(\.defaultSets) == [5, 4])
+        #expect(exercises.map(\.defaultReps) == [5, 6])
+        #expect(exercises.map(\.defaultRestSeconds) == [180, 120])
+        #expect(exercises.map(\.defaultWeight) == [100, 80])
+    }
+
+    @Test("createTemplate defaults omitted rest seconds to 90")
+    func defaultsMissingRestSeconds() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        try await env.exerciseRepository.save(
+            Exercise(name: "Bench Press", externalId: "bench")
+        )
+        let payload = CreateTemplatePayload(
+            name: "Push",
+            notes: nil,
+            exercises: [
+                InboxTemplateExercisePayload(
+                    externalId: "bench",
+                    order: 0,
+                    defaultSets: 3,
+                    defaultReps: 8,
+                    defaultWeight: nil,
+                    defaultRestSeconds: nil,
+                    notes: nil
+                )
+            ]
+        )
+
+        // Act
+        _ = await env.applier.process([
+            try makeOperation(op: "createTemplate", payload: payload)
+        ])
+
+        // Assert
+        let template = try #require(try await env.templateRepository.fetchAll().first)
+        #expect(template.exercises.first?.defaultRestSeconds == 90)
+    }
+
+    @Test("an unresolved external id fails the whole template")
+    func unresolvedExerciseFailsAtomically() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        try await env.exerciseRepository.save(
+            Exercise(name: "Bench Press", externalId: "bench")
+        )
+        let badExternalId = "missing-row"
+        let payload = CreateTemplatePayload(
+            name: "Must Not Exist",
+            notes: nil,
+            exercises: [
+                InboxTemplateExercisePayload(
+                    externalId: "bench",
+                    order: 0,
+                    defaultSets: 3,
+                    defaultReps: 8,
+                    defaultWeight: nil,
+                    defaultRestSeconds: 90,
+                    notes: nil
+                ),
+                InboxTemplateExercisePayload(
+                    externalId: badExternalId,
+                    order: 1,
+                    defaultSets: 3,
+                    defaultReps: 10,
+                    defaultWeight: nil,
+                    defaultRestSeconds: 90,
+                    notes: nil
+                ),
+            ]
+        )
+
+        // Act
+        let results = await env.applier.process([
+            try makeOperation(op: "createTemplate", payload: payload)
+        ])
+
+        // Assert
+        #expect(try await env.templateRepository.fetchAll().isEmpty)
+        #expect(results.first?.status == .failed)
+        #expect(results.first?.error?.contains(badExternalId) == true)
+    }
+
+    @Test("one malformed operation does not stop the rest of its batch")
+    func malformedOperationDoesNotAbortBatch() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let malformed = InboxOperationDTO(
+            id: "bad-operation",
+            createdAt: "2026-07-27T12:00:00.000Z",
+            op: "createTemplate",
+            payload: .object(["name": .string("Missing exercises")]),
+            requiresApproval: true,
+            status: "pending",
+            appliedAt: nil,
+            error: nil
+        )
+        let valid = try makeOperation(
+            id: "good-operation",
+            op: "createCustomExercise",
+            payload: CreateCustomExercisePayload(
+                name: "Cable Cross",
+                equipment: "cable",
+                primaryMuscles: ["chest"],
+                secondaryMuscles: [],
+                instructions: [],
+                notes: nil
+            )
+        )
+
+        // Act
+        let results = await env.applier.process([malformed, valid])
+
+        // Assert
+        #expect(results.map(\.status) == [.failed, .applied])
+        #expect(try await env.exerciseRepository.fetchByExternalId("custom:cable-cross") != nil)
+    }
+
+    @Test("deleteTemplate ignores the approval flag and applies immediately")
+    func deleteAppliesImmediately() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Push Day", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "delete-push",
+            op: "deleteTemplate",
+            payload: DeleteTemplatePayload(id: template.id.uuidString, name: template.name),
+            requiresApproval: true
+        )
+
+        // Act
+        let results = await env.applier.process([operation])
+
+        // Assert
+        #expect(results.first?.status == .applied)
+        #expect(try await env.templateRepository.fetch(id: template.id) == nil)
+    }
+
+    @Test("updateTemplate ignores the approval flag and replaces ordered exercises immediately")
+    func updateAppliesAndReplacesExercises() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let bench = Exercise(name: "Bench Press", externalId: "bench")
+        let squat = Exercise(name: "Squat", externalId: "squat")
+        try await env.exerciseRepository.save(bench)
+        try await env.exerciseRepository.save(squat)
+        let template = WorkoutTemplate(name: "Old Name", syncStatus: .synced)
+        template.exercises = [
+            TemplateExercise(
+                order: 0,
+                exercise: bench,
+                defaultSets: 3,
+                defaultReps: 8
+            )
+        ]
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "update-template",
+            op: "updateTemplate",
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "New Name",
+                notes: "updated",
+                exercises: [
+                    InboxTemplateExercisePayload(
+                        externalId: "squat",
+                        order: 0,
+                        defaultSets: 5,
+                        defaultReps: 5,
+                        defaultWeight: 100,
+                        defaultRestSeconds: nil,
+                        notes: nil
+                    )
+                ]
+            ),
+            requiresApproval: true
+        )
+
+        // Act
+        let results = await env.applier.process([operation])
+
+        // Assert
+        #expect(results.first?.status == .applied)
+        #expect(template.name == "New Name")
+        #expect(template.notes == "updated")
+        #expect(template.exercises.count == 1)
+        #expect(template.exercises.first?.exercise?.externalId == "squat")
+        #expect(template.exercises.first?.defaultSets == 5)
+        #expect(template.exercises.first?.defaultRestSeconds == 90)
+        #expect(template.syncStatus == .pending)
+    }
+
+    @Test("an unresolved update leaves every template field unchanged")
+    func unresolvedUpdateIsAtomic() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let bench = Exercise(name: "Bench Press", externalId: "bench")
+        try await env.exerciseRepository.save(bench)
+        let template = WorkoutTemplate(
+            name: "Original",
+            notes: "keep",
+            syncStatus: .synced
+        )
+        template.exercises = [
+            TemplateExercise(
+                order: 0,
+                exercise: bench,
+                defaultSets: 3,
+                defaultReps: 8
+            )
+        ]
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "bad-update",
+            op: "updateTemplate",
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "Must Not Apply",
+                notes: "must not apply",
+                exercises: [
+                    InboxTemplateExercisePayload(
+                        externalId: "missing-update-exercise",
+                        order: 0,
+                        defaultSets: 4,
+                        defaultReps: 6,
+                        defaultWeight: nil,
+                        defaultRestSeconds: 60,
+                        notes: nil
+                    )
+                ]
+            ),
+            requiresApproval: true
+        )
+
+        // Act
+        let results = await env.applier.process([operation])
+
+        // Assert
+        let result = try #require(results.first)
+        #expect(result.status == .failed)
+        #expect(result.error?.contains("missing-update-exercise") == true)
+        #expect(template.name == "Original")
+        #expect(template.notes == "keep")
+        #expect(template.exercises.first?.exercise?.externalId == "bench")
+        #expect(template.syncStatus == .synced)
+    }
+
+    @Test("syncIfNeeded auto-applies and pushes a delete end-to-end")
+    func syncAutoAppliesAndPushesDelete() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Delete Me", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        env.network.fetchInboxResult = InboxListResponse(
+            operations: [
+                try makeOperation(
+                    id: "auto-delete",
+                    op: "deleteTemplate",
+                    payload: DeleteTemplatePayload(
+                        id: template.id.uuidString,
+                        name: template.name
+                    ),
+                    requiresApproval: true
+                )
+            ]
+        )
+        env.network.pushSnapshotResult = makeInboxPushResponse()
+
+        // Act
+        await env.manager.syncIfNeeded()
+
+        // Assert
+        #expect(try await env.templateRepository.fetch(id: template.id) == nil)
+        #expect(env.network.lastInboxAckRequest?.results.first?.status == .applied)
+        #expect(env.network.pushSnapshotCallCount == 1)
+        #expect(
+            env.network.lastSnapshotRequest?.snapshot.templates.contains(
+                where: { $0.id == template.id }
+            ) == false
+        )
+        #expect(env.manager.syncError == nil)
+    }
+
+    @Test("createCustomExercise assigns custom identity")
+    func createsCustomExerciseIdentity() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operation = try makeOperation(
+            op: "createCustomExercise",
+            payload: CreateCustomExercisePayload(
+                name: "Belt Squat (Machine)",
+                equipment: "machine",
+                primaryMuscles: ["quadriceps"],
+                secondaryMuscles: ["glutes"],
+                instructions: ["Stand tall"],
+                notes: "custom setup"
+            ),
+            requiresApproval: true
+        )
+
+        // Act
+        let results = await env.applier.process([operation])
+
+        // Assert
+        let exercise = try #require(
+            try await env.exerciseRepository.fetchByExternalId(
+                "custom:belt-squat-machine"
+            )
+        )
+        #expect(results.first?.status == .applied)
+        #expect(exercise.isCustom == true)
+        #expect(exercise.externalId?.hasPrefix("custom:") == true)
+        #expect(exercise.equipment == "machine")
+        #expect(exercise.primaryMuscles == ["quadriceps"])
+    }
+
+    @Test("idle phone drains inbox before the pending guard and pushes the create")
+    func idlePhoneAppliesAndPushesInboxCreate() async throws {
+        // Arrange — no local record is pending before this sync.
+        let env = try InboxTestEnv()
+        try await env.exerciseRepository.save(
+            Exercise(name: "Bench Press", externalId: "bench")
+        )
+        env.network.fetchInboxResult = InboxListResponse(
+            operations: [
+                try makeOperation(
+                    id: "idle-create",
+                    op: "createTemplate",
+                    payload: CreateTemplatePayload(
+                        name: "Arrived While Idle",
+                        notes: nil,
+                        exercises: [
+                            InboxTemplateExercisePayload(
+                                externalId: "bench",
+                                order: 0,
+                                defaultSets: 3,
+                                defaultReps: 8,
+                                defaultWeight: nil,
+                                defaultRestSeconds: nil,
+                                notes: nil
+                            )
+                        ]
+                    )
+                )
+            ]
+        )
+        env.network.pushSnapshotResult = makeInboxPushResponse()
+
+        // Act
+        await env.manager.syncIfNeeded()
+
+        // Assert
+        #expect(
+            try await env.templateRepository.fetchAll().contains {
+                $0.name == "Arrived While Idle"
+            }
+        )
+        #expect(env.network.ackInboxCallCount == 1)
+        #expect(env.network.lastInboxAckRequest?.results.first?.status == .applied)
+        #expect(env.network.pushSnapshotCallCount == 1)
+        #expect(
+            env.network.lastSnapshotRequest?.snapshot.templates.contains {
+                $0.name == "Arrived While Idle"
+            } == true
+        )
+    }
+
+    @Test("idle phone pushes an inbox-created custom exercise")
+    func idlePhonePushesCustomExercise() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        env.network.fetchInboxResult = InboxListResponse(
+            operations: [
+                try makeOperation(
+                    id: "idle-custom",
+                    op: "createCustomExercise",
+                    payload: CreateCustomExercisePayload(
+                        name: "Reverse Sled Drag",
+                        equipment: "sled",
+                        primaryMuscles: ["quadriceps"],
+                        secondaryMuscles: [],
+                        instructions: [],
+                        notes: nil
+                    )
+                )
+            ]
+        )
+        env.network.pushSnapshotResult = makeInboxPushResponse()
+
+        // Act
+        await env.manager.syncIfNeeded()
+
+        // Assert
+        #expect(env.network.pushSnapshotCallCount == 1)
+        #expect(
+            env.network.lastSnapshotRequest?.snapshot.customExercises.first?
+                .externalId == "custom:reverse-sled-drag"
+        )
+    }
+
+}

--- a/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
+++ b/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
@@ -51,7 +51,8 @@ private func makeOperation<Payload: Encodable>(
     id: String = UUID().uuidString,
     op: String,
     payload: Payload,
-    requiresApproval: Bool = false
+    requiresApproval: Bool = false,
+    status: String = "pending"
 ) throws -> InboxOperationDTO {
     let data = try JSONEncoder().encode(payload)
     let payloadJSON = try JSONDecoder().decode(InboxJSONValue.self, from: data)
@@ -61,7 +62,7 @@ private func makeOperation<Payload: Encodable>(
         op: op,
         payload: payloadJSON,
         requiresApproval: requiresApproval,
-        status: "pending",
+        status: status,
         appliedAt: nil,
         error: nil
     )
@@ -118,7 +119,7 @@ struct InboxApplierTests {
         let operation = try makeOperation(
             op: "createTemplate",
             payload: payload,
-            requiresApproval: true
+            requiresApproval: false
         )
 
         // Act
@@ -168,6 +169,67 @@ struct InboxApplierTests {
         // Assert
         let template = try #require(try await env.templateRepository.fetchAll().first)
         #expect(template.exercises.first?.defaultRestSeconds == 90)
+    }
+
+    @Test("replaying createTemplate uses the operation id and does not duplicate")
+    func replayedTemplateCreateIsIdempotent() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let bench = Exercise(name: "Bench Press", externalId: "bench")
+        let row = Exercise(name: "Cable Row", externalId: "row")
+        try await env.exerciseRepository.save(bench)
+        try await env.exerciseRepository.save(row)
+        let operationID = UUID()
+        let operation = try makeOperation(
+            id: operationID.uuidString,
+            op: "createTemplate",
+            payload: CreateTemplatePayload(
+                name: "Replay Safe",
+                notes: nil,
+                exercises: [
+                    InboxTemplateExercisePayload(
+                        externalId: "bench",
+                        order: 0,
+                        defaultSets: 3,
+                        defaultReps: 8,
+                        defaultWeight: nil,
+                        defaultRestSeconds: 90,
+                        notes: nil
+                    ),
+                    InboxTemplateExercisePayload(
+                        externalId: "row",
+                        order: 1,
+                        defaultSets: 4,
+                        defaultReps: 10,
+                        defaultWeight: nil,
+                        defaultRestSeconds: 60,
+                        notes: nil
+                    ),
+                ]
+            )
+        )
+
+        // Act
+        let first = await env.applier.process([operation])
+        let firstTemplate = try #require(
+            try await env.templateRepository.fetch(id: operationID)
+        )
+        let originalRelationshipIDs = Set(firstTemplate.exercises.map(\.id))
+        let replay = await env.applier.process([operation])
+
+        // Assert
+        let templates = try await env.templateRepository.fetchAll()
+        let replayedTemplate = try #require(templates.first)
+        let storedRelationships = try env.context.fetch(
+            FetchDescriptor<TemplateExercise>()
+        )
+        #expect(first.first?.status == .applied)
+        #expect(replay.first?.status == .applied)
+        #expect(templates.count == 1)
+        #expect(replayedTemplate.id == operationID)
+        #expect(replayedTemplate.exercises.count == 2)
+        #expect(Set(replayedTemplate.exercises.map(\.id)) == originalRelationshipIDs)
+        #expect(storedRelationships.count == 2)
     }
 
     @Test("an unresolved external id fails the whole template")
@@ -223,16 +285,17 @@ struct InboxApplierTests {
             createdAt: "2026-07-27T12:00:00.000Z",
             op: "createTemplate",
             payload: .object(["name": .string("Missing exercises")]),
-            requiresApproval: true,
+            requiresApproval: false,
             status: "pending",
             appliedAt: nil,
             error: nil
         )
         let valid = try makeOperation(
-            id: "good-operation",
+            id: "10000000-0000-4000-8000-000000000001",
             op: "createCustomExercise",
             payload: CreateCustomExercisePayload(
                 name: "Cable Cross",
+                externalId: "custom:cable-cross:10000000-0000-4000-8000-000000000001",
                 equipment: "cable",
                 primaryMuscles: ["chest"],
                 secondaryMuscles: [],
@@ -246,11 +309,15 @@ struct InboxApplierTests {
 
         // Assert
         #expect(results.map(\.status) == [.failed, .applied])
-        #expect(try await env.exerciseRepository.fetchByExternalId("custom:cable-cross") != nil)
+        #expect(
+            try await env.exerciseRepository.fetchByExternalId(
+                "custom:cable-cross:10000000-0000-4000-8000-000000000001"
+            ) != nil
+        )
     }
 
-    @Test("deleteTemplate ignores the approval flag and applies immediately")
-    func deleteAppliesImmediately() async throws {
+    @Test("an approval-required delete is acknowledged before any mutation")
+    func deleteAwaitsApprovalWithoutMutation() async throws {
         // Arrange
         let env = try InboxTestEnv()
         let template = WorkoutTemplate(name: "Push Day", syncStatus: .synced)
@@ -266,12 +333,12 @@ struct InboxApplierTests {
         let results = await env.applier.process([operation])
 
         // Assert
-        #expect(results.first?.status == .applied)
-        #expect(try await env.templateRepository.fetch(id: template.id) == nil)
+        #expect(results.first?.status.rawValue == "awaitingApproval")
+        #expect(try await env.templateRepository.fetch(id: template.id) != nil)
     }
 
-    @Test("updateTemplate ignores the approval flag and replaces ordered exercises immediately")
-    func updateAppliesAndReplacesExercises() async throws {
+    @Test("an approval-required update is acknowledged before any mutation")
+    func updateAwaitsApprovalWithoutMutation() async throws {
         // Arrange
         let env = try InboxTestEnv()
         let bench = Exercise(name: "Bench Press", externalId: "bench")
@@ -314,14 +381,81 @@ struct InboxApplierTests {
         let results = await env.applier.process([operation])
 
         // Assert
-        #expect(results.first?.status == .applied)
-        #expect(template.name == "New Name")
-        #expect(template.notes == "updated")
+        #expect(results.first?.status.rawValue == "awaitingApproval")
+        #expect(template.name == "Old Name")
+        #expect(template.notes == nil)
         #expect(template.exercises.count == 1)
-        #expect(template.exercises.first?.exercise?.externalId == "squat")
-        #expect(template.exercises.first?.defaultSets == 5)
+        #expect(template.exercises.first?.exercise?.externalId == "bench")
+        #expect(template.exercises.first?.defaultSets == 3)
         #expect(template.exercises.first?.defaultRestSeconds == 90)
-        #expect(template.syncStatus == .pending)
+        #expect(template.syncStatus == .synced)
+    }
+
+    @Test("update and delete types cannot bypass approval with a false flag")
+    func approvalTypesRejectFalseApprovalFlags() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Protected", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let update = try makeOperation(
+            id: "mismatched-update",
+            op: "updateTemplate",
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "Must Not Apply",
+                notes: nil,
+                exercises: nil
+            ),
+            requiresApproval: false
+        )
+        let delete = try makeOperation(
+            id: "mismatched-delete",
+            op: "deleteTemplate",
+            payload: DeleteTemplatePayload(
+                id: template.id.uuidString,
+                name: template.name
+            ),
+            requiresApproval: false
+        )
+
+        // Act
+        let results = await env.applier.process([update, delete])
+
+        // Assert
+        #expect(results.map(\.status) == [.failed, .failed])
+        #expect(
+            results.allSatisfy {
+                $0.error?.localizedCaseInsensitiveContains("approval") == true
+            }
+        )
+        #expect(template.name == "Protected")
+        #expect(try await env.templateRepository.fetch(id: template.id) != nil)
+        #expect(template.syncStatus == .synced)
+    }
+
+    @Test("a create type with a true approval flag fails instead of being held")
+    func createRejectsTrueApprovalFlag() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operation = try makeOperation(
+            op: "createTemplate",
+            payload: CreateTemplatePayload(
+                name: "Mismatched Create",
+                notes: nil,
+                exercises: []
+            ),
+            requiresApproval: true
+        )
+
+        // Act
+        let result = await env.applier.process([operation]).first
+
+        // Assert
+        #expect(result?.status == .failed)
+        #expect(
+            result?.error?.localizedCaseInsensitiveContains("approval") == true
+        )
+        #expect(try await env.templateRepository.fetchAll().isEmpty)
     }
 
     @Test("an unresolved update leaves every template field unchanged")
@@ -363,14 +497,14 @@ struct InboxApplierTests {
                     )
                 ]
             ),
-            requiresApproval: true
+            requiresApproval: true,
+            status: "awaitingApproval"
         )
 
         // Act
-        let results = await env.applier.process([operation])
+        let result = await env.applier.approve(operation)
 
         // Assert
-        let result = try #require(results.first)
         #expect(result.status == .failed)
         #expect(result.error?.contains("missing-update-exercise") == true)
         #expect(template.name == "Original")
@@ -379,8 +513,104 @@ struct InboxApplierTests {
         #expect(template.syncStatus == .synced)
     }
 
-    @Test("syncIfNeeded auto-applies and pushes a delete end-to-end")
-    func syncAutoAppliesAndPushesDelete() async throws {
+    @Test("approving an awaiting update applies it locally")
+    func approveAppliesAwaitingUpdate() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Old Name", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "approved-update",
+            op: "updateTemplate",
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "Approved Name",
+                notes: nil,
+                exercises: nil
+            ),
+            requiresApproval: true,
+            status: "awaitingApproval"
+        )
+
+        // Act
+        let result = await env.applier.approve(operation)
+
+        // Assert
+        #expect(result.status == .applied)
+        #expect(template.name == "Approved Name")
+        #expect(template.syncStatus == .pending)
+    }
+
+    @Test("the correct approval sequence never reports failed")
+    func correctApprovalSequenceNeverFails() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Before", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let pending = try makeOperation(
+            id: "correct-update-sequence",
+            op: "updateTemplate",
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "After",
+                notes: nil,
+                exercises: nil
+            ),
+            requiresApproval: true
+        )
+        let awaiting = try makeOperation(
+            id: pending.id,
+            op: pending.op,
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "After",
+                notes: nil,
+                exercises: nil
+            ),
+            requiresApproval: true,
+            status: "awaitingApproval"
+        )
+
+        // Act
+        let pendingResult = await env.applier.process([pending]).first
+        let approvalResult = await env.applier.approve(awaiting)
+
+        // Assert
+        #expect(pendingResult?.status == .awaitingApproval)
+        #expect(approvalResult.status == .applied)
+        #expect(pendingResult?.status != .failed)
+        #expect(approvalResult.status != .failed)
+        #expect(template.name == "After")
+    }
+
+    @Test("declining an awaiting delete rejects it without local mutation")
+    func declineRejectsAwaitingDeleteWithoutMutation() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Keep Me", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "declined-delete",
+            op: "deleteTemplate",
+            payload: DeleteTemplatePayload(
+                id: template.id.uuidString,
+                name: template.name
+            ),
+            requiresApproval: true,
+            status: "awaitingApproval"
+        )
+
+        // Act
+        let result = env.applier.decline(operation)
+
+        // Assert
+        #expect(result.status == .rejected)
+        #expect(try await env.templateRepository.fetch(id: template.id) != nil)
+        #expect(template.syncStatus == .synced)
+    }
+
+    @Test("syncIfNeeded holds a delete for approval without pushing")
+    func syncHoldsDeleteForApproval() async throws {
         // Arrange
         let env = try InboxTestEnv()
         let template = WorkoutTemplate(name: "Delete Me", syncStatus: .synced)
@@ -404,15 +634,103 @@ struct InboxApplierTests {
         await env.manager.syncIfNeeded()
 
         // Assert
-        #expect(try await env.templateRepository.fetch(id: template.id) == nil)
+        #expect(try await env.templateRepository.fetch(id: template.id) != nil)
+        #expect(
+            env.network.lastInboxAckRequest?.results.first?.status.rawValue
+                == "awaitingApproval"
+        )
+        #expect(env.network.pushSnapshotCallCount == 0)
+        #expect(env.manager.syncError == nil)
+    }
+
+    @Test("syncIfNeeded refetches awaiting approvals so restart re-presents them")
+    func syncRefetchesDurableAwaitingApprovals() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operation = try makeOperation(
+            id: "durable-approval",
+            op: "deleteTemplate",
+            payload: DeleteTemplatePayload(
+                id: UUID().uuidString,
+                name: "Durable Delete"
+            ),
+            requiresApproval: true,
+            status: "awaitingApproval"
+        )
+        env.network.awaitingApprovalInboxResult = InboxListResponse(
+            operations: [operation]
+        )
+
+        // Act
+        await env.manager.syncIfNeeded()
+
+        // Assert
+        #expect(env.manager.pendingApprovals.map(\.id) == ["durable-approval"])
+        #expect(
+            env.network.fetchedInboxStatuses
+                .contains(.awaitingApproval)
+        )
+    }
+
+    @Test("approving through SyncManager applies, acks, and pushes")
+    func managerApprovesAndPushes() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Before", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "approved-manager-update",
+            op: "updateTemplate",
+            payload: UpdateTemplatePayload(
+                id: template.id.uuidString,
+                name: "After",
+                notes: nil,
+                exercises: nil
+            ),
+            requiresApproval: true,
+            status: "awaitingApproval"
+        )
+        env.network.pushSnapshotResult = makeInboxPushResponse()
+        var wasDirtyWhenSnapshotStarted = false
+        env.network.onPushSnapshot = {
+            wasDirtyWhenSnapshotStarted = env.settings.isSnapshotDirty
+        }
+
+        // Act
+        try await env.manager.approve(operation)
+
+        // Assert
+        #expect(template.name == "After")
         #expect(env.network.lastInboxAckRequest?.results.first?.status == .applied)
         #expect(env.network.pushSnapshotCallCount == 1)
-        #expect(
-            env.network.lastSnapshotRequest?.snapshot.templates.contains(
-                where: { $0.id == template.id }
-            ) == false
+        #expect(wasDirtyWhenSnapshotStarted == true)
+        #expect(env.settings.isSnapshotDirty == false)
+    }
+
+    @Test("declining through SyncManager acks rejected and mutates nothing")
+    func managerDeclinesWithoutMutation() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let template = WorkoutTemplate(name: "Keep", syncStatus: .synced)
+        try await env.templateRepository.save(template)
+        let operation = try makeOperation(
+            id: "declined-manager-delete",
+            op: "deleteTemplate",
+            payload: DeleteTemplatePayload(
+                id: template.id.uuidString,
+                name: template.name
+            ),
+            requiresApproval: true,
+            status: "awaitingApproval"
         )
-        #expect(env.manager.syncError == nil)
+
+        // Act
+        try await env.manager.decline(operation)
+
+        // Assert
+        #expect(try await env.templateRepository.fetch(id: template.id) != nil)
+        #expect(env.network.lastInboxAckRequest?.results.first?.status == .rejected)
+        #expect(env.network.pushSnapshotCallCount == 0)
     }
 
     @Test("createCustomExercise assigns custom identity")
@@ -420,16 +738,18 @@ struct InboxApplierTests {
         // Arrange
         let env = try InboxTestEnv()
         let operation = try makeOperation(
+            id: "10000000-0000-4000-8000-000000000004",
             op: "createCustomExercise",
             payload: CreateCustomExercisePayload(
                 name: "Belt Squat (Machine)",
+                externalId: "custom:belt-squat-machine:10000000-0000-4000-8000-000000000004",
                 equipment: "machine",
                 primaryMuscles: ["quadriceps"],
                 secondaryMuscles: ["glutes"],
                 instructions: ["Stand tall"],
                 notes: "custom setup"
             ),
-            requiresApproval: true
+            requiresApproval: false
         )
 
         // Act
@@ -438,7 +758,7 @@ struct InboxApplierTests {
         // Assert
         let exercise = try #require(
             try await env.exerciseRepository.fetchByExternalId(
-                "custom:belt-squat-machine"
+                "custom:belt-squat-machine:10000000-0000-4000-8000-000000000004"
             )
         )
         #expect(results.first?.status == .applied)
@@ -446,6 +766,201 @@ struct InboxApplierTests {
         #expect(exercise.externalId?.hasPrefix("custom:") == true)
         #expect(exercise.equipment == "machine")
         #expect(exercise.primaryMuscles == ["quadriceps"])
+    }
+
+    @Test("replaying createCustomExercise uses the operation id and does not duplicate")
+    func replayedCustomExerciseCreateIsIdempotent() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operationID = UUID()
+        let operation = try makeOperation(
+            id: operationID.uuidString,
+            op: "createCustomExercise",
+            payload: CreateCustomExercisePayload(
+                name: "Replay Curl",
+                externalId: "custom:replay-curl:\(operationID.uuidString.lowercased())",
+                equipment: nil,
+                primaryMuscles: nil,
+                secondaryMuscles: nil,
+                instructions: nil,
+                notes: nil
+            )
+        )
+
+        // Act
+        let first = await env.applier.process([operation])
+        let saved = try #require(
+            try await env.exerciseRepository.fetch(id: operationID)
+        )
+        saved.name = "Locally Renamed Replay Curl"
+        saved.equipment = "band"
+        try env.context.save()
+        let replay = await env.applier.process([operation])
+
+        // Assert
+        let exercises = try await env.exerciseRepository.fetchAll()
+            .filter(\.isCustom)
+        #expect(first.first?.status == .applied)
+        #expect(replay.first?.status == .applied)
+        #expect(exercises.count == 1)
+        #expect(exercises.first?.id == operationID)
+        #expect(exercises.first?.name == "Locally Renamed Replay Curl")
+        #expect(exercises.first?.equipment == "band")
+    }
+
+    @Test("custom external ids enforce one bounded operation identity grammar")
+    func validatesCustomExternalIdGrammar() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operationID = UUID()
+        let operationIdText = operationID.uuidString.lowercased()
+        let invalidExternalIds = [
+            "custom:",
+            "custom:row",
+            "custom:Bad_Slug:\(operationIdText)",
+            "custom:\(String(repeating: "a", count: 65)):\(operationIdText)",
+            "custom:row:00000000-0000-4000-8000-000000000000",
+        ]
+
+        // Act
+        var results: [InboxAckResult] = []
+        for externalId in invalidExternalIds {
+            let operation = try makeOperation(
+                id: operationID.uuidString,
+                op: "createCustomExercise",
+                payload: CreateCustomExercisePayload(
+                    name: "Invalid Identity",
+                    externalId: externalId,
+                    equipment: nil,
+                    primaryMuscles: nil,
+                    secondaryMuscles: nil,
+                    instructions: nil,
+                    notes: nil
+                )
+            )
+            results.append(contentsOf: await env.applier.process([operation]))
+        }
+
+        // Assert
+        #expect(results.count == invalidExternalIds.count)
+        #expect(results.allSatisfy { $0.status == .failed })
+        #expect(
+            results.allSatisfy {
+                $0.error?.localizedCaseInsensitiveContains("externalId") == true
+            }
+        )
+        #expect(try await env.exerciseRepository.fetchAll().isEmpty)
+    }
+
+    @Test("custom external ids accept a 64-character slug and matching UUID")
+    func acceptsMaximumCustomExternalIdSlug() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operationID = UUID()
+        let externalId = "custom:\(String(repeating: "a", count: 64)):"
+            + operationID.uuidString.lowercased()
+        let operation = try makeOperation(
+            id: operationID.uuidString,
+            op: "createCustomExercise",
+            payload: CreateCustomExercisePayload(
+                name: "Maximum Slug",
+                externalId: externalId,
+                equipment: nil,
+                primaryMuscles: nil,
+                secondaryMuscles: nil,
+                instructions: nil,
+                notes: nil
+            )
+        )
+
+        // Act
+        let result = await env.applier.process([operation]).first
+
+        // Assert
+        #expect(result?.status == .applied)
+        #expect(
+            try await env.exerciseRepository.fetch(id: operationID)?
+                .externalId == externalId
+        )
+    }
+
+    @Test("a server-issued custom external id resolves in a later template operation")
+    func customExerciseResolvesInLaterTemplate() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let customOperationID = UUID()
+        let externalId =
+            "custom:deja-vu-row:\(customOperationID.uuidString.lowercased())"
+        let custom = InboxOperationDTO(
+            id: customOperationID.uuidString,
+            createdAt: "2026-07-27T12:00:00.000Z",
+            op: "createCustomExercise",
+            payload: .object([
+                "name": .string("Déjà Vu Row"),
+                "externalId": .string(externalId),
+            ]),
+            requiresApproval: false,
+            status: "pending",
+            appliedAt: nil,
+            error: nil
+        )
+        let template = try makeOperation(
+            op: "createTemplate",
+            payload: CreateTemplatePayload(
+                name: "Custom Pull",
+                notes: nil,
+                exercises: [
+                    InboxTemplateExercisePayload(
+                        externalId: externalId,
+                        order: 0,
+                        defaultSets: 3,
+                        defaultReps: 10,
+                        defaultWeight: nil,
+                        defaultRestSeconds: nil,
+                        notes: nil
+                    )
+                ]
+            )
+        )
+
+        // Act
+        let results = await env.applier.process([custom, template])
+
+        // Assert
+        #expect(results.map(\.status) == [.applied, .applied])
+        let saved = try #require(
+            try await env.templateRepository.fetchAll().first
+        )
+        #expect(saved.exercises.first?.exercise?.externalId == externalId)
+    }
+
+    @Test("a custom exercise without a server-issued external id fails loudly")
+    func missingCustomExternalIdFailsLoudly() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let operation = InboxOperationDTO(
+            id: UUID().uuidString,
+            createdAt: "2026-07-27T12:00:00.000Z",
+            op: "createCustomExercise",
+            payload: .object([
+                "name": .string("Legacy Inert Exercise"),
+            ]),
+            requiresApproval: false,
+            status: "pending",
+            appliedAt: nil,
+            error: nil
+        )
+
+        // Act
+        let result = await env.applier.process([operation]).first
+
+        // Assert
+        #expect(result?.status == .failed)
+        #expect(
+            result?.error?.localizedCaseInsensitiveContains("externalId")
+                == true
+        )
+        #expect(try await env.exerciseRepository.fetchAll().isEmpty)
     }
 
     @Test("idle phone drains inbox before the pending guard and pushes the create")
@@ -458,7 +973,7 @@ struct InboxApplierTests {
         env.network.fetchInboxResult = InboxListResponse(
             operations: [
                 try makeOperation(
-                    id: "idle-create",
+                    id: "10000000-0000-4000-8000-000000000002",
                     op: "createTemplate",
                     payload: CreateTemplatePayload(
                         name: "Arrived While Idle",
@@ -506,10 +1021,11 @@ struct InboxApplierTests {
         env.network.fetchInboxResult = InboxListResponse(
             operations: [
                 try makeOperation(
-                    id: "idle-custom",
+                    id: "10000000-0000-4000-8000-000000000003",
                     op: "createCustomExercise",
                     payload: CreateCustomExercisePayload(
                         name: "Reverse Sled Drag",
+                        externalId: "custom:reverse-sled-drag:10000000-0000-4000-8000-000000000003",
                         equipment: "sled",
                         primaryMuscles: ["quadriceps"],
                         secondaryMuscles: [],
@@ -528,7 +1044,8 @@ struct InboxApplierTests {
         #expect(env.network.pushSnapshotCallCount == 1)
         #expect(
             env.network.lastSnapshotRequest?.snapshot.customExercises.first?
-                .externalId == "custom:reverse-sled-drag"
+                .externalId
+                == "custom:reverse-sled-drag:10000000-0000-4000-8000-000000000003"
         )
     }
 

--- a/ClaudeLifterTests/ServiceTests/SettingsManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SettingsManagerTests.swift
@@ -71,6 +71,18 @@ struct SettingsManagerTests {
         #expect(reloaded.lastSyncRevision == 42)
     }
 
+    @Test("snapshot dirty state persists across SettingsManager instances")
+    func snapshotDirtyPersists() {
+        let suite = "settings-snapshot-dirty-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        let settings = SettingsManager(defaults: defaults)
+
+        settings.isSnapshotDirty = true
+        let reloaded = SettingsManager(defaults: UserDefaults(suiteName: suite)!)
+
+        #expect(reloaded.isSnapshotDirty == true)
+    }
+
     @Test("clearing lastSyncRevision removes the stored value")
     func lastSyncRevisionClears() {
         // Arrange

--- a/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
@@ -14,6 +14,7 @@ private struct SyncTestEnv {
     let templateRepo: SwiftDataTemplateRepository
     let exerciseRepo: SwiftDataExerciseRepository
     let bodyWeightRepo: SwiftDataBodyWeightRepository
+    let inboxApplier: InboxApplier
     let network: MockNetworkService
     let settings: SettingsManager
     let manager: SyncManager
@@ -25,6 +26,10 @@ private struct SyncTestEnv {
         templateRepo = SwiftDataTemplateRepository(context: context)
         exerciseRepo = SwiftDataExerciseRepository(context: context)
         bodyWeightRepo = SwiftDataBodyWeightRepository(context: context)
+        inboxApplier = InboxApplier(
+            templateRepository: templateRepo,
+            exerciseRepository: exerciseRepo
+        )
         network = MockNetworkService()
         settings = SettingsManager(defaults: UserDefaults(suiteName: "sync-test-\(UUID())")!)
         settings.serverURL = serverURL
@@ -34,7 +39,8 @@ private struct SyncTestEnv {
             exerciseRepository: exerciseRepo,
             bodyWeightRepository: bodyWeightRepo,
             networkService: network,
-            settings: settings
+            settings: settings,
+            inboxApplier: inboxApplier
         )
     }
 }
@@ -210,10 +216,11 @@ struct SyncIfNeededTests {
 
         await env.manager.syncIfNeeded()
 
+        #expect(env.network.fetchInboxCallCount == 0)
         #expect(env.network.pushSnapshotCallCount == 0)
     }
 
-    @Test("skips the network when nothing is pending")
+    @Test("skips snapshot push when inbox is empty and nothing is pending")
     func skipsWhenNothingPending() async throws {
         let env = try SyncTestEnv()
         env.context.insert(Workout(name: "Synced", startedAt: .now, syncStatus: .synced))
@@ -221,6 +228,7 @@ struct SyncIfNeededTests {
 
         await env.manager.syncIfNeeded()
 
+        #expect(env.network.fetchInboxCallCount == 1)
         #expect(env.network.pushSnapshotCallCount == 0)
     }
 
@@ -577,7 +585,11 @@ struct SyncStateTests {
             exerciseRepository: SwiftDataExerciseRepository(context: context),
             bodyWeightRepository: SwiftDataBodyWeightRepository(context: context),
             networkService: MockNetworkService(),
-            settings: settings
+            settings: settings,
+            inboxApplier: InboxApplier(
+                templateRepository: SwiftDataTemplateRepository(context: context),
+                exerciseRepository: SwiftDataExerciseRepository(context: context)
+            )
         )
         #expect(manager.lastRevision == 17)
         _ = container

--- a/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
@@ -19,7 +19,10 @@ private struct SyncTestEnv {
     let settings: SettingsManager
     let manager: SyncManager
 
-    init(serverURL: String = "https://example.com") throws {
+    init(
+        serverURL: String = "https://example.com",
+        defaults: UserDefaults? = nil
+    ) throws {
         container = try makeTestContainer()
         context = container.mainContext
         workoutRepo = SwiftDataWorkoutRepository(context: context)
@@ -31,7 +34,10 @@ private struct SyncTestEnv {
             exerciseRepository: exerciseRepo
         )
         network = MockNetworkService()
-        settings = SettingsManager(defaults: UserDefaults(suiteName: "sync-test-\(UUID())")!)
+        settings = SettingsManager(
+            defaults: defaults
+                ?? UserDefaults(suiteName: "sync-test-\(UUID())")!
+        )
         settings.serverURL = serverURL
         manager = SyncManager(
             workoutRepository: workoutRepo,
@@ -56,6 +62,46 @@ private func makePushResponse(revision: Int = 1, serverTime: Date = Date(timeInt
             "bodyWeightEntries": SnapshotCollectionCounts(upserted: 0, deleted: 0),
         ]
     )
+}
+
+// Inbox operation ids must parse as UUIDs — the applier derives the created
+// entity's identity from them so a replayed operation is a no-op. The server
+// mints them with randomUUID(), so fixtures must be real UUIDs too.
+private let requestedOperationID = "11111111-1111-4111-8111-111111111111"
+private let validOperationID = "22222222-2222-4222-8222-222222222222"
+private let extraOperationID = "33333333-3333-4333-8333-333333333333"
+private let conflictingOperationID = "44444444-4444-4444-8444-444444444444"
+
+private func makePendingInboxCreate(id: String) -> InboxOperationDTO {
+    InboxOperationDTO(
+        id: id,
+        createdAt: "2026-07-27T12:00:00.000Z",
+        op: "createTemplate",
+        payload: .object([
+            "name": .string("Ack Validation \(id)"),
+            "exercises": .array([]),
+        ]),
+        requiresApproval: false,
+        status: "pending",
+        appliedAt: nil,
+        error: nil
+    )
+}
+
+@MainActor
+private func runAckValidationScenario(
+    _ response: InboxAckResponse
+) async throws -> (syncError: String?, pushCount: Int) {
+    let env = try SyncTestEnv()
+    env.network.fetchInboxResult = InboxListResponse(
+        operations: [makePendingInboxCreate(id: requestedOperationID)]
+    )
+    env.network.ackInboxResult = response
+    env.network.pushSnapshotResult = makePushResponse()
+
+    await env.manager.syncIfNeeded()
+
+    return (env.manager.syncError, env.network.pushSnapshotCallCount)
 }
 
 @Suite("SyncManager Snapshot Push")
@@ -228,7 +274,7 @@ struct SyncIfNeededTests {
 
         await env.manager.syncIfNeeded()
 
-        #expect(env.network.fetchInboxCallCount == 1)
+        #expect(env.network.fetchInboxCallCount == 2)
         #expect(env.network.pushSnapshotCallCount == 0)
     }
 
@@ -255,6 +301,239 @@ struct SyncIfNeededTests {
         await env.manager.syncIfNeeded()
 
         #expect(env.manager.syncError != nil)
+    }
+
+    @Test("an ack conflict surfaces an error after valid batch-mates are pushed")
+    func recordsInboxAckConflict() async throws {
+        // Arrange
+        let env = try SyncTestEnv()
+        env.network.fetchInboxResult = InboxListResponse(
+            operations: [
+                makePendingInboxCreate(id: validOperationID),
+                InboxOperationDTO(
+                    id: conflictingOperationID,
+                    createdAt: "2026-07-27T12:00:00.000Z",
+                    op: "deleteTemplate",
+                    payload: .object([
+                        "id": .string(UUID().uuidString),
+                        "name": .string("Already handled"),
+                    ]),
+                    requiresApproval: true,
+                    status: "pending",
+                    appliedAt: nil,
+                    error: nil
+                )
+            ]
+        )
+        let responseJSON = Data(
+            """
+            {
+              "counts": {
+                "updated": 1,
+                "unchanged": 0,
+                "notFound": 0,
+                "invalid": 1
+              },
+              "results": [
+                {
+                  "id": "\(validOperationID)",
+                  "requestedStatus": "applied",
+                  "resultingStatus": "applied",
+                  "outcome": "updated"
+                },
+                {
+                  "id": "\(conflictingOperationID)",
+                  "requestedStatus": "awaitingApproval",
+                  "resultingStatus": "applied",
+                  "outcome": "conflict",
+                  "conflict": "applied deleteTemplate cannot transition to awaitingApproval"
+                }
+              ]
+            }
+            """.utf8
+        )
+        env.network.ackInboxResult = try JSONDecoder().decode(
+            InboxAckResponse.self,
+            from: responseJSON
+        )
+        env.network.pushSnapshotResult = makePushResponse()
+
+        // Act
+        await env.manager.syncIfNeeded()
+
+        // Assert
+        #expect(env.manager.syncError?.localizedCaseInsensitiveContains("conflict") == true)
+        #expect(env.network.pushSnapshotCallCount == 1)
+        #expect(
+            env.network.lastSnapshotRequest?.snapshot.templates.contains {
+                $0.name == "Ack Validation \(validOperationID)"
+            } == true
+        )
+    }
+
+    @Test("ack responses are validated against the exact request without blocking push")
+    func rejectsIncompleteMismatchedAndExtraAckResults() async throws {
+        let correct = InboxAckOperationResult(
+            id: requestedOperationID,
+            requestedStatus: .applied,
+            resultingStatus: "applied",
+            outcome: .updated,
+            conflict: nil
+        )
+        let scenarios: [(String, InboxAckResponse)] = [
+            (
+                "missing",
+                InboxAckResponse(
+                    counts: InboxAckCounts(
+                        updated: 1,
+                        unchanged: 0,
+                        notFound: 0,
+                        invalid: 0
+                    ),
+                    results: []
+                )
+            ),
+            (
+                "not found",
+                InboxAckResponse(
+                    counts: InboxAckCounts(
+                        updated: 0,
+                        unchanged: 0,
+                        notFound: 1,
+                        invalid: 0
+                    ),
+                    results: [
+                        InboxAckOperationResult(
+                            id: requestedOperationID,
+                            requestedStatus: .applied,
+                            resultingStatus: nil,
+                            outcome: .notFound,
+                            conflict: nil
+                        ),
+                    ]
+                )
+            ),
+            (
+                "requested status",
+                InboxAckResponse(
+                    counts: InboxAckCounts(
+                        updated: 1,
+                        unchanged: 0,
+                        notFound: 0,
+                        invalid: 0
+                    ),
+                    results: [
+                        InboxAckOperationResult(
+                            id: requestedOperationID,
+                            requestedStatus: .failed,
+                            resultingStatus: "failed",
+                            outcome: .updated,
+                            conflict: nil
+                        ),
+                    ]
+                )
+            ),
+            (
+                "extra",
+                InboxAckResponse(
+                    counts: InboxAckCounts(
+                        updated: 2,
+                        unchanged: 0,
+                        notFound: 0,
+                        invalid: 0
+                    ),
+                    results: [
+                        correct,
+                        InboxAckOperationResult(
+                            id: extraOperationID,
+                            requestedStatus: .applied,
+                            resultingStatus: "applied",
+                            outcome: .updated,
+                            conflict: nil
+                        ),
+                    ]
+                )
+            ),
+            (
+                "exactly one",
+                InboxAckResponse(
+                    counts: InboxAckCounts(
+                        updated: 2,
+                        unchanged: 0,
+                        notFound: 0,
+                        invalid: 0
+                    ),
+                    results: [correct, correct]
+                )
+            ),
+        ]
+
+        for (expectedDiagnostic, response) in scenarios {
+            let result = try await runAckValidationScenario(response)
+            #expect(
+                result.syncError?
+                    .localizedCaseInsensitiveContains(expectedDiagnostic) == true
+            )
+            #expect(result.pushCount == 1)
+        }
+    }
+
+    @Test("an inbox-applied custom exercise retries snapshot push after restart")
+    func customExercisePushRetriesAfterRestart() async throws {
+        // Arrange
+        let defaults = UserDefaults(
+            suiteName: "sync-dirty-restart-\(UUID())"
+        )!
+        let env = try SyncTestEnv(defaults: defaults)
+        env.network.fetchInboxResult = InboxListResponse(
+            operations: [
+                InboxOperationDTO(
+                    id: "10000000-0000-4000-8000-000000000005",
+                    createdAt: "2026-07-27T12:00:00.000Z",
+                    op: "createCustomExercise",
+                    payload: .object([
+                        "name": .string("Restart Sled Drag"),
+                        "externalId": .string(
+                            "custom:restart-sled-drag:10000000-0000-4000-8000-000000000005"
+                        ),
+                    ]),
+                    requiresApproval: false,
+                    status: "pending",
+                    appliedAt: nil,
+                    error: nil
+                )
+            ]
+        )
+        env.network.pushSnapshotError = SyncError.serverError(500)
+
+        // Act — local apply succeeds, but the first snapshot push fails.
+        await env.manager.syncIfNeeded()
+
+        // Assert — the durable trigger survives a new SettingsManager and
+        // causes a push even though the restarted app sees an empty inbox.
+        #expect(env.settings.isSnapshotDirty == true)
+        env.network.fetchInboxResult = InboxListResponse(operations: [])
+        env.network.pushSnapshotError = nil
+        env.network.pushSnapshotResult = makePushResponse(revision: 2)
+        let reloadedSettings = SettingsManager(defaults: defaults)
+        let restarted = SyncManager(
+            workoutRepository: env.workoutRepo,
+            templateRepository: env.templateRepo,
+            exerciseRepository: env.exerciseRepo,
+            bodyWeightRepository: env.bodyWeightRepo,
+            networkService: env.network,
+            settings: reloadedSettings,
+            inboxApplier: env.inboxApplier
+        )
+        await restarted.syncIfNeeded()
+
+        #expect(env.network.pushSnapshotCallCount == 2)
+        #expect(
+            env.network.lastSnapshotRequest?.snapshot.customExercises
+                .contains { $0.name == "Restart Sled Drag" } == true
+        )
+        #expect(reloadedSettings.isSnapshotDirty == false)
+        #expect(restarted.syncError == nil)
     }
 }
 

--- a/ClaudeLifterTests/ViewModelTests/HomeViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/HomeViewModelTests.swift
@@ -3,6 +3,41 @@ import Foundation
 import SwiftData
 @testable import ClaudeLifter
 
+@MainActor
+private final class MockInboxApprovalManager: InboxApprovalManaging {
+    var approvals: [InboxOperationDTO] = []
+    var approvedIDs: [String] = []
+    var declinedIDs: [String] = []
+
+    func fetchPendingApprovals() async throws -> [InboxOperationDTO] {
+        approvals
+    }
+
+    func approve(_ operation: InboxOperationDTO) async throws {
+        approvedIDs.append(operation.id)
+    }
+
+    func decline(_ operation: InboxOperationDTO) async throws {
+        declinedIDs.append(operation.id)
+    }
+}
+
+private func approvalOperation(id: String = "approval") -> InboxOperationDTO {
+    InboxOperationDTO(
+        id: id,
+        createdAt: "2026-07-27T12:00:00.000Z",
+        op: "deleteTemplate",
+        payload: .object([
+            "id": .string(UUID().uuidString),
+            "name": .string("Push Day"),
+        ]),
+        requiresApproval: true,
+        status: "awaitingApproval",
+        appliedAt: nil,
+        error: nil
+    )
+}
+
 @Suite("HomeViewModel Tests")
 @MainActor
 struct HomeViewModelTests {
@@ -69,5 +104,50 @@ struct HomeViewModelTests {
 
         #expect(workoutRepo.savedWorkouts.count == 1)
         #expect(workoutRepo.savedWorkouts.first?.name == "Quick Workout")
+    }
+}
+
+@Suite("InboxApprovalViewModel Tests")
+@MainActor
+struct InboxApprovalViewModelTests {
+    @Test("load re-presents server-durable awaiting approvals")
+    func loadsAwaitingApprovals() async {
+        let manager = MockInboxApprovalManager()
+        manager.approvals = [approvalOperation(id: "restart-approval")]
+        let vm = InboxApprovalViewModel(manager: manager)
+
+        await vm.load()
+
+        #expect(vm.approvals.map(\.id) == ["restart-approval"])
+    }
+
+    @Test("approve delegates and removes only the decided approval")
+    func approvesOneOperation() async {
+        let manager = MockInboxApprovalManager()
+        let first = approvalOperation(id: "first")
+        let second = approvalOperation(id: "second")
+        manager.approvals = [first, second]
+        let vm = InboxApprovalViewModel(manager: manager)
+        await vm.load()
+
+        await vm.approve(first)
+
+        #expect(manager.approvedIDs == ["first"])
+        #expect(vm.approvals.map(\.id) == ["second"])
+    }
+
+    @Test("decline delegates and removes only the decided approval")
+    func declinesOneOperation() async {
+        let manager = MockInboxApprovalManager()
+        let first = approvalOperation(id: "first")
+        let second = approvalOperation(id: "second")
+        manager.approvals = [first, second]
+        let vm = InboxApprovalViewModel(manager: manager)
+        await vm.load()
+
+        await vm.decline(second)
+
+        #expect(manager.declinedIDs == ["second"])
+        #expect(vm.approvals.map(\.id) == ["first"])
     }
 }

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,123 +1,68 @@
 # HANDOFF — MCP write path (#88)
 
-Written 2026-07-27 ~21:00, immediately before a Claude Code restart. The restart is
-required and it destroys the session that did this work, so everything needed to
-finish is here.
+Updated 2026-07-27 ~23:30. The original handoff task is **done**; this file now
+describes where the write path actually stands.
 
-## Why a restart was needed
+## Current state
 
-The `workout` MCP server (configured in `~/.claude.json`) loads its code at session
-start. It was running the pre-#88 **read-only** build, so the write tools did not
-exist in the session's toolset even after `dist/` was rebuilt. Restarting Claude Code
-relaunches the server from the new `dist/` and the write tools appear.
-
-## State at handoff — all verified, not assumed
+**PR #108 is open** against `main` from `feat/mcp-write-inbox` (head `87b6ac7`).
+It completes #88 and closes #97 and #95. Nothing is blocked; the PR is awaiting
+review/merge.
 
 | Piece | State | Evidence |
 |---|---|---|
-| Functions inbox endpoints | **deployed live** | `az functionapp function list` shows `inboxEnqueue`, `inboxList`, `inboxAck` |
-| Cosmos `inbox` container | **created** | `az cosmosdb sql container create`, pk `/id` |
-| Functions test suite | **130 passed** | `npm test` in `infra/functions` |
-| MCP write tools + catalog | **48 passed**, builds | `npm test`, `tsc --noEmit`, `npm run build` in `infra/mcp` |
-| Swift inbox apply-path | **all Swift Testing suites passed** | `xcodebuild test`, 0 issues recorded |
-| App on phone | **installed** | `devicectl install` → `com.eddelord.ClaudeLifter`, 2026-07-27 20:52 |
-| Functions read path post-deploy | **no regression** | MCP `health` → `authValid: true`; `list_templates` returns the same 3 templates |
+| Functions inbox endpoints | deployed live | `az functionapp function list` shows `inboxEnqueue`, `inboxList`, `inboxAck` |
+| Cosmos `inbox` container | created | pk `/id` |
+| Swift suite | **650 passed** | `xcodebuild test`, iPhone 13 Pro Max / iOS 26.5 |
+| Functions (Jest) | **145 passed** | `npm test` in `infra/functions` |
+| MCP (vitest) | **52 passed**, tsc clean, builds | `infra/mcp` |
+| Write path end-to-end | **proven in production** | 4 templates created via MCP, drained by the phone, full exercise lists — no #79 regression |
 
-Branch `feat/mcp-write-inbox`, committed as `d98ecf8` and pushed. Design:
-`infra/MCP_WRITE_PATH.md`.
+The four gym-restart templates (Upper A / Lower A / Upper B / Lower B) are live on
+the phone. The three unused pre-existing templates were deleted; the April 24
+Pull Day *session* survives in history with a dangling `templateId`.
 
-## The one remaining task — DONE 2026-07-27
+Design: `infra/MCP_WRITE_PATH.md` — trust it and `syncSnapshot.ts` over SPEC §7/§11.
 
-All four templates were created via `create_program`, drained by the phone, and
-verified with `list_templates`: each has its full exercise list, so the #79
-regression did **not** recur. The three unused pre-existing templates (Full Body
-Basics, Push Day, Pull Day) were deleted; the April 24 Pull Day *session* survives
-in history with a dangling `templateId`. Those deletions exposed **#97** — see
-"Known-open" below.
+## What PR #108 changed
 
-The original brief follows, for reference.
+- **#97** — the `requiresApproval` gate had no client implementation, so
+  approval-required operations applied unprompted and were then recorded `failed`
+  despite succeeding. The applier now acks `awaitingApproval` before mutating,
+  Home surfaces approvals, and approval is derived from operation **type** so a
+  malformed envelope cannot auto-apply an update or delete.
+- **#95** — creates derive entity identity from the operation id, so a re-served
+  operation upserts rather than duplicating.
+- Ack semantics: same-status retry is a no-op; terminal operations are never
+  overwritten; illegal transitions from a nonterminal state still go terminal
+  (otherwise they re-serve forever) but are now reported per-operation. A conflict
+  no longer blocks `pushSnapshot`.
+- Durable snapshot-dirty marker; server-issued `custom:<slug>:<operation-uuid>`
+  external ids under one grammar across MCP, Functions, and the phone.
 
-Create four workout templates via MCP. They are the program in
-`~/Documents/Analysis/fitness_and_wellness/gym_restart_program.md`, whose first
-session is **Wednesday 2026-07-29, 06:00** — so this needs to be done before then.
+## Known-open — read before touching the write path
 
-Every `externalId` below was resolved against `ClaudeLifter/Resources/exercises.json`
-and verified to exist. Do not invent or substitute ids; `search_exercises` first if
-anything needs changing.
-
-### Upper A
-| order | externalId | sets | reps |
-|---|---|---|---|
-| 0 | `Barbell_Bench_Press_-_Medium_Grip` | 3 | 8 |
-| 1 | `Seated_Cable_Rows` | 3 | 10 |
-| 2 | `Dumbbell_Shoulder_Press` | 3 | 10 |
-| 3 | `Wide-Grip_Lat_Pulldown` | 3 | 10 |
-| 4 | `Barbell_Curl` | 2 | 12 |
-| 5 | `Triceps_Pushdown_-_Rope_Attachment` | 2 | 12 |
-
-### Lower A
-| order | externalId | sets | reps |
-|---|---|---|---|
-| 0 | `Barbell_Squat` | 3 | 8 |
-| 1 | `Romanian_Deadlift` | 3 | 10 |
-| 2 | `Leg_Press` | 2 | 12 |
-| 3 | `Seated_Calf_Raise` | 2 | 15 |
-
-### Upper B
-| order | externalId | sets | reps |
-|---|---|---|---|
-| 0 | `Incline_Dumbbell_Press` | 3 | 10 |
-| 1 | `Wide-Grip_Lat_Pulldown` | 3 | 10 |
-| 2 | `Seated_One-arm_Cable_Pulley_Rows` | 3 | 10 |
-| 3 | `Side_Lateral_Raise` | 3 | 12 |
-
-### Lower B
-| order | externalId | sets | reps |
-|---|---|---|---|
-| 0 | `Trap_Bar_Deadlift` | 3 | 5 |
-| 1 | `Split_Squat_with_Dumbbells` | 2 | 10 |
-| 2 | `Seated_Leg_Curl` | 3 | 12 |
-| 3 | `Barbell_Ab_Rollout_-_On_Knees` | 2 | 10 |
-
-Leave `defaultWeight` unset — Evan is 7 months detrained and week 1 is ~50% of old
-working weights, which he sets at the bar. Omit `defaultRestSeconds`; the phone
-injects 90.
-
-## How to do it and how to know it worked
-
-1. `create_program` with all four templates (it validates every externalId before
-   enqueueing any, so a typo enqueues nothing).
-2. `list_pending_writes` → expect four `pending` operations.
-3. **Evan opens the app** — the inbox drains on sync, before the pending-changes
-   guard. Templates appear on Home.
-4. `list_pending_writes` → the four should now be `applied`. Anything `failed`
-   carries the reason in its `error`.
-5. `list_templates` → the four new templates, each with its full exercise list.
-
-**A template arriving with zero exercises is the #79 regression and means the fix
-failed.** Do not paper over it.
-
-## Known-open, deliberately not blocking
-
-- **#97** — the `requiresApproval` gate has no client implementation.
-  `InboxApplier` gates only on `status == "pending"` and never reads
-  `requiresApproval`, so approval-required ops apply **unprompted** and then ack
-  `pending → applied`, which the server rejects. The op ends `failed` while having
-  fully succeeded — so `failed` is not evidence an op did not happen.
-- **#95** — apply/ack is not transactional. A dropped ack after a successful local
-  apply re-serves the operation and creates a *duplicate* template. If duplicates
-  appear, that is why. Delete the extra and fix #95.
-- **#88 comment** — `create_custom_exercise` mints a `custom:` externalId that write
-  validation cannot resolve, so custom exercises cannot yet be used in templates.
-  Irrelevant here: all 17 exercises above are bundled.
+- **#103** — approval decisions are **not durable**. A lost final ack still lets a
+  user contradict a decision already applied, and `updateTemplate` can replay over
+  an intervening edit. Needs a local operation receipt. Biggest remaining gap.
+- **#104** — UI-created custom exercises are never pushed (`Exercise` is absent
+  from `hasPendingChanges`). **Pre-existing**; the dirty marker covers only the
+  inbox case.
+- #98 partial `create_program` enqueue · #99 import/sync ordering race ·
+  #100 Home staleness · #101 stale-write preconditions · #102 producer-side
+  enqueue idempotency · #105 MCP trusting historical `applied` records ·
+  #106 unconditional Cosmos replace on ack · #107 approval prompt trusts the
+  payload name.
 - **#96** — four Exercise Library UI tests are permanently red (they query
   `textFields` for a `.searchable` field). Pre-existing, unrelated.
 
-## Review findings logged this session
+## Gotchas worth keeping
 
-#89 (mixed weight units corrupt PRs/1RM/volume — the one that matters), #90, #91,
-#92, #93, #94, #96.
-
-## Suggested next step after the templates land
-
-Commit `feat/mcp-write-inbox` and open a PR against #88. Nothing is committed yet.
+- The `workout` MCP server loads its code at **session start**. After rebuilding
+  `infra/mcp/dist/`, Claude Code must be restarted before new tools appear.
+- The **iPhone 13 Pro Max simulator did not exist** on this machine and had to be
+  created (`xcrun simctl create` against the iOS 26.5 runtime). Do not substitute
+  iPhone 17 — it is documented to produce a false `ChatCoachTests` failure.
+- Static typechecks are not a test run. Two separate rounds of this work passed
+  typechecking and still failed the simulator suite (once a real product defect,
+  once non-UUID test fixtures). Always run `xcodebuild test`.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -23,9 +23,19 @@ relaunches the server from the new `dist/` and the write tools appear.
 | App on phone | **installed** | `devicectl install` → `com.eddelord.ClaudeLifter`, 2026-07-27 20:52 |
 | Functions read path post-deploy | **no regression** | MCP `health` → `authValid: true`; `list_templates` returns the same 3 templates |
 
-Branch `feat/mcp-write-inbox`, **uncommitted**. Design: `infra/MCP_WRITE_PATH.md`.
+Branch `feat/mcp-write-inbox`, committed as `d98ecf8` and pushed. Design:
+`infra/MCP_WRITE_PATH.md`.
 
-## The one remaining task
+## The one remaining task — DONE 2026-07-27
+
+All four templates were created via `create_program`, drained by the phone, and
+verified with `list_templates`: each has its full exercise list, so the #79
+regression did **not** recur. The three unused pre-existing templates (Full Body
+Basics, Push Day, Pull Day) were deleted; the April 24 Pull Day *session* survives
+in history with a dangling `templateId`. Those deletions exposed **#97** — see
+"Known-open" below.
+
+The original brief follows, for reference.
 
 Create four workout templates via MCP. They are the program in
 `~/Documents/Analysis/fitness_and_wellness/gym_restart_program.md`, whose first
@@ -89,6 +99,11 @@ failed.** Do not paper over it.
 
 ## Known-open, deliberately not blocking
 
+- **#97** — the `requiresApproval` gate has no client implementation.
+  `InboxApplier` gates only on `status == "pending"` and never reads
+  `requiresApproval`, so approval-required ops apply **unprompted** and then ack
+  `pending → applied`, which the server rejects. The op ends `failed` while having
+  fully succeeded — so `failed` is not evidence an op did not happen.
 - **#95** — apply/ack is not transactional. A dropped ack after a successful local
   apply re-serves the operation and creates a *duplicate* template. If duplicates
   appear, that is why. Delete the extra and fix #95.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,108 @@
+# HANDOFF — MCP write path (#88)
+
+Written 2026-07-27 ~21:00, immediately before a Claude Code restart. The restart is
+required and it destroys the session that did this work, so everything needed to
+finish is here.
+
+## Why a restart was needed
+
+The `workout` MCP server (configured in `~/.claude.json`) loads its code at session
+start. It was running the pre-#88 **read-only** build, so the write tools did not
+exist in the session's toolset even after `dist/` was rebuilt. Restarting Claude Code
+relaunches the server from the new `dist/` and the write tools appear.
+
+## State at handoff — all verified, not assumed
+
+| Piece | State | Evidence |
+|---|---|---|
+| Functions inbox endpoints | **deployed live** | `az functionapp function list` shows `inboxEnqueue`, `inboxList`, `inboxAck` |
+| Cosmos `inbox` container | **created** | `az cosmosdb sql container create`, pk `/id` |
+| Functions test suite | **130 passed** | `npm test` in `infra/functions` |
+| MCP write tools + catalog | **48 passed**, builds | `npm test`, `tsc --noEmit`, `npm run build` in `infra/mcp` |
+| Swift inbox apply-path | **all Swift Testing suites passed** | `xcodebuild test`, 0 issues recorded |
+| App on phone | **installed** | `devicectl install` → `com.eddelord.ClaudeLifter`, 2026-07-27 20:52 |
+| Functions read path post-deploy | **no regression** | MCP `health` → `authValid: true`; `list_templates` returns the same 3 templates |
+
+Branch `feat/mcp-write-inbox`, **uncommitted**. Design: `infra/MCP_WRITE_PATH.md`.
+
+## The one remaining task
+
+Create four workout templates via MCP. They are the program in
+`~/Documents/Analysis/fitness_and_wellness/gym_restart_program.md`, whose first
+session is **Wednesday 2026-07-29, 06:00** — so this needs to be done before then.
+
+Every `externalId` below was resolved against `ClaudeLifter/Resources/exercises.json`
+and verified to exist. Do not invent or substitute ids; `search_exercises` first if
+anything needs changing.
+
+### Upper A
+| order | externalId | sets | reps |
+|---|---|---|---|
+| 0 | `Barbell_Bench_Press_-_Medium_Grip` | 3 | 8 |
+| 1 | `Seated_Cable_Rows` | 3 | 10 |
+| 2 | `Dumbbell_Shoulder_Press` | 3 | 10 |
+| 3 | `Wide-Grip_Lat_Pulldown` | 3 | 10 |
+| 4 | `Barbell_Curl` | 2 | 12 |
+| 5 | `Triceps_Pushdown_-_Rope_Attachment` | 2 | 12 |
+
+### Lower A
+| order | externalId | sets | reps |
+|---|---|---|---|
+| 0 | `Barbell_Squat` | 3 | 8 |
+| 1 | `Romanian_Deadlift` | 3 | 10 |
+| 2 | `Leg_Press` | 2 | 12 |
+| 3 | `Seated_Calf_Raise` | 2 | 15 |
+
+### Upper B
+| order | externalId | sets | reps |
+|---|---|---|---|
+| 0 | `Incline_Dumbbell_Press` | 3 | 10 |
+| 1 | `Wide-Grip_Lat_Pulldown` | 3 | 10 |
+| 2 | `Seated_One-arm_Cable_Pulley_Rows` | 3 | 10 |
+| 3 | `Side_Lateral_Raise` | 3 | 12 |
+
+### Lower B
+| order | externalId | sets | reps |
+|---|---|---|---|
+| 0 | `Trap_Bar_Deadlift` | 3 | 5 |
+| 1 | `Split_Squat_with_Dumbbells` | 2 | 10 |
+| 2 | `Seated_Leg_Curl` | 3 | 12 |
+| 3 | `Barbell_Ab_Rollout_-_On_Knees` | 2 | 10 |
+
+Leave `defaultWeight` unset — Evan is 7 months detrained and week 1 is ~50% of old
+working weights, which he sets at the bar. Omit `defaultRestSeconds`; the phone
+injects 90.
+
+## How to do it and how to know it worked
+
+1. `create_program` with all four templates (it validates every externalId before
+   enqueueing any, so a typo enqueues nothing).
+2. `list_pending_writes` → expect four `pending` operations.
+3. **Evan opens the app** — the inbox drains on sync, before the pending-changes
+   guard. Templates appear on Home.
+4. `list_pending_writes` → the four should now be `applied`. Anything `failed`
+   carries the reason in its `error`.
+5. `list_templates` → the four new templates, each with its full exercise list.
+
+**A template arriving with zero exercises is the #79 regression and means the fix
+failed.** Do not paper over it.
+
+## Known-open, deliberately not blocking
+
+- **#95** — apply/ack is not transactional. A dropped ack after a successful local
+  apply re-serves the operation and creates a *duplicate* template. If duplicates
+  appear, that is why. Delete the extra and fix #95.
+- **#88 comment** — `create_custom_exercise` mints a `custom:` externalId that write
+  validation cannot resolve, so custom exercises cannot yet be used in templates.
+  Irrelevant here: all 17 exercises above are bundled.
+- **#96** — four Exercise Library UI tests are permanently red (they query
+  `textFields` for a `.searchable` field). Pre-existing, unrelated.
+
+## Review findings logged this session
+
+#89 (mixed weight units corrupt PRs/1RM/volume — the one that matters), #90, #91,
+#92, #93, #94, #96.
+
+## Suggested next step after the templates land
+
+Commit `feat/mcp-write-inbox` and open a PR against #88. Nothing is committed yet.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -13,7 +13,8 @@ review/merge.
 |---|---|---|
 | Functions inbox endpoints | deployed live | `az functionapp function list` shows `inboxEnqueue`, `inboxList`, `inboxAck` |
 | Cosmos `inbox` container | created | pk `/id` |
-| Swift suite | **650 passed** | `xcodebuild test`, iPhone 13 Pro Max / iOS 26.5 |
+| Swift Testing suites | **650 passed** | `xcodebuild test`, iPhone 13 Pro Max / iOS 26.5 |
+| XCUITest | 4 failing — pre-existing #96 | identical on the pre-change baseline; makes `xcodebuild test` exit 65 |
 | Functions (Jest) | **145 passed** | `npm test` in `infra/functions` |
 | MCP (vitest) | **52 passed**, tsc clean, builds | `infra/mcp` |
 | Write path end-to-end | **proven in production** | 4 templates created via MCP, drained by the phone, full exercise lists — no #79 regression |
@@ -66,3 +67,8 @@ Design: `infra/MCP_WRITE_PATH.md` — trust it and `syncSnapshot.ts` over SPEC �
 - Static typechecks are not a test run. Two separate rounds of this work passed
   typechecking and still failed the simulator suite (once a real product defect,
   once non-UUID test fixtures). Always run `xcodebuild test`.
+- **`xcodebuild test` exits 65 even when your change is fine**, because the four
+  #96 UI tests are permanently red. Grepping only Swift Testing's `✘` format
+  misses them — they are XCUITest and print `Test Case '-[...]' failed`. Read the
+  `Failing tests:` block and diff it against a baseline run before concluding
+  anything, and never pipe `xcodebuild` through `tail` without `set -o pipefail`.

--- a/infra/MCP_WRITE_PATH.md
+++ b/infra/MCP_WRITE_PATH.md
@@ -74,7 +74,7 @@ interface InboxOperation {
 |---|---|---|
 | `/api/inbox` | POST | Body `{ op, payload }`. Validates, assigns `id`/`createdAt`/`requiresApproval`, sets `status: "pending"`, returns the stored doc. |
 | `/api/inbox` | GET | `?status=` (default `pending`). Returns `{ operations: [...] }` oldest-first. |
-| `/api/inbox/ack` | POST | Body `{ results: [{ id, status, error? }] }`. Terminal-state writes are idempotent no-ops. Returns counts. |
+| `/api/inbox/ack` | POST | Body `{ results: [{ id, status, error? }] }`. Retrying the operation's current status is an idempotent no-op. An invalid transition fails a nonterminal operation so it cannot loop; a terminal disagreement stays unchanged. Both return a per-operation `conflict` outcome. |
 
 ### Status machine
 
@@ -83,9 +83,32 @@ pending ──► applied | failed                      (creates: applied on fet
 pending ──► awaitingApproval ──► applied | rejected | failed   (update/delete)
 ```
 
-The phone acks **every** operation it fetches in the same cycle — creates as
-`applied`/`failed`, approval-required ops as `awaitingApproval` — so nothing is
-served twice. Applied and rejected docs are retained as an audit trail.
+The phone acks **every** pending operation it fetches in the same cycle — creates
+as `applied`/`failed`, approval-required ops as `awaitingApproval` — before it
+mutates any approval-required operation. It separately refetches
+`awaitingApproval` operations for the Home approval UI, including after an app
+restart. Applied and rejected docs are retained as an audit trail.
+
+Ack responses include one result per requested id:
+
+```ts
+{
+  counts: { updated, unchanged, notFound, invalid },
+  results: [{
+    id,
+    requestedStatus,
+    resultingStatus?,
+    outcome: "updated" | "unchanged" | "notFound" | "conflict",
+    conflict?
+  }]
+}
+```
+
+The iOS client treats malformed, missing, extra, `notFound`, or `conflict`
+results as a sync error, but still pushes locally applied batch-mates. A
+nonterminal conflict is durably rewritten to `failed` with the reason so it is
+not served forever. An already-terminal operation receiving a different status
+remains unchanged.
 
 ### Payloads
 
@@ -95,7 +118,8 @@ served twice. Applied and rejected docs are retained as an audit trail.
 // field is absent. The Function preserves omission and never injects — one
 // layer owns the default, and it is the layer whose type demands a value.
 
-// createTemplate — no client-supplied UUID; the phone assigns it.
+// createTemplate — no client-supplied UUID. The phone deterministically uses
+// the inbox operation UUID, so replaying a create after a lost ack is a no-op.
 { name: string, notes?: string,
   exercises: [{ externalId: string, order: number, defaultSets: number,
                 defaultReps: number, defaultWeight?: number,
@@ -108,27 +132,37 @@ served twice. Applied and rejected docs are retained as an audit trail.
 // deleteTemplate — name carried so the approval banner needs no lookup.
 { id: string, name: string }
 
-// createCustomExercise — phone assigns the UUID, sets isCustom = true and
-// externalId = "custom:<slug-of-name>" so later template writes can reference it.
+// createCustomExercise input — no externalId accepted from the producer.
 { name: string, equipment?: string, primaryMuscles?: string[],
   secondaryMuscles?: string[], instructions?: string[], notes?: string }
+
+// Stored createCustomExercise payload — the Function adds this canonical id:
+// "custom:<ascii-name-slug>:<inbox-operation-uuid>"
+// slug grammar: lowercase alphanumeric hyphen-separated segments, 1...64 chars
+// The phone uses the inbox UUID as the Exercise UUID and consumes this
+// server-issued externalId verbatim.
 ```
 
 ## Validation — three layers, deliberately redundant
 
-1. **MCP tool boundary.** Every `externalId` is resolved against a slim catalog
+1. **MCP tool boundary.** Bundled `externalId`s resolve against a slim catalog
    index generated at build time from `ClaudeLifter/Resources/exercises.json`
-   (~1 MB → id/name/muscles/equipment/category only). An unknown id is rejected
-   *before* the HTTP call, with `search_exercises` suggestions in the error. This
-   is the fix for #79 root cause 2 — an invented exercise can no longer be
-   enqueued at all.
+   (~1 MB → id/name/muscles/equipment/category only). `custom:` ids resolve
+   against the cloud snapshot or a durable pending/applied
+   `createCustomExercise` inbox operation, so a custom exercise can be used in a
+   template even before the phone's next snapshot push. An unknown id is rejected
+   *before* the template HTTP POST, with `search_exercises` suggestions in the
+   error.
 2. **Function enqueue.** Structural: `externalId` non-empty strings, positive
-   integer sets/reps, unique `order`. Rejects with 400 before any write.
+   integer sets/reps, unique `order`. Custom exercise ids are minted as
+   `custom:<slug>:<operation-uuid>` with a 64-character slug bound. Rejects with
+   400 before any write.
 3. **Phone apply.** `fetchByExternalId` **strictly** — no fuzzy fallback, no
    placeholder creation. If any exercise in an operation fails to resolve, the
    **entire operation fails** and is acked `failed` with the unresolved ids. A
    partial template is precisely the bug that started this; half-applying is worse
-   than failing loudly.
+   than failing loudly. A custom exercise payload must use the same bounded
+   grammar and its UUID suffix must equal the inbox operation UUID.
 
 ## Sync ordering — the trap
 
@@ -142,24 +176,39 @@ when Claude is writing. Required order:
 3. `hasPendingChanges()` — now true, because applying marked new templates `.pending`
 4. `pushSnapshot()`
 
-## Approval — decided against an in-app queue (2026-07-27)
+When any inbox operation applies locally, `SettingsManager.isSnapshotDirty` is
+set in UserDefaults before the ack. It is cleared only after a snapshot push
+succeeds. This is required for custom exercises, which have no per-record
+`syncStatus`: a failed push followed by an app restart still retries even if the
+inbox is then empty.
 
-An earlier draft queued update/delete in a local `PendingWriteApproval` model behind
-a Home approval banner. **Dropped at Evan's direction:** for a single-user app the
-approval already happens in conversation — he asks for the change, then it is made.
-An in-app banner re-confirms a decision he just made, one screen later.
+## Approval — server-durable, no SwiftData queue
 
-Consequences, both good:
+Update and delete operations never mutate local data while `pending`. The phone
+first acks them `awaitingApproval`, then refetches that durable server state and
+shows one Home approval card per operation. The card follows the app's existing
+confirmation pattern and opens a confirmation dialog with Approve, Decline, and
+Cancel.
 
-- **No new `@Model`, so no SwiftData schema change**, and none of the on-device
-  migration risk that has bitten this app before.
-- All four operations auto-apply on sync. `awaitingApproval` stays in the Function's
-  status machine as an unused-but-valid state rather than being ripped out, so a
-  future UI can adopt it without a wire change.
+- Approve applies locally, acks `applied`, and pushes the dirty snapshot.
+- Decline acks `rejected` and performs no repository mutation.
+- A restart loses no queue state: `awaitingApproval` is refetched from the
+  server and shown again.
 
-The safety net for a destructive mistake is the existing cloud snapshot restore plus
-backup export — not a confirmation tap. A deleted template's absence from the next
-snapshot propagates the delete to the mirror; no tombstones needed.
+There is deliberately **no new SwiftData `@Model`** for approvals, so this change
+does not require an AppSchema version bump or migration.
+
+## Create replay safety
+
+`createTemplate` and `createCustomExercise` derive their local entity UUID from
+the Function-assigned inbox operation UUID. Before inserting, the applier fetches
+that UUID through the repository; if it already exists, replay is a successful
+no-op. A lost ack can therefore re-serve a create without inserting a duplicate.
+
+Custom external ids are minted once by the Function as
+`custom:<slug>:<operation-uuid>`. The reserved prefix keeps them separate from
+bundled ids, and the operation suffix disambiguates names that normalize to the
+same slug. Swift does not duplicate the TypeScript slug algorithm.
 
 ## MCP tool surface
 

--- a/infra/MCP_WRITE_PATH.md
+++ b/infra/MCP_WRITE_PATH.md
@@ -1,0 +1,181 @@
+# MCP Write Path — Inbox Design
+
+Status: design agreed 2026-07-27. Supersedes the disabled write tools from #79.
+
+## The problem the obvious design gets wrong
+
+Writing templates from MCP straight into Cosmos **cannot work**, and not for the
+reason #79 recorded. `syncSnapshot.ts` reconciles each container to exactly the
+phone's snapshot: it upserts every doc in the push, then **deletes every doc whose
+id is not in it** (`syncSnapshot.ts:212-225`). The phone doesn't know about an
+MCP-written template, so the template is absent from the next snapshot, so the
+server deletes it. Any direct write to the mirror is erased on the next sync.
+
+The mirror is a projection of the phone. Writes have to reach the phone.
+
+## Exercise identity — the other half of #79
+
+`ExerciseImportService.swift:49` constructs `Exercise(...)` without an `id`, so
+`Exercise.id` is a **random UUID assigned at import time on that install**. That is
+why MCP-invented `exerciseId`s never resolved and why templates arrived empty.
+
+`Exercise.externalId` holds the free-exercise-db string id
+(`Barbell_Bench_Press_-_Medium_Grip`), is stable across installs, and is already in
+the repo at `ClaudeLifter/Resources/exercises.json`. `ExerciseRepository` already
+exposes `fetchByExternalId(_:)`.
+
+**Rule: MCP references exercises by `externalId`, never by UUID. The phone
+resolves.** No cloud exercise catalog needs to be seeded.
+
+## Architecture
+
+A durable **inbox** of proposed operations that the phone drains on sync.
+
+```
+MCP write tool
+    │  validates externalIds against the bundled catalog  ← invented exercises die here
+    ▼
+POST /api/inbox ──────────► Cosmos `inbox` container   (NOT in SNAPSHOT_COLLECTIONS)
+                                    │
+                     GET /api/inbox │ (phone, every sync, BEFORE the pending-changes guard)
+                                    ▼
+                            apply in SwiftData
+                        creates → applied immediately
+              update/delete → held for user approval on Home
+                                    │
+                     POST /api/inbox/ack
+                                    ▼
+                       normal snapshot push makes them real in the mirror
+```
+
+The phone stays authoritative. The snapshot contract is untouched.
+
+## Wire contract
+
+New Cosmos container `inbox`, partition key `/id`. Excluded from
+`SNAPSHOT_COLLECTIONS` — snapshot reconciliation must never see it.
+
+```ts
+interface InboxOperation {
+  id: string;              // uuid, assigned by the Function (never the client)
+  createdAt: string;       // ISO 8601, server clock
+  op: "createTemplate" | "updateTemplate" | "deleteTemplate" | "createCustomExercise";
+  payload: object;         // op-specific, validated at enqueue
+  requiresApproval: boolean; // server-computed: false for creates, true for update/delete
+  status: "pending" | "awaitingApproval" | "applied" | "rejected" | "failed";
+  appliedAt?: string;
+  error?: string;          // set when status === "failed"
+}
+```
+
+### Endpoints
+
+| Endpoint | Method | Behaviour |
+|---|---|---|
+| `/api/inbox` | POST | Body `{ op, payload }`. Validates, assigns `id`/`createdAt`/`requiresApproval`, sets `status: "pending"`, returns the stored doc. |
+| `/api/inbox` | GET | `?status=` (default `pending`). Returns `{ operations: [...] }` oldest-first. |
+| `/api/inbox/ack` | POST | Body `{ results: [{ id, status, error? }] }`. Terminal-state writes are idempotent no-ops. Returns counts. |
+
+### Status machine
+
+```
+pending ──► applied | failed                      (creates: applied on fetch)
+pending ──► awaitingApproval ──► applied | rejected | failed   (update/delete)
+```
+
+The phone acks **every** operation it fetches in the same cycle — creates as
+`applied`/`failed`, approval-required ops as `awaitingApproval` — so nothing is
+served twice. Applied and rejected docs are retained as an audit trail.
+
+### Payloads
+
+```ts
+// `defaultRestSeconds` is optional on the wire and non-optional in iOS
+// (#79 root cause 3). The PHONE owns the default: it injects 90 when the
+// field is absent. The Function preserves omission and never injects — one
+// layer owns the default, and it is the layer whose type demands a value.
+
+// createTemplate — no client-supplied UUID; the phone assigns it.
+{ name: string, notes?: string,
+  exercises: [{ externalId: string, order: number, defaultSets: number,
+                defaultReps: number, defaultWeight?: number,
+                defaultRestSeconds?: number /* default 90 */, notes?: string }] }
+
+// updateTemplate — `exercises`, when present, REPLACES the whole ordered list.
+{ id: string /* template UUID from list_templates */, name?: string,
+  notes?: string, exercises?: [ ...as above ] }
+
+// deleteTemplate — name carried so the approval banner needs no lookup.
+{ id: string, name: string }
+
+// createCustomExercise — phone assigns the UUID, sets isCustom = true and
+// externalId = "custom:<slug-of-name>" so later template writes can reference it.
+{ name: string, equipment?: string, primaryMuscles?: string[],
+  secondaryMuscles?: string[], instructions?: string[], notes?: string }
+```
+
+## Validation — three layers, deliberately redundant
+
+1. **MCP tool boundary.** Every `externalId` is resolved against a slim catalog
+   index generated at build time from `ClaudeLifter/Resources/exercises.json`
+   (~1 MB → id/name/muscles/equipment/category only). An unknown id is rejected
+   *before* the HTTP call, with `search_exercises` suggestions in the error. This
+   is the fix for #79 root cause 2 — an invented exercise can no longer be
+   enqueued at all.
+2. **Function enqueue.** Structural: `externalId` non-empty strings, positive
+   integer sets/reps, unique `order`. Rejects with 400 before any write.
+3. **Phone apply.** `fetchByExternalId` **strictly** — no fuzzy fallback, no
+   placeholder creation. If any exercise in an operation fails to resolve, the
+   **entire operation fails** and is acked `failed` with the unresolved ids. A
+   partial template is precisely the bug that started this; half-applying is worse
+   than failing loudly.
+
+## Sync ordering — the trap
+
+`SyncManager.syncIfNeeded()` returns early when there are no pending local changes
+(`SyncManager.swift:132`). Fetching the inbox after that guard means **MCP writes
+never arrive on an idle phone** — the common case, since the phone is idle exactly
+when Claude is writing. Required order:
+
+1. Fetch inbox + apply (before any pending-changes guard)
+2. Ack results
+3. `hasPendingChanges()` — now true, because applying marked new templates `.pending`
+4. `pushSnapshot()`
+
+## Approval — decided against an in-app queue (2026-07-27)
+
+An earlier draft queued update/delete in a local `PendingWriteApproval` model behind
+a Home approval banner. **Dropped at Evan's direction:** for a single-user app the
+approval already happens in conversation — he asks for the change, then it is made.
+An in-app banner re-confirms a decision he just made, one screen later.
+
+Consequences, both good:
+
+- **No new `@Model`, so no SwiftData schema change**, and none of the on-device
+  migration risk that has bitten this app before.
+- All four operations auto-apply on sync. `awaitingApproval` stays in the Function's
+  status machine as an unused-but-valid state rather than being ripped out, so a
+  future UI can adopt it without a wire change.
+
+The safety net for a destructive mistake is the existing cloud snapshot restore plus
+backup export — not a confirmation tap. A deleted template's absence from the next
+snapshot propagates the delete to the mirror; no tombstones needed.
+
+## MCP tool surface
+
+Re-enabled / new:
+
+| Tool | Notes |
+|---|---|
+| `search_exercises` | Bundled catalog index + cloud `customExercises`. No longer queries the empty container. |
+| `create_template` | Enqueues `createTemplate`. Auto-applies on the phone. |
+| `update_template` | Enqueues `updateTemplate`. Requires approval. |
+| `delete_template` | Enqueues `deleteTemplate`. Requires approval. |
+| `create_program` | N × `createTemplate` in one call, all-or-nothing validation. |
+| `create_custom_exercise` | Enqueues `createCustomExercise`. Auto-applies. |
+| `list_pending_writes` | Reads back queued/applied/failed operations — closes the loop so a write can be *verified*, not assumed. |
+
+## Out of scope
+
+Workout-session and body-weight writes (deliberately deferred — corrupting logged
+training data is the most damaging failure mode and there is no need for it yet).

--- a/infra/functions/src/functions/inbox.ts
+++ b/infra/functions/src/functions/inbox.ts
@@ -1,0 +1,633 @@
+/**
+ * Durable MCP write inbox (issue #88).
+ *
+ * POST /api/inbox
+ *   Validates one operation completely, assigns its server-owned envelope,
+ *   and creates it in the Cosmos `inbox` container.
+ *
+ * GET /api/inbox
+ *   Returns all operations for one status (pending by default), oldest first.
+ *   Cosmos query pages are consumed to exhaustion.
+ *
+ * POST /api/inbox/ack
+ *   Advances operation statuses. Existing terminal operations are idempotent
+ *   no-ops, and unknown ids are counted rather than treated as server errors.
+ */
+
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { Container } from "@azure/cosmos";
+import { randomUUID } from "node:crypto";
+import { authenticate } from "../shared/auth";
+import { getDatabase } from "../shared/cosmos";
+import { readItemOrNull } from "../shared/readHelpers";
+import {
+  InboxAckCounts,
+  InboxAckRequest,
+  InboxAckResponse,
+  InboxAckResult,
+  InboxAckStatus,
+  InboxEnqueueRequest,
+  InboxEnqueueResponse,
+  InboxListResponse,
+  InboxOperation,
+  InboxOperationPayload,
+  InboxOperationStatus,
+  InboxOperationType,
+} from "../shared/types";
+
+const INBOX_CONTAINER = "inbox";
+const PAGE_SIZE = 100;
+
+const OPERATION_TYPES: readonly InboxOperationType[] = [
+  "createTemplate",
+  "updateTemplate",
+  "deleteTemplate",
+  "createCustomExercise",
+];
+
+const OPERATION_STATUSES: readonly InboxOperationStatus[] = [
+  "pending",
+  "awaitingApproval",
+  "applied",
+  "rejected",
+  "failed",
+];
+
+const ACK_STATUSES: readonly InboxAckStatus[] = [
+  "awaitingApproval",
+  "applied",
+  "rejected",
+  "failed",
+];
+
+const TERMINAL_STATUSES = new Set<InboxOperationStatus>([
+  "applied",
+  "rejected",
+  "failed",
+]);
+
+const COSMOS_SYSTEM_PROPS = ["_rid", "_self", "_etag", "_attachments", "_ts"];
+
+function badRequest(message: string): HttpResponseInit {
+  return { status: 400, jsonBody: { error: message } };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalStringArray(value: unknown): value is string[] | undefined {
+  return (
+    value === undefined ||
+    (Array.isArray(value) && value.every((entry) => typeof entry === "string"))
+  );
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isOptionalFiniteNumber(value: unknown): value is number | undefined {
+  return value === undefined || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isOperationType(value: unknown): value is InboxOperationType {
+  return (
+    typeof value === "string" &&
+    OPERATION_TYPES.includes(value as InboxOperationType)
+  );
+}
+
+function isOperationStatus(value: unknown): value is InboxOperationStatus {
+  return (
+    typeof value === "string" &&
+    OPERATION_STATUSES.includes(value as InboxOperationStatus)
+  );
+}
+
+function isAckStatus(value: unknown): value is InboxAckStatus {
+  return (
+    typeof value === "string" && ACK_STATUSES.includes(value as InboxAckStatus)
+  );
+}
+
+function validateTemplateExercises(
+  value: unknown,
+  field: string
+): HttpResponseInit | null {
+  if (!Array.isArray(value)) {
+    return badRequest(`Malformed payload: ${field} must be an array`);
+  }
+
+  const orders = new Set<number>();
+  for (let index = 0; index < value.length; index += 1) {
+    const exercise = value[index];
+    if (!isObject(exercise)) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}] must be an object`
+      );
+    }
+    if (!isNonEmptyString(exercise["externalId"])) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].externalId must be a non-empty string`
+      );
+    }
+    const order = exercise["order"];
+    if (!Number.isInteger(order) || (order as number) < 0) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].order must be a non-negative integer`
+      );
+    }
+    if (orders.has(order as number)) {
+      return badRequest(
+        `Malformed payload: ${field} contains duplicate order ${String(order)}`
+      );
+    }
+    orders.add(order as number);
+
+    if (!isPositiveInteger(exercise["defaultSets"])) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].defaultSets must be a positive integer`
+      );
+    }
+    if (!isPositiveInteger(exercise["defaultReps"])) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].defaultReps must be a positive integer`
+      );
+    }
+    if (!isOptionalFiniteNumber(exercise["defaultWeight"])) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].defaultWeight must be a finite number`
+      );
+    }
+    const restSeconds = exercise["defaultRestSeconds"];
+    if (
+      restSeconds !== undefined &&
+      (!Number.isInteger(restSeconds) || (restSeconds as number) < 0)
+    ) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].defaultRestSeconds must be a non-negative integer`
+      );
+    }
+    if (!isOptionalString(exercise["notes"])) {
+      return badRequest(
+        `Malformed payload: ${field}[${index}].notes must be a string`
+      );
+    }
+  }
+
+  return null;
+}
+
+function validateCreateTemplate(
+  payload: Record<string, unknown>
+): HttpResponseInit | null {
+  if (!isNonEmptyString(payload["name"])) {
+    return badRequest("Malformed payload: name must be a non-empty string");
+  }
+  if (!isOptionalString(payload["notes"])) {
+    return badRequest("Malformed payload: notes must be a string");
+  }
+  return validateTemplateExercises(payload["exercises"], "exercises");
+}
+
+function validateUpdateTemplate(
+  payload: Record<string, unknown>
+): HttpResponseInit | null {
+  if (!isNonEmptyString(payload["id"])) {
+    return badRequest("Malformed payload: id must be a non-empty string");
+  }
+  if (
+    payload["name"] !== undefined &&
+    !isNonEmptyString(payload["name"])
+  ) {
+    return badRequest("Malformed payload: name must be a non-empty string");
+  }
+  if (!isOptionalString(payload["notes"])) {
+    return badRequest("Malformed payload: notes must be a string");
+  }
+  if (payload["exercises"] !== undefined) {
+    return validateTemplateExercises(payload["exercises"], "exercises");
+  }
+  return null;
+}
+
+function validateDeleteTemplate(
+  payload: Record<string, unknown>
+): HttpResponseInit | null {
+  if (!isNonEmptyString(payload["id"])) {
+    return badRequest("Malformed payload: id must be a non-empty string");
+  }
+  if (!isNonEmptyString(payload["name"])) {
+    return badRequest("Malformed payload: name must be a non-empty string");
+  }
+  return null;
+}
+
+function validateCreateCustomExercise(
+  payload: Record<string, unknown>
+): HttpResponseInit | null {
+  if (!isNonEmptyString(payload["name"])) {
+    return badRequest("Malformed payload: name must be a non-empty string");
+  }
+  if (!isOptionalString(payload["equipment"])) {
+    return badRequest("Malformed payload: equipment must be a string");
+  }
+  if (!isOptionalStringArray(payload["primaryMuscles"])) {
+    return badRequest("Malformed payload: primaryMuscles must be a string array");
+  }
+  if (!isOptionalStringArray(payload["secondaryMuscles"])) {
+    return badRequest("Malformed payload: secondaryMuscles must be a string array");
+  }
+  if (!isOptionalStringArray(payload["instructions"])) {
+    return badRequest("Malformed payload: instructions must be a string array");
+  }
+  if (!isOptionalString(payload["notes"])) {
+    return badRequest("Malformed payload: notes must be a string");
+  }
+  return null;
+}
+
+/**
+ * Validates the complete enqueue body before Cosmos is accessed. Top-level
+ * id/requiresApproval fields are deliberately not read; the Function owns
+ * the operation envelope.
+ */
+function validateEnqueueBody(
+  body: unknown
+):
+  | { ok: true; value: InboxEnqueueRequest }
+  | { ok: false; error: HttpResponseInit } {
+  if (!isObject(body)) {
+    return {
+      ok: false,
+      error: badRequest("Malformed body: expected a JSON object"),
+    };
+  }
+  if (!isOperationType(body["op"])) {
+    return {
+      ok: false,
+      error: badRequest(`Unknown op: ${JSON.stringify(body["op"])}`),
+    };
+  }
+  if (!isObject(body["payload"])) {
+    return {
+      ok: false,
+      error: badRequest("Malformed body: payload must be an object"),
+    };
+  }
+
+  const op = body["op"];
+  const payload = body["payload"];
+  let validationError: HttpResponseInit | null;
+  switch (op) {
+    case "createTemplate":
+      validationError = validateCreateTemplate(payload);
+      break;
+    case "updateTemplate":
+      validationError = validateUpdateTemplate(payload);
+      break;
+    case "deleteTemplate":
+      validationError = validateDeleteTemplate(payload);
+      break;
+    case "createCustomExercise":
+      validationError = validateCreateCustomExercise(payload);
+      break;
+  }
+  if (validationError) return { ok: false, error: validationError };
+
+  return {
+    ok: true,
+    value: { op, payload } as unknown as InboxEnqueueRequest,
+  };
+}
+
+function validateAckBody(
+  body: unknown
+):
+  | { ok: true; value: InboxAckRequest }
+  | { ok: false; error: HttpResponseInit } {
+  if (!isObject(body) || !Array.isArray(body["results"])) {
+    return {
+      ok: false,
+      error: badRequest("Malformed body: results must be an array"),
+    };
+  }
+
+  const ids = new Set<string>();
+  for (let index = 0; index < body["results"].length; index += 1) {
+    const result = body["results"][index];
+    if (!isObject(result)) {
+      return {
+        ok: false,
+        error: badRequest(`Malformed body: results[${index}] must be an object`),
+      };
+    }
+    if (!isNonEmptyString(result["id"])) {
+      return {
+        ok: false,
+        error: badRequest(
+          `Malformed body: results[${index}].id must be a non-empty string`
+        ),
+      };
+    }
+    if (ids.has(result["id"])) {
+      return {
+        ok: false,
+        error: badRequest(`Malformed body: duplicate result id ${result["id"]}`),
+      };
+    }
+    ids.add(result["id"]);
+    if (!isAckStatus(result["status"])) {
+      return {
+        ok: false,
+        error: badRequest(
+          `Malformed body: results[${index}].status is not an ack status`
+        ),
+      };
+    }
+    if (!isOptionalString(result["error"])) {
+      return {
+        ok: false,
+        error: badRequest(
+          `Malformed body: results[${index}].error must be a string`
+        ),
+      };
+    }
+  }
+
+  return { ok: true, value: body as unknown as InboxAckRequest };
+}
+
+function stripSystemProps(operation: InboxOperation): InboxOperation {
+  const clean = { ...operation } as InboxOperation & Record<string, unknown>;
+  for (const property of COSMOS_SYSTEM_PROPS) delete clean[property];
+  return clean;
+}
+
+async function queryAllByStatus(
+  container: Container,
+  status: InboxOperationStatus
+): Promise<InboxOperation[]> {
+  const iterator = container.items.query(
+    {
+      query:
+        "SELECT * FROM c WHERE c.status = @status ORDER BY c.createdAt ASC",
+      parameters: [{ name: "@status", value: status }],
+    },
+    { maxItemCount: PAGE_SIZE }
+  );
+  const operations: InboxOperation[] = [];
+  while (iterator.hasMoreResults()) {
+    const { resources } = await iterator.fetchNext();
+    for (const operation of resources ?? []) {
+      operations.push(stripSystemProps(operation as InboxOperation));
+    }
+  }
+  return operations.sort((left, right) =>
+    left.createdAt.localeCompare(right.createdAt)
+  );
+}
+
+function requiresApproval(op: InboxOperationType): boolean {
+  return op === "updateTemplate" || op === "deleteTemplate";
+}
+
+function transitionError(
+  operation: InboxOperation,
+  nextStatus: InboxAckStatus
+): string | null {
+  if (TERMINAL_STATUSES.has(operation.status)) return null;
+
+  if (operation.status === "pending") {
+    if (operation.requiresApproval) {
+      return nextStatus === "awaitingApproval" || nextStatus === "failed"
+        ? null
+        : `${operation.status} ${operation.op} cannot transition to ${nextStatus}`;
+    }
+    return nextStatus === "applied" || nextStatus === "failed"
+      ? null
+      : `${operation.status} ${operation.op} cannot transition to ${nextStatus}`;
+  }
+
+  if (operation.status === "awaitingApproval") {
+    return nextStatus === "applied" ||
+      nextStatus === "rejected" ||
+      nextStatus === "failed"
+      ? null
+      : `${operation.status} ${operation.op} cannot transition to ${nextStatus}`;
+  }
+
+  return `Unknown current status for ${operation.id}: ${String(operation.status)}`;
+}
+
+function applyAckResult(
+  operation: InboxOperation,
+  result: InboxAckResult
+): InboxOperation {
+  const updated = stripSystemProps({ ...operation, status: result.status });
+  delete updated.appliedAt;
+  delete updated.error;
+  if (result.status === "applied") {
+    updated.appliedAt = new Date().toISOString();
+  }
+  if (result.status === "failed" && result.error !== undefined) {
+    updated.error = result.error;
+  }
+  return updated;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+app.http("inboxEnqueue", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  route: "inbox",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const authError = authenticate(request);
+    if (authError) return authError;
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return badRequest("Invalid JSON body");
+    }
+
+    const validation = validateEnqueueBody(body);
+    if (!validation.ok) return validation.error;
+
+    const operation: InboxOperation = {
+      id: randomUUID(),
+      createdAt: new Date().toISOString(),
+      op: validation.value.op,
+      payload: validation.value.payload as InboxOperationPayload,
+      requiresApproval: requiresApproval(validation.value.op),
+      status: "pending",
+    };
+
+    try {
+      await getDatabase().container(INBOX_CONTAINER).items.create(operation);
+      const response: InboxEnqueueResponse = operation;
+      return { jsonBody: response };
+    } catch (error) {
+      context.error("Inbox enqueue failed:", error);
+      return { status: 500, jsonBody: { error: "Failed to enqueue operation" } };
+    }
+  },
+});
+
+app.http("inboxList", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  route: "inbox",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const authError = authenticate(request);
+    if (authError) return authError;
+
+    const requestedStatus = request.query.get("status") || "pending";
+    if (!isOperationStatus(requestedStatus)) {
+      return badRequest(`Unknown status: ${JSON.stringify(requestedStatus)}`);
+    }
+
+    try {
+      const operations = await queryAllByStatus(
+        getDatabase().container(INBOX_CONTAINER),
+        requestedStatus
+      );
+      const response: InboxListResponse = { operations };
+      return { jsonBody: response };
+    } catch (error) {
+      context.error("Inbox list failed:", error);
+      return { status: 500, jsonBody: { error: "Failed to list inbox" } };
+    }
+  },
+});
+
+app.http("inboxAck", {
+  methods: ["POST"],
+  authLevel: "anonymous",
+  route: "inbox/ack",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const authError = authenticate(request);
+    if (authError) return authError;
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return badRequest("Invalid JSON body");
+    }
+
+    const validation = validateAckBody(body);
+    if (!validation.ok) return validation.error;
+
+    const counts: InboxAckCounts = {
+      updated: 0,
+      unchanged: 0,
+      notFound: 0,
+      invalid: 0,
+    };
+    const failures: string[] = [];
+    const replacements: {
+      operation: InboxOperation;
+      result: InboxAckResult;
+      invalid?: boolean;
+    }[] = [];
+    const container = getDatabase().container(INBOX_CONTAINER);
+
+    // Phase one reads and validates every requested transition. No Cosmos
+    // replacement occurs until all structurally valid transitions are known.
+    for (const result of validation.value.results) {
+      try {
+        const operation = await readItemOrNull<InboxOperation>(
+          container,
+          result.id
+        );
+        if (!operation) {
+          counts.notFound += 1;
+          continue;
+        }
+        if (TERMINAL_STATUSES.has(operation.status)) {
+          counts.unchanged += 1;
+          continue;
+        }
+        const invalidTransition = transitionError(operation, result.status);
+        if (invalidTransition) {
+          // An ack batch arrives AFTER the phone applied these operations
+          // locally. Rejecting the whole request over one bad entry would
+          // leave its batch-mates `pending`, and the next sync would re-serve
+          // and re-apply them — duplicate templates, the exact failure class
+          // this issue exists to remove. Nor can the bad entry stay `pending`:
+          // an illegal transition never becomes legal, so it would be
+          // re-served forever. Force it terminal, with the reason recorded.
+          replacements.push({
+            operation,
+            result: {
+              id: result.id,
+              status: "failed",
+              error: `Invalid transition: ${invalidTransition}`,
+            },
+            invalid: true,
+          });
+          continue;
+        }
+        replacements.push({ operation, result });
+      } catch (error) {
+        failures.push(`read ${result.id}: ${errorMessage(error)}`);
+      }
+    }
+
+    // Phase two applies every valid transition, collecting per-item failures
+    // so one transient Cosmos error does not prevent independent acknowledgements.
+    for (const { operation, result, invalid } of replacements) {
+      const updated = applyAckResult(operation, result);
+      try {
+        await container.item(operation.id, operation.id).replace(updated);
+        if (invalid) counts.invalid += 1;
+        else counts.updated += 1;
+      } catch (error) {
+        failures.push(`replace ${operation.id}: ${errorMessage(error)}`);
+      }
+    }
+
+    if (failures.length > 0) {
+      context.error("Inbox ack incomplete:", failures);
+      return {
+        status: 500,
+        jsonBody: {
+          error: `Inbox ack incomplete: ${failures.length} operation(s) failed`,
+          failures,
+          counts,
+        },
+      };
+    }
+
+    const response: InboxAckResponse = { counts };
+    return { jsonBody: response };
+  },
+});

--- a/infra/functions/src/functions/inbox.ts
+++ b/infra/functions/src/functions/inbox.ts
@@ -10,8 +10,9 @@
  *   Cosmos query pages are consumed to exhaustion.
  *
  * POST /api/inbox/ack
- *   Advances operation statuses. Existing terminal operations are idempotent
- *   no-ops, and unknown ids are counted rather than treated as server errors.
+ *   Advances operation statuses. Retrying the current status is an idempotent
+ *   no-op. Illegal transitions fail nonterminal operations so they cannot loop;
+ *   terminal disagreements remain unchanged. Both are reported per operation.
  */
 
 import {
@@ -24,9 +25,11 @@ import { Container } from "@azure/cosmos";
 import { randomUUID } from "node:crypto";
 import { authenticate } from "../shared/auth";
 import { getDatabase } from "../shared/cosmos";
+import { customExerciseExternalId } from "../shared/customExerciseIdentity";
 import { readItemOrNull } from "../shared/readHelpers";
 import {
   InboxAckCounts,
+  InboxAckOperationResult,
   InboxAckRequest,
   InboxAckResponse,
   InboxAckResult,
@@ -410,10 +413,18 @@ function transitionError(
   operation: InboxOperation,
   nextStatus: InboxAckStatus
 ): string | null {
-  if (TERMINAL_STATUSES.has(operation.status)) return null;
+  const expectedApproval = requiresApproval(operation.op);
+  if (operation.requiresApproval !== expectedApproval) {
+    return `${operation.op} approval flag mismatch: stored ` +
+      `${String(operation.requiresApproval)}, expected ${String(expectedApproval)}`;
+  }
+
+  if (TERMINAL_STATUSES.has(operation.status)) {
+    return `${operation.status} ${operation.op} cannot transition to ${nextStatus}`;
+  }
 
   if (operation.status === "pending") {
-    if (operation.requiresApproval) {
+    if (expectedApproval) {
       return nextStatus === "awaitingApproval" || nextStatus === "failed"
         ? null
         : `${operation.status} ${operation.op} cannot transition to ${nextStatus}`;
@@ -475,11 +486,22 @@ app.http("inboxEnqueue", {
     const validation = validateEnqueueBody(body);
     if (!validation.ok) return validation.error;
 
+    const id = randomUUID();
+    const payload =
+      validation.value.op === "createCustomExercise"
+        ? {
+            ...validation.value.payload,
+            externalId: customExerciseExternalId(
+              validation.value.payload.name,
+              id
+            ),
+          }
+        : validation.value.payload;
     const operation: InboxOperation = {
-      id: randomUUID(),
+      id,
       createdAt: new Date().toISOString(),
       op: validation.value.op,
-      payload: validation.value.payload as InboxOperationPayload,
+      payload: payload as InboxOperationPayload,
       requiresApproval: requiresApproval(validation.value.op),
       status: "pending",
     };
@@ -553,16 +575,25 @@ app.http("inboxAck", {
       invalid: 0,
     };
     const failures: string[] = [];
+    const results: (InboxAckOperationResult | undefined)[] =
+      new Array(validation.value.results.length);
     const replacements: {
       operation: InboxOperation;
-      result: InboxAckResult;
-      invalid?: boolean;
+      requestedResult: InboxAckResult;
+      resultToApply: InboxAckResult;
+      index: number;
+      conflict?: string;
     }[] = [];
     const container = getDatabase().container(INBOX_CONTAINER);
 
     // Phase one reads and validates every requested transition. No Cosmos
     // replacement occurs until all structurally valid transitions are known.
-    for (const result of validation.value.results) {
+    for (
+      let index = 0;
+      index < validation.value.results.length;
+      index += 1
+    ) {
+      const result = validation.value.results[index];
       try {
         const operation = await readItemOrNull<InboxOperation>(
           container,
@@ -570,33 +601,55 @@ app.http("inboxAck", {
         );
         if (!operation) {
           counts.notFound += 1;
+          results[index] = {
+            id: result.id,
+            requestedStatus: result.status,
+            outcome: "notFound",
+          };
           continue;
         }
-        if (TERMINAL_STATUSES.has(operation.status)) {
+        if (operation.status === result.status) {
           counts.unchanged += 1;
+          results[index] = {
+            id: result.id,
+            requestedStatus: result.status,
+            resultingStatus: operation.status,
+            outcome: "unchanged",
+          };
           continue;
         }
         const invalidTransition = transitionError(operation, result.status);
         if (invalidTransition) {
-          // An ack batch arrives AFTER the phone applied these operations
-          // locally. Rejecting the whole request over one bad entry would
-          // leave its batch-mates `pending`, and the next sync would re-serve
-          // and re-apply them — duplicate templates, the exact failure class
-          // this issue exists to remove. Nor can the bad entry stay `pending`:
-          // an illegal transition never becomes legal, so it would be
-          // re-served forever. Force it terminal, with the reason recorded.
-          replacements.push({
-            operation,
-            result: {
+          counts.invalid += 1;
+          if (TERMINAL_STATUSES.has(operation.status)) {
+            results[index] = {
               id: result.id,
-              status: "failed",
-              error: `Invalid transition: ${invalidTransition}`,
-            },
-            invalid: true,
-          });
+              requestedStatus: result.status,
+              resultingStatus: operation.status,
+              outcome: "conflict",
+              conflict: invalidTransition,
+            };
+          } else {
+            replacements.push({
+              operation,
+              requestedResult: result,
+              resultToApply: {
+                id: result.id,
+                status: "failed",
+                error: `Invalid transition: ${invalidTransition}`,
+              },
+              index,
+              conflict: invalidTransition,
+            });
+          }
           continue;
         }
-        replacements.push({ operation, result });
+        replacements.push({
+          operation,
+          requestedResult: result,
+          resultToApply: result,
+          index,
+        });
       } catch (error) {
         failures.push(`read ${result.id}: ${errorMessage(error)}`);
       }
@@ -604,12 +657,35 @@ app.http("inboxAck", {
 
     // Phase two applies every valid transition, collecting per-item failures
     // so one transient Cosmos error does not prevent independent acknowledgements.
-    for (const { operation, result, invalid } of replacements) {
-      const updated = applyAckResult(operation, result);
+    for (
+      const {
+        operation,
+        requestedResult,
+        resultToApply,
+        index,
+        conflict,
+      } of replacements
+    ) {
+      const updated = applyAckResult(operation, resultToApply);
       try {
         await container.item(operation.id, operation.id).replace(updated);
-        if (invalid) counts.invalid += 1;
-        else counts.updated += 1;
+        if (conflict) {
+          results[index] = {
+            id: requestedResult.id,
+            requestedStatus: requestedResult.status,
+            resultingStatus: updated.status,
+            outcome: "conflict",
+            conflict,
+          };
+        } else {
+          counts.updated += 1;
+          results[index] = {
+            id: requestedResult.id,
+            requestedStatus: requestedResult.status,
+            resultingStatus: updated.status,
+            outcome: "updated",
+          };
+        }
       } catch (error) {
         failures.push(`replace ${operation.id}: ${errorMessage(error)}`);
       }
@@ -623,11 +699,20 @@ app.http("inboxAck", {
           error: `Inbox ack incomplete: ${failures.length} operation(s) failed`,
           failures,
           counts,
+          results: results.filter(
+            (result): result is InboxAckOperationResult =>
+              result !== undefined
+          ),
         },
       };
     }
 
-    const response: InboxAckResponse = { counts };
+    const response: InboxAckResponse = {
+      counts,
+      results: results.filter(
+        (result): result is InboxAckOperationResult => result !== undefined
+      ),
+    };
     return { jsonBody: response };
   },
 });

--- a/infra/functions/src/shared/customExerciseIdentity.ts
+++ b/infra/functions/src/shared/customExerciseIdentity.ts
@@ -1,0 +1,42 @@
+export const MAX_CUSTOM_EXERCISE_SLUG_LENGTH = 64;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidCustomExerciseExternalId(
+  externalId: string,
+  operationId?: string
+): boolean {
+  const parts = externalId.split(":");
+  if (parts.length !== 3 || parts[0] !== "custom") return false;
+  const [, slug, suffix] = parts;
+  if (
+    slug.length === 0 ||
+    slug.length > MAX_CUSTOM_EXERCISE_SLUG_LENGTH ||
+    !SLUG_PATTERN.test(slug) ||
+    !UUID_PATTERN.test(suffix)
+  ) {
+    return false;
+  }
+  return operationId === undefined ||
+    suffix.toLowerCase() === operationId.toLowerCase();
+}
+
+export function customExerciseExternalId(
+  name: string,
+  operationId: string
+): string {
+  const normalized =
+    name
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .toLowerCase() || "exercise";
+  const slug =
+    normalized
+      .slice(0, MAX_CUSTOM_EXERCISE_SLUG_LENGTH)
+      .replace(/-+$/g, "") || "exercise";
+  return `custom:${slug}:${operationId.toLowerCase()}`;
+}

--- a/infra/functions/src/shared/types.ts
+++ b/infra/functions/src/shared/types.ts
@@ -138,6 +138,8 @@ export interface DeleteTemplatePayload {
 
 export interface CreateCustomExercisePayload {
   name: string;
+  /** Server-generated from name + operation id; ignored on enqueue input. */
+  externalId?: string;
   equipment?: string;
   primaryMuscles?: string[];
   secondaryMuscles?: string[];
@@ -190,12 +192,27 @@ export interface InboxAckCounts {
   updated: number;
   unchanged: number;
   notFound: number;
-  /** Illegal transitions, forced to `failed` so they are never re-served. */
+  /** Invalid/conflicting transitions; nonterminal operations are failed. */
   invalid: number;
+}
+
+export type InboxAckOutcome =
+  | "updated"
+  | "unchanged"
+  | "notFound"
+  | "conflict";
+
+export interface InboxAckOperationResult {
+  id: string;
+  requestedStatus: InboxAckStatus;
+  resultingStatus?: InboxOperationStatus;
+  outcome: InboxAckOutcome;
+  conflict?: string;
 }
 
 export interface InboxAckResponse {
   counts: InboxAckCounts;
+  results: InboxAckOperationResult[];
 }
 
 export interface SasRequest {

--- a/infra/functions/src/shared/types.ts
+++ b/infra/functions/src/shared/types.ts
@@ -91,6 +91,113 @@ export interface SyncMetaDoc {
   serverTime: string;
 }
 
+// ─── MCP write inbox (issue #88) ────────────────────────────────────────────
+// Durable operations fetched and applied by the phone. This collection is
+// deliberately separate from snapshot reconciliation.
+
+export type InboxOperationType =
+  | "createTemplate"
+  | "updateTemplate"
+  | "deleteTemplate"
+  | "createCustomExercise";
+
+export type InboxOperationStatus =
+  | "pending"
+  | "awaitingApproval"
+  | "applied"
+  | "rejected"
+  | "failed";
+
+export interface InboxTemplateExercisePayload {
+  externalId: string;
+  order: number;
+  defaultSets: number;
+  defaultReps: number;
+  defaultWeight?: number;
+  defaultRestSeconds?: number;
+  notes?: string;
+}
+
+export interface CreateTemplatePayload {
+  name: string;
+  notes?: string;
+  exercises: InboxTemplateExercisePayload[];
+}
+
+export interface UpdateTemplatePayload {
+  id: string;
+  name?: string;
+  notes?: string;
+  exercises?: InboxTemplateExercisePayload[];
+}
+
+export interface DeleteTemplatePayload {
+  id: string;
+  name: string;
+}
+
+export interface CreateCustomExercisePayload {
+  name: string;
+  equipment?: string;
+  primaryMuscles?: string[];
+  secondaryMuscles?: string[];
+  instructions?: string[];
+  notes?: string;
+}
+
+export type InboxOperationPayload =
+  | CreateTemplatePayload
+  | UpdateTemplatePayload
+  | DeleteTemplatePayload
+  | CreateCustomExercisePayload;
+
+export interface InboxOperation {
+  id: string;
+  createdAt: string;
+  op: InboxOperationType;
+  payload: InboxOperationPayload;
+  requiresApproval: boolean;
+  status: InboxOperationStatus;
+  appliedAt?: string;
+  error?: string;
+}
+
+export type InboxEnqueueRequest =
+  | { op: "createTemplate"; payload: CreateTemplatePayload }
+  | { op: "updateTemplate"; payload: UpdateTemplatePayload }
+  | { op: "deleteTemplate"; payload: DeleteTemplatePayload }
+  | { op: "createCustomExercise"; payload: CreateCustomExercisePayload };
+
+export type InboxEnqueueResponse = InboxOperation;
+
+export interface InboxListResponse {
+  operations: InboxOperation[];
+}
+
+export type InboxAckStatus = Exclude<InboxOperationStatus, "pending">;
+
+export interface InboxAckResult {
+  id: string;
+  status: InboxAckStatus;
+  error?: string;
+}
+
+export interface InboxAckRequest {
+  results: InboxAckResult[];
+}
+
+export interface InboxAckCounts {
+  updated: number;
+  unchanged: number;
+  notFound: number;
+  /** Illegal transitions, forced to `failed` so they are never re-served. */
+  invalid: number;
+}
+
+export interface InboxAckResponse {
+  counts: InboxAckCounts;
+}
+
 export interface SasRequest {
   path: string;
   mode: "upload" | "download";

--- a/infra/functions/tests/inbox.test.ts
+++ b/infra/functions/tests/inbox.test.ts
@@ -8,6 +8,10 @@
 
 import { app, HttpRequest, InvocationContext } from "@azure/functions";
 import { authenticate } from "../src/shared/auth";
+import {
+  MAX_CUSTOM_EXERCISE_SLUG_LENGTH,
+  isValidCustomExerciseExternalId,
+} from "../src/shared/customExerciseIdentity";
 import { mockDatabase } from "./__mocks__/cosmos";
 
 // Keep the RED phase runnable before the implementation module exists. Once
@@ -244,13 +248,20 @@ describe("POST /api/inbox — enqueue", () => {
 
     expect(isOk(response.status)).toBe(true);
     const operation = response.jsonBody as Doc;
+    const expectedPayload =
+      op === "createCustomExercise"
+        ? {
+            ...payload,
+            externalId: `custom:cable-katana-extension:${operation["id"]}`,
+          }
+        : payload;
     expect(operation).toEqual({
       id: expect.stringMatching(
         /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
       ),
       createdAt: expect.any(String),
       op,
-      payload,
+      payload: expectedPayload,
       requiresApproval,
       status: "pending",
     });
@@ -258,6 +269,62 @@ describe("POST /api/inbox — enqueue", () => {
     expect(inbox.create).toHaveBeenCalledTimes(1);
     expect(inbox.create).toHaveBeenCalledWith(operation);
   });
+
+  test("custom external ids pin slugging and disambiguate identical slugs", async () => {
+    const first = (await enqueue({
+      op: "createCustomExercise",
+      payload: { name: "Déjà Vu Row" },
+    })).jsonBody as Doc;
+    const second = (await enqueue({
+      op: "createCustomExercise",
+      payload: { name: "Deja--Vu Row" },
+    })).jsonBody as Doc;
+
+    expect((first["payload"] as Doc)["externalId"]).toBe(
+      `custom:deja-vu-row:${first["id"]}`
+    );
+    expect((second["payload"] as Doc)["externalId"]).toBe(
+      `custom:deja-vu-row:${second["id"]}`
+    );
+    expect((first["payload"] as Doc)["externalId"]).not.toBe(
+      (second["payload"] as Doc)["externalId"]
+    );
+  });
+
+  test("custom external ids bound long generated slugs", async () => {
+    const operation = (await enqueue({
+      op: "createCustomExercise",
+      payload: {
+        name: String("Very Long Exercise ").repeat(12),
+      },
+    })).jsonBody as Doc;
+    const externalId = (operation["payload"] as Doc)["externalId"] as string;
+    const slug = externalId.split(":")[1];
+
+    expect(slug).toHaveLength(MAX_CUSTOM_EXERCISE_SLUG_LENGTH);
+    expect(
+      isValidCustomExerciseExternalId(externalId, operation["id"] as string)
+    ).toBe(true);
+  });
+
+  test.each([
+    ["maximum slug", `custom:${"a".repeat(64)}:10000000-0000-4000-8000-000000000001`, true],
+    ["bare prefix", "custom:", false],
+    ["missing UUID", "custom:row", false],
+    ["invalid slug", "custom:Bad_Slug:10000000-0000-4000-8000-000000000001", false],
+    ["overlong slug", `custom:${"a".repeat(65)}:10000000-0000-4000-8000-000000000001`, false],
+    ["wrong operation UUID", "custom:row:00000000-0000-4000-8000-000000000000", false],
+  ])(
+    "validates the shared custom externalId grammar: %s",
+    (_label, externalId, expected) => {
+      expect(
+        isValidCustomExerciseExternalId(
+          externalId as string,
+          "10000000-0000-4000-8000-000000000001"
+        )
+      ).toBe(expected);
+    }
+  );
 
   test("ignores a client-supplied operation id and assigns a server UUID", async () => {
     const response = await enqueue({
@@ -431,6 +498,14 @@ describe("POST /api/inbox/ack", () => {
     expect(isOk(response.status)).toBe(true);
     expect(response.jsonBody).toEqual({
       counts: { updated: 1, unchanged: 0, notFound: 0, invalid: 0 },
+      results: [
+        {
+          id: "operation-1",
+          requestedStatus: "applied",
+          resultingStatus: "applied",
+          outcome: "updated",
+        },
+      ],
     });
     const stored = inbox.docs.get("operation-1");
     expect(stored?.["status"]).toBe("applied");
@@ -466,7 +541,7 @@ describe("POST /api/inbox/ack", () => {
   });
 
   test.each(["applied", "rejected", "failed"])(
-    "acking a terminal %s operation is a no-op success",
+    "retrying terminal status %s is a no-op success",
     async (status) => {
       inbox.seed(
         pendingOperation({
@@ -479,12 +554,20 @@ describe("POST /api/inbox/ack", () => {
 
       const before = { ...inbox.docs.get("operation-1") };
       const response = await ack({
-        results: [{ id: "operation-1", status: "applied" }],
+        results: [{ id: "operation-1", status }],
       });
 
       expect(isOk(response.status)).toBe(true);
       expect(response.jsonBody).toEqual({
         counts: { updated: 0, unchanged: 1, notFound: 0, invalid: 0 },
+        results: [
+          {
+            id: "operation-1",
+            requestedStatus: status,
+            resultingStatus: status,
+            outcome: "unchanged",
+          },
+        ],
       });
       expect(inbox.docs.get("operation-1")).toEqual(before);
       expect(inbox.replace).not.toHaveBeenCalled();
@@ -499,6 +582,13 @@ describe("POST /api/inbox/ack", () => {
     expect(isOk(response.status)).toBe(true);
     expect(response.jsonBody).toEqual({
       counts: { updated: 0, unchanged: 0, notFound: 1, invalid: 0 },
+      results: [
+        {
+          id: "missing-operation",
+          requestedStatus: "applied",
+          outcome: "notFound",
+        },
+      ],
     });
     expect(inbox.replace).not.toHaveBeenCalled();
   });
@@ -533,14 +623,41 @@ describe("POST /api/inbox/ack", () => {
     expect(inbox.replace).not.toHaveBeenCalled();
     expect(inbox.docs.get("operation-1")?.["status"]).toBe("pending");
   });
+
+  test("retrying the status an operation is already in is an idempotent no-op", async () => {
+    inbox.seed(
+      pendingOperation({
+        op: "updateTemplate",
+        requiresApproval: true,
+        status: "awaitingApproval",
+      })
+    );
+
+    const before = { ...inbox.docs.get("operation-1") };
+    const response = await ack({
+      results: [{ id: "operation-1", status: "awaitingApproval" }],
+    });
+
+    expect(response.status ?? 200).toBe(200);
+    expect(response.jsonBody).toEqual({
+      counts: { updated: 0, unchanged: 1, notFound: 0, invalid: 0 },
+      results: [
+        {
+          id: "operation-1",
+          requestedStatus: "awaitingApproval",
+          resultingStatus: "awaitingApproval",
+          outcome: "unchanged",
+        },
+      ],
+    });
+    expect(inbox.docs.get("operation-1")).toEqual(before);
+    expect(inbox.replace).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/inbox/ack — an illegal transition must not poison the batch", () => {
-  // An ack batch is sent AFTER the phone has already applied the operations
-  // locally. If one bad entry 400s the whole request, the good entries stay
-  // `pending`, get re-served on the next sync, and the phone creates duplicate
-  // templates. An illegal transition must therefore be recorded as a terminal
-  // failure, never allowed to discard its batch-mates or to be re-served.
+  // A nonterminal poison pill must become terminal while valid batch-mates
+  // still advance. Terminal disagreements remain untouched.
   test("valid acks in the same batch still apply", async () => {
     inbox.seed(
       pendingOperation({ id: "good", op: "createTemplate", requiresApproval: false }),
@@ -557,21 +674,161 @@ describe("POST /api/inbox/ack — an illegal transition must not poison the batc
 
     expect(response.status ?? 200).toBe(200);
     expect(inbox.docs.get("good")?.["status"]).toBe("applied");
+    expect(response.jsonBody).toEqual({
+      counts: { updated: 1, unchanged: 0, notFound: 0, invalid: 1 },
+      results: [
+        {
+          id: "good",
+          requestedStatus: "applied",
+          resultingStatus: "applied",
+          outcome: "updated",
+        },
+        {
+          id: "bad",
+          requestedStatus: "applied",
+          resultingStatus: "failed",
+          outcome: "conflict",
+          conflict:
+            "pending deleteTemplate cannot transition to applied",
+        },
+      ],
+    });
   });
 
-  test("the illegal entry becomes terminally failed, not re-served", async () => {
+  test("the illegal nonterminal entry fails terminally and is not re-served", async () => {
     inbox.seed(
       pendingOperation({ id: "bad", op: "deleteTemplate", requiresApproval: true })
     );
 
-    await ack({ results: [{ id: "bad", status: "applied" }] });
+    const response = await ack({
+      results: [{ id: "bad", status: "applied" }],
+    });
 
-    const stored = inbox.docs.get("bad");
-    expect(stored?.["status"]).toBe("failed");
-    expect(String(stored?.["error"])).toMatch(/transition/i);
-
-    // Re-served only if still pending — a poison pill would loop forever.
+    expect(inbox.docs.get("bad")).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error:
+          "Invalid transition: pending deleteTemplate cannot transition to applied",
+      })
+    );
+    expect(response.jsonBody).toEqual({
+      counts: { updated: 0, unchanged: 0, notFound: 0, invalid: 1 },
+      results: [
+        {
+          id: "bad",
+          requestedStatus: "applied",
+          resultingStatus: "failed",
+          outcome: "conflict",
+          conflict:
+            "pending deleteTemplate cannot transition to applied",
+        },
+      ],
+    });
     const listed = await list("pending");
     expect((listed.jsonBody as { operations: unknown[] }).operations).toHaveLength(0);
+  });
+
+  test("a terminal operation receiving a different status stays unchanged", async () => {
+    inbox.seed(
+      pendingOperation({
+        id: "terminal",
+        op: "updateTemplate",
+        requiresApproval: true,
+        status: "applied",
+        appliedAt: "2026-07-27T11:00:00.000Z",
+      })
+    );
+
+    const before = { ...inbox.docs.get("terminal") };
+    const response = await ack({
+      results: [{ id: "terminal", status: "failed", error: "stale client" }],
+    });
+
+    expect(inbox.docs.get("terminal")).toEqual(before);
+    expect(inbox.replace).not.toHaveBeenCalled();
+    expect(response.jsonBody).toEqual({
+      counts: { updated: 0, unchanged: 0, notFound: 0, invalid: 1 },
+      results: [
+        {
+          id: "terminal",
+          requestedStatus: "failed",
+          resultingStatus: "applied",
+          outcome: "conflict",
+          conflict: "applied updateTemplate cannot transition to failed",
+        },
+      ],
+    });
+  });
+
+  test.each([
+    ["updateTemplate", false, "applied", true],
+    ["deleteTemplate", false, "applied", true],
+    ["createTemplate", true, "awaitingApproval", false],
+    ["createCustomExercise", true, "awaitingApproval", false],
+  ])(
+    "derives approval for %s and terminally fails stored flag %p",
+    async (op, storedFlag, requestedStatus, expectedFlag) => {
+      inbox.seed(
+        pendingOperation({
+          id: "mismatched-approval",
+          op,
+          requiresApproval: storedFlag,
+        })
+      );
+
+      const response = await ack({
+        results: [
+          { id: "mismatched-approval", status: requestedStatus },
+        ],
+      });
+
+      expect(inbox.docs.get("mismatched-approval")).toEqual(
+        expect.objectContaining({
+          status: "failed",
+          error:
+            `Invalid transition: ${op} approval flag mismatch: ` +
+            `stored ${String(storedFlag)}, expected ${String(expectedFlag)}`,
+        })
+      );
+      expect(response.jsonBody).toEqual({
+        counts: { updated: 0, unchanged: 0, notFound: 0, invalid: 1 },
+        results: [
+          {
+            id: "mismatched-approval",
+            requestedStatus,
+            resultingStatus: "failed",
+            outcome: "conflict",
+            conflict:
+              `${op} approval flag mismatch: stored ${String(storedFlag)}, ` +
+              `expected ${String(expectedFlag)}`,
+          },
+        ],
+      });
+    }
+  );
+
+  test("the correct pending-awaitingApproval-applied sequence never stores failed", async () => {
+    inbox.seed(
+      pendingOperation({
+        id: "correct-sequence",
+        op: "updateTemplate",
+        requiresApproval: true,
+      })
+    );
+
+    const awaiting = await ack({
+      results: [{ id: "correct-sequence", status: "awaitingApproval" }],
+    });
+    const applied = await ack({
+      results: [{ id: "correct-sequence", status: "applied" }],
+    });
+
+    expect(inbox.docs.get("correct-sequence")?.["status"]).toBe("applied");
+    expect(
+      inbox.replace.mock.calls.map(([, document]) => document["status"])
+    ).toEqual(["awaitingApproval", "applied"]);
+    expect(JSON.stringify([awaiting.jsonBody, applied.jsonBody])).not.toContain(
+      '"failed"'
+    );
   });
 });

--- a/infra/functions/tests/inbox.test.ts
+++ b/infra/functions/tests/inbox.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Tests for the durable MCP write inbox — issue #88.
+ *
+ * POST /api/inbox     — validate and enqueue one server-owned operation
+ * GET  /api/inbox     — list every operation for one status, oldest first
+ * POST /api/inbox/ack — advance operation statuses idempotently
+ */
+
+import { app, HttpRequest, InvocationContext } from "@azure/functions";
+import { authenticate } from "../src/shared/auth";
+import { mockDatabase } from "./__mocks__/cosmos";
+
+// Keep the RED phase runnable before the implementation module exists. Once
+// inbox.ts is added, requiring it registers the three handlers under test.
+try {
+  require("../src/functions/inbox");
+} catch (error) {
+  const missingInboxModule =
+    (error as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND" &&
+    String((error as Error).message).includes("../src/functions/inbox");
+  if (!missingInboxModule) throw error;
+}
+
+const mockApp = app as unknown as { http: jest.Mock };
+const mockAuthenticate = authenticate as jest.Mock;
+
+type Doc = Record<string, unknown>;
+type Handler = (
+  req: unknown,
+  ctx: InvocationContext
+) => Promise<{ status?: number; jsonBody?: unknown }>;
+
+function findHandler(name: string): Handler {
+  const call = mockApp.http.mock.calls.find(([n]: [string]) => n === name);
+  if (!call) throw new Error(`${name} handler was not registered with app.http()`);
+  return call[1].handler;
+}
+
+function findRegistration(name: string): Record<string, unknown> {
+  const call = mockApp.http.mock.calls.find(([n]: [string]) => n === name);
+  if (!call) throw new Error(`${name} was not registered with app.http()`);
+  return call[1];
+}
+
+function makeRequest(
+  body?: unknown,
+  options?: { query?: Record<string, string>; authenticated?: boolean }
+) {
+  const headers =
+    options?.authenticated === false ? {} : { "x-api-key": "test-key" };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new (HttpRequest as any)(body, headers, { query: options?.query });
+}
+
+function isOk(status?: number): boolean {
+  return status === undefined || status === 200;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const pages: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    pages.push(items.slice(index, index + size));
+  }
+  return pages;
+}
+
+class FakeInboxContainer {
+  docs = new Map<string, Doc>();
+  pageSize = 2;
+
+  readonly create = jest.fn(async (doc: Doc) => {
+    this.docs.set(doc["id"] as string, { ...doc });
+    return { resource: doc };
+  });
+
+  readonly query = jest.fn(
+    (
+      querySpec: {
+        query: string;
+        parameters?: { name: string; value: unknown }[];
+      },
+      _options?: { maxItemCount?: number }
+    ) => {
+      const status = querySpec.parameters?.find(
+        (parameter) => parameter.name === "@status"
+      )?.value;
+      const resources = [...this.docs.values()]
+        .filter((doc) => status === undefined || doc["status"] === status)
+        .sort((left, right) =>
+          String(left["createdAt"]).localeCompare(String(right["createdAt"]))
+        );
+      const pages = chunk(resources, this.pageSize);
+      let page = 0;
+      return {
+        hasMoreResults: () => page < pages.length,
+        fetchNext: async () => ({ resources: pages[page++] ?? [] }),
+      };
+    }
+  );
+
+  readonly read = jest.fn(async (id: string) => ({
+    resource: this.docs.get(id),
+  }));
+
+  readonly replace = jest.fn(async (id: string, doc: Doc) => {
+    this.docs.set(id, { ...doc });
+    return { resource: doc };
+  });
+
+  readonly items = { create: this.create, query: this.query };
+
+  readonly item = jest.fn((id: string, _partitionKey: string) => ({
+    read: () => this.read(id),
+    replace: (doc: Doc) => this.replace(id, doc),
+  }));
+
+  seed(...docs: Doc[]) {
+    for (const doc of docs) this.docs.set(doc["id"] as string, { ...doc });
+  }
+}
+
+let inbox: FakeInboxContainer;
+
+beforeEach(() => {
+  inbox = new FakeInboxContainer();
+  mockDatabase.container.mockReset();
+  mockDatabase.container.mockImplementation((name: string) => {
+    if (name !== "inbox") throw new Error(`Unexpected container: ${name}`);
+    return inbox;
+  });
+  mockAuthenticate.mockReturnValue(null);
+});
+
+async function enqueue(body: unknown) {
+  return findHandler("inboxEnqueue")(makeRequest(body), new InvocationContext());
+}
+
+async function list(status?: string) {
+  return findHandler("inboxList")(
+    makeRequest(undefined, { query: status === undefined ? undefined : { status } }),
+    new InvocationContext()
+  );
+}
+
+async function ack(body: unknown) {
+  return findHandler("inboxAck")(makeRequest(body), new InvocationContext());
+}
+
+const templateExercise = {
+  externalId: "Barbell_Bench_Press_-_Medium_Grip",
+  order: 0,
+  defaultSets: 3,
+  defaultReps: 8,
+  defaultWeight: 80,
+  defaultRestSeconds: 120,
+  notes: "Pause on chest",
+};
+
+function pendingOperation(overrides: Doc = {}): Doc {
+  return {
+    id: "operation-1",
+    createdAt: "2026-07-27T10:00:00.000Z",
+    op: "createTemplate",
+    payload: { name: "Push Day", exercises: [templateExercise] },
+    requiresApproval: false,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("registration", () => {
+  test("POST enqueue registers on inbox", () => {
+    const registration = findRegistration("inboxEnqueue");
+    expect(registration.methods).toEqual(["POST"]);
+    expect(registration.route).toBe("inbox");
+  });
+
+  test("GET list registers on inbox", () => {
+    const registration = findRegistration("inboxList");
+    expect(registration.methods).toEqual(["GET"]);
+    expect(registration.route).toBe("inbox");
+  });
+
+  test("POST ack registers on inbox/ack", () => {
+    const registration = findRegistration("inboxAck");
+    expect(registration.methods).toEqual(["POST"]);
+    expect(registration.route).toBe("inbox/ack");
+  });
+});
+
+describe("authentication", () => {
+  test.each([
+    ["enqueue", "inboxEnqueue", { op: "deleteTemplate", payload: { id: "t1", name: "Push" } }],
+    ["list", "inboxList", undefined],
+    ["ack", "inboxAck", { results: [] }],
+  ])("%s rejects missing or invalid auth before touching Cosmos", async (_label, name, body) => {
+    mockAuthenticate.mockReturnValue({
+      status: 401,
+      jsonBody: { error: "Unauthorized" },
+    });
+
+    const response = await findHandler(name)(makeRequest(body), new InvocationContext());
+
+    expect(response.status).toBe(401);
+    expect(mockDatabase.container).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/inbox — enqueue", () => {
+  test.each([
+    [
+      "createTemplate",
+      {
+        name: "Push Day",
+        notes: "Heavy",
+        exercises: [templateExercise],
+      },
+      false,
+    ],
+    [
+      "updateTemplate",
+      {
+        id: "template-1",
+        name: "Push Day v2",
+        exercises: [{ ...templateExercise, order: 1 }],
+      },
+      true,
+    ],
+    ["deleteTemplate", { id: "template-1", name: "Push Day" }, true],
+    [
+      "createCustomExercise",
+      {
+        name: "Cable Katana Extension",
+        equipment: "cable",
+        primaryMuscles: ["triceps"],
+        secondaryMuscles: ["shoulders"],
+        instructions: ["Set the pulley low", "Extend overhead"],
+        notes: "Keep elbow still",
+      },
+      false,
+    ],
+  ])("enqueues a valid %s operation", async (op, payload, requiresApproval) => {
+    const response = await enqueue({ op, payload });
+
+    expect(isOk(response.status)).toBe(true);
+    const operation = response.jsonBody as Doc;
+    expect(operation).toEqual({
+      id: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      ),
+      createdAt: expect.any(String),
+      op,
+      payload,
+      requiresApproval,
+      status: "pending",
+    });
+    expect(Number.isNaN(Date.parse(operation["createdAt"] as string))).toBe(false);
+    expect(inbox.create).toHaveBeenCalledTimes(1);
+    expect(inbox.create).toHaveBeenCalledWith(operation);
+  });
+
+  test("ignores a client-supplied operation id and assigns a server UUID", async () => {
+    const response = await enqueue({
+      id: "client-controlled-id",
+      op: "createCustomExercise",
+      payload: { name: "My Exercise" },
+    });
+
+    const operation = response.jsonBody as Doc;
+    expect(operation["id"]).not.toBe("client-controlled-id");
+    expect(operation["id"]).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/i));
+    expect(inbox.docs.has("client-controlled-id")).toBe(false);
+  });
+
+  test("computes requiresApproval server-side so deleteTemplate cannot spoof it", async () => {
+    const response = await enqueue({
+      op: "deleteTemplate",
+      payload: { id: "template-1", name: "Push Day" },
+      requiresApproval: false,
+    });
+
+    const operation = response.jsonBody as Doc;
+    expect(operation["requiresApproval"]).toBe(true);
+    expect(inbox.docs.get(operation["id"] as string)?.["requiresApproval"]).toBe(true);
+  });
+
+  test("rejects an unknown op before writing", async () => {
+    const response = await enqueue({ op: "renameEverything", payload: {} });
+
+    expect(response.status).toBe(400);
+    expect(inbox.create).not.toHaveBeenCalled();
+  });
+
+  test.each([undefined, "", "   "])(
+    "rejects missing or empty externalId (%p) before writing",
+    async (externalId) => {
+      const exercise = { ...templateExercise, externalId };
+      const response = await enqueue({
+        op: "createTemplate",
+        payload: { name: "Push Day", exercises: [exercise] },
+      });
+
+      expect(response.status).toBe(400);
+      expect(inbox.create).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each([
+    ["defaultSets", 0],
+    ["defaultSets", -1],
+    ["defaultSets", 1.5],
+    ["defaultReps", 0],
+    ["defaultReps", -1],
+    ["defaultReps", 2.5],
+  ])("rejects invalid %s=%p before writing", async (field, value) => {
+    const response = await enqueue({
+      op: "createTemplate",
+      payload: {
+        name: "Push Day",
+        exercises: [{ ...templateExercise, [field]: value }],
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(inbox.create).not.toHaveBeenCalled();
+  });
+
+  test("rejects duplicate exercise order values within one template before writing", async () => {
+    const response = await enqueue({
+      op: "updateTemplate",
+      payload: {
+        id: "template-1",
+        exercises: [
+          templateExercise,
+          { ...templateExercise, externalId: "Incline_Dumbbell_Press", order: 0 },
+        ],
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(inbox.create).not.toHaveBeenCalled();
+  });
+
+  test("rejects invalid JSON before writing", async () => {
+    const request = makeRequest();
+    request.json = async () => {
+      throw new Error("bad json");
+    };
+
+    const response = await findHandler("inboxEnqueue")(
+      request,
+      new InvocationContext()
+    );
+
+    expect(response.status).toBe(400);
+    expect(inbox.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/inbox — list", () => {
+  beforeEach(() => {
+    inbox.seed(
+      pendingOperation({
+        id: "pending-newest",
+        createdAt: "2026-07-27T12:00:00.000Z",
+      }),
+      pendingOperation({
+        id: "applied",
+        createdAt: "2026-07-27T08:00:00.000Z",
+        status: "applied",
+        appliedAt: "2026-07-27T08:01:00.000Z",
+      }),
+      pendingOperation({
+        id: "pending-oldest",
+        createdAt: "2026-07-27T09:00:00.000Z",
+      }),
+      pendingOperation({
+        id: "pending-middle",
+        createdAt: "2026-07-27T10:00:00.000Z",
+      }),
+      pendingOperation({
+        id: "failed",
+        createdAt: "2026-07-27T11:00:00.000Z",
+        status: "failed",
+        error: "Unknown exercise",
+      })
+    );
+  });
+
+  test("defaults status to pending, returns oldest-first, and exhausts query pages", async () => {
+    inbox.pageSize = 1;
+
+    const response = await list();
+
+    expect(isOk(response.status)).toBe(true);
+    const body = response.jsonBody as { operations: Doc[] };
+    expect(body.operations.map((operation) => operation["id"])).toEqual([
+      "pending-oldest",
+      "pending-middle",
+      "pending-newest",
+    ]);
+    const [querySpec, options] = inbox.query.mock.calls[0];
+    expect(querySpec.query).toMatch(/WHERE\s+c\.status\s*=\s*@status/i);
+    expect(querySpec.query).toMatch(/ORDER\s+BY\s+c\.createdAt\s+ASC/i);
+    expect(options?.maxItemCount).toBeGreaterThan(0);
+  });
+
+  test("filters by an explicit status", async () => {
+    const response = await list("failed");
+
+    const body = response.jsonBody as { operations: Doc[] };
+    expect(body.operations.map((operation) => operation["id"])).toEqual(["failed"]);
+  });
+
+  test("rejects an unknown status without querying Cosmos", async () => {
+    const response = await list("banana");
+
+    expect(response.status).toBe(400);
+    expect(inbox.query).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/inbox/ack", () => {
+  test("transitions a pending create operation to applied and stamps appliedAt", async () => {
+    inbox.seed(pendingOperation());
+
+    const response = await ack({
+      results: [{ id: "operation-1", status: "applied" }],
+    });
+
+    expect(isOk(response.status)).toBe(true);
+    expect(response.jsonBody).toEqual({
+      counts: { updated: 1, unchanged: 0, notFound: 0, invalid: 0 },
+    });
+    const stored = inbox.docs.get("operation-1");
+    expect(stored?.["status"]).toBe("applied");
+    expect(Number.isNaN(Date.parse(stored?.["appliedAt"] as string))).toBe(false);
+    expect(inbox.replace).toHaveBeenCalledTimes(1);
+  });
+
+  test("transitions an approval operation pending to awaitingApproval to applied", async () => {
+    inbox.seed(
+      pendingOperation({
+        op: "updateTemplate",
+        payload: { id: "template-1", name: "Updated" },
+        requiresApproval: true,
+      })
+    );
+
+    const awaiting = await ack({
+      results: [{ id: "operation-1", status: "awaitingApproval" }],
+    });
+    expect(isOk(awaiting.status)).toBe(true);
+    expect(inbox.docs.get("operation-1")?.["status"]).toBe("awaitingApproval");
+    expect(inbox.docs.get("operation-1")?.["appliedAt"]).toBeUndefined();
+
+    const applied = await ack({
+      results: [{ id: "operation-1", status: "applied" }],
+    });
+    expect(isOk(applied.status)).toBe(true);
+    expect(inbox.docs.get("operation-1")?.["status"]).toBe("applied");
+    expect(Number.isNaN(Date.parse(
+      inbox.docs.get("operation-1")?.["appliedAt"] as string
+    ))).toBe(false);
+    expect(inbox.replace).toHaveBeenCalledTimes(2);
+  });
+
+  test.each(["applied", "rejected", "failed"])(
+    "acking a terminal %s operation is a no-op success",
+    async (status) => {
+      inbox.seed(
+        pendingOperation({
+          status,
+          appliedAt:
+            status === "applied" ? "2026-07-27T11:00:00.000Z" : undefined,
+          error: status === "failed" ? "Already failed" : undefined,
+        })
+      );
+
+      const before = { ...inbox.docs.get("operation-1") };
+      const response = await ack({
+        results: [{ id: "operation-1", status: "applied" }],
+      });
+
+      expect(isOk(response.status)).toBe(true);
+      expect(response.jsonBody).toEqual({
+        counts: { updated: 0, unchanged: 1, notFound: 0, invalid: 0 },
+      });
+      expect(inbox.docs.get("operation-1")).toEqual(before);
+      expect(inbox.replace).not.toHaveBeenCalled();
+    }
+  );
+
+  test("an unknown id does not 500 or write", async () => {
+    const response = await ack({
+      results: [{ id: "missing-operation", status: "applied" }],
+    });
+
+    expect(isOk(response.status)).toBe(true);
+    expect(response.jsonBody).toEqual({
+      counts: { updated: 0, unchanged: 0, notFound: 1, invalid: 0 },
+    });
+    expect(inbox.replace).not.toHaveBeenCalled();
+  });
+
+  test("a failed ack stores the supplied error", async () => {
+    inbox.seed(pendingOperation());
+
+    const response = await ack({
+      results: [{ id: "operation-1", status: "failed", error: "No such exercise" }],
+    });
+
+    expect(isOk(response.status)).toBe(true);
+    expect(inbox.docs.get("operation-1")).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error: "No such exercise",
+      })
+    );
+  });
+
+  test("validates the complete ack body before rewriting any operation", async () => {
+    inbox.seed(pendingOperation());
+
+    const response = await ack({
+      results: [
+        { id: "operation-1", status: "applied" },
+        { id: "", status: "applied" },
+      ],
+    });
+
+    expect(response.status).toBe(400);
+    expect(inbox.replace).not.toHaveBeenCalled();
+    expect(inbox.docs.get("operation-1")?.["status"]).toBe("pending");
+  });
+});
+
+describe("POST /api/inbox/ack — an illegal transition must not poison the batch", () => {
+  // An ack batch is sent AFTER the phone has already applied the operations
+  // locally. If one bad entry 400s the whole request, the good entries stay
+  // `pending`, get re-served on the next sync, and the phone creates duplicate
+  // templates. An illegal transition must therefore be recorded as a terminal
+  // failure, never allowed to discard its batch-mates or to be re-served.
+  test("valid acks in the same batch still apply", async () => {
+    inbox.seed(
+      pendingOperation({ id: "good", op: "createTemplate", requiresApproval: false }),
+      pendingOperation({ id: "bad", op: "deleteTemplate", requiresApproval: true })
+    );
+
+    const response = await ack({
+      results: [
+        { id: "good", status: "applied" },
+        // Illegal: an approval-required op cannot jump straight to applied.
+        { id: "bad", status: "applied" },
+      ],
+    });
+
+    expect(response.status ?? 200).toBe(200);
+    expect(inbox.docs.get("good")?.["status"]).toBe("applied");
+  });
+
+  test("the illegal entry becomes terminally failed, not re-served", async () => {
+    inbox.seed(
+      pendingOperation({ id: "bad", op: "deleteTemplate", requiresApproval: true })
+    );
+
+    await ack({ results: [{ id: "bad", status: "applied" }] });
+
+    const stored = inbox.docs.get("bad");
+    expect(stored?.["status"]).toBe("failed");
+    expect(String(stored?.["error"])).toMatch(/transition/i);
+
+    // Re-served only if still pending — a poison pill would loop forever.
+    const listed = await list("pending");
+    expect((listed.jsonBody as { operations: unknown[] }).operations).toHaveLength(0);
+  });
+});

--- a/infra/mcp/README.md
+++ b/infra/mcp/README.md
@@ -1,10 +1,9 @@
 # ClaudeLifter Workout MCP Server
 
-Read-only MCP server exposing ClaudeLifter workout data to Claude Code and
-Claude Desktop (claude.ai), using Max-subscription tokens instead of API
-billing.
+MCP server exposing ClaudeLifter workout data and durable inbox writes to
+Claude Code and Claude Desktop.
 
-## Architecture (v2 — issue #79)
+## Architecture
 
 The server is a **thin HTTP client of the Azure Functions API**. It
 authenticates with the same `x-api-key` shared secret the iOS app uses — no
@@ -15,23 +14,18 @@ Claude Code / Claude Desktop
         │ stdio
         ▼
   workout MCP server ──(HTTPS + x-api-key)──▶ Azure Functions API ──▶ Cosmos DB
+          │                                                │
+          └── bundled exercise catalog                     └── inbox → iPhone
 ```
 
 v1 connected to Cosmos DB directly via `DefaultAzureCredential` and failed
 with 403 on every query (no data-plane role assignment was provisioned).
 v2 removes that entire auth path: one auth mechanism, one data-access layer.
 
-## Read-only status
-
-This server is **read-only**. The write tools (`create_template`,
-`update_template`, `delete_template`, `create_program`) are hard-disabled and
-return an explanatory error: the old direct-to-Cosmos write path produced
-templates the iOS app could not resolve (invented `exerciseId`s, DTO drift).
-Writes return once the write path is redesigned — tracked in issue #79.
-
-`search_exercises` is also disabled: the app bundles the exercise library
-locally and never syncs it, so the cloud `exercises` container is empty and
-searches would silently return nothing.
+Read tools query the phone-authoritative cloud mirror. Write tools enqueue
+operations in `/api/inbox`; the iPhone drains and applies that inbox during
+sync. Every template exercise uses a stable `externalId`, validated against a
+slim build-time catalog before any write request is sent.
 
 ## Tools
 
@@ -44,6 +38,13 @@ searches would silently return nothing.
 | `get_exercise_history` | Past sets for one exercise across workouts |
 | `get_stats` | Summary statistics: totals, PRs, workouts/week |
 | `get_calendar` | Per-day workout frequency for a date range |
+| `search_exercises` | Ranked bundled-catalog search merged with synced custom exercises |
+| `create_template` | Validate exercise IDs and enqueue a template |
+| `update_template` | Enqueue a template update for approval |
+| `delete_template` | Enqueue a template deletion for approval |
+| `create_program` | Validate all templates, then enqueue each |
+| `create_custom_exercise` | Enqueue a custom exercise |
+| `list_pending_writes` | List inbox operations by status |
 | `health` | Diagnostic: Functions API connectivity + auth status + base URL |
 
 If something isn't working, call the `health` tool first — it reports whether
@@ -66,7 +67,7 @@ Never commit the API key; keep it in your local MCP config only.
 ```bash
 cd infra/mcp
 npm install
-npm run build   # emits dist/src/server.js
+npm run build   # emits dist/src/server.js and dist/catalog-index.json
 ```
 
 ### Claude Code
@@ -118,8 +119,8 @@ claude mcp add workout \
 
 ## Backing API endpoints
 
-The Functions API endpoints backing these tools (all `GET`, all requiring
-`x-api-key`, all bounded/validated):
+The Functions API endpoints backing these tools all require `x-api-key`
+except health:
 
 | Endpoint | Query params |
 |----------|--------------|
@@ -130,6 +131,8 @@ The Functions API endpoints backing these tools (all `GET`, all requiring
 | `/api/exercises/{exerciseId}/history` | `limit` (default 20, max 100) |
 | `/api/stats` | `startDate`, `endDate` (scan capped at 500 most recent workouts) |
 | `/api/calendar` | `startDate`, `endDate` (both required) |
+| `/api/sync/snapshot` | supplies `snapshot.customExercises` for catalog search |
+| `/api/inbox` | `GET ?status=` lists operations; `POST` enqueues one |
 | `/api/health` | — (anonymous) |
 
 ## Development

--- a/infra/mcp/package-lock.json
+++ b/infra/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claudelifter-mcp",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claudelifter-mcp",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },

--- a/infra/mcp/package.json
+++ b/infra/mcp/package.json
@@ -1,13 +1,14 @@
 {
   "name": "claudelifter-mcp",
   "version": "2.0.0",
-  "description": "Read-only MCP server for ClaudeLifter workout data, routed through the Azure Functions API",
+  "description": "MCP server for ClaudeLifter reads and durable inbox writes through the Azure Functions API",
   "type": "module",
   "main": "dist/src/server.js",
   "scripts": {
-    "build": "tsc",
+    "build": "node scripts/build-catalog.mjs && tsc",
     "watch": "tsc -w",
     "clean": "rm -rf dist",
+    "pretest": "node scripts/build-catalog.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/infra/mcp/scripts/build-catalog.mjs
+++ b/infra/mcp/scripts/build-catalog.mjs
@@ -1,0 +1,42 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sourceUrl = new URL(
+  "../../../ClaudeLifter/Resources/exercises.json",
+  import.meta.url
+);
+const outputUrl = new URL("../dist/catalog-index.json", import.meta.url);
+
+const source = JSON.parse(await readFile(sourceUrl, "utf8"));
+if (!Array.isArray(source)) {
+  throw new Error("Exercise catalog source must be a JSON array");
+}
+
+const index = source.map((exercise, index) => {
+  if (
+    exercise === null ||
+    typeof exercise !== "object" ||
+    typeof exercise.id !== "string" ||
+    exercise.id.length === 0 ||
+    typeof exercise.name !== "string" ||
+    !Array.isArray(exercise.primaryMuscles)
+  ) {
+    throw new Error(`Malformed exercise catalog entry at index ${index}`);
+  }
+
+  return {
+    externalId: exercise.id,
+    name: exercise.name,
+    primaryMuscles: exercise.primaryMuscles,
+    equipment: exercise.equipment ?? null,
+    category: exercise.category ?? null,
+  };
+});
+
+await mkdir(dirname(fileURLToPath(outputUrl)), { recursive: true });
+await writeFile(outputUrl, `${JSON.stringify(index)}\n`, "utf8");
+
+console.log(
+  `Built ${fileURLToPath(outputUrl)} with ${index.length} exercises`
+);

--- a/infra/mcp/src/registry.ts
+++ b/infra/mcp/src/registry.ts
@@ -1,29 +1,52 @@
-/**
- * MCP tool registry — issue #79.
- *
- * Read-only ship: the server exposes 7 read tools + a health diagnostic.
- * All data access goes through the Azure Functions API (shared/http.ts).
- *
- * Write tools (create_template, update_template, delete_template,
- * create_program) are hard-disabled: the old direct-to-Cosmos write path
- * produced templates the iOS app could not resolve (invented exerciseIds,
- * DTO drift). They return a clear error until the write path is redesigned.
- *
- * search_exercises is likewise disabled: the app never syncs the exercise
- * library to the cloud, so the exercises container is empty and searches
- * would silently return nothing.
- */
+/** MCP tool registry. Reads and durable inbox writes use the Functions API. */
 
 import { listTemplates, getTemplate } from "./tools/templates.js";
 import { listWorkouts, getWorkout } from "./tools/workouts.js";
 import { getExerciseHistory } from "./tools/exercises.js";
 import { getStats, getCalendar } from "./tools/stats.js";
 import { health } from "./tools/health.js";
+import { searchExercises } from "./tools/catalog.js";
+import {
+  createCustomExercise,
+  createProgram,
+  createTemplate,
+  deleteTemplate,
+  listPendingWrites,
+  updateTemplate,
+} from "./tools/writes.js";
 
 export interface ToolResult {
   content: { type: "text"; text: string }[];
   isError?: boolean;
 }
+
+const templateExerciseSchema = {
+  type: "object" as const,
+  properties: {
+    externalId: {
+      type: "string",
+      description:
+        "Stable external ID returned by search_exercises; never invent one",
+    },
+    order: { type: "integer", minimum: 0 },
+    defaultSets: { type: "integer", minimum: 1 },
+    defaultReps: { type: "integer", minimum: 1 },
+    defaultWeight: { type: "number" },
+    defaultRestSeconds: { type: "integer", minimum: 0 },
+    notes: { type: "string" },
+  },
+  required: ["externalId", "order", "defaultSets", "defaultReps"],
+};
+
+const createTemplateProperties = {
+  name: { type: "string", description: "Template name" },
+  notes: { type: "string", description: "Optional template notes" },
+  exercises: {
+    type: "array",
+    items: templateExerciseSchema,
+    description: "Ordered exercises using exact externalId values",
+  },
+};
 
 export const TOOLS = [
   {
@@ -119,27 +142,122 @@ export const TOOLS = [
       "configured base URL",
     inputSchema: { type: "object" as const, properties: {} },
   },
+  {
+    name: "search_exercises",
+    description:
+      "Search the bundled exercise catalog and synced custom exercises by name",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: {
+          type: "string",
+          description: "Exercise name or partial name",
+        },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "create_template",
+    description:
+      "Validate exercise externalIds and enqueue a template for the app",
+    inputSchema: {
+      type: "object" as const,
+      properties: createTemplateProperties,
+      required: ["name", "exercises"],
+    },
+  },
+  {
+    name: "update_template",
+    description:
+      "Validate any exercise externalIds and enqueue a template update for approval",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Template UUID" },
+        name: { type: "string" },
+        notes: { type: "string" },
+        exercises: {
+          type: "array",
+          items: templateExerciseSchema,
+          description: "Replacement exercise list",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "delete_template",
+    description: "Enqueue a template deletion for approval",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Template UUID" },
+        name: {
+          type: "string",
+          description: "Template name shown in the approval prompt",
+        },
+      },
+      required: ["id", "name"],
+    },
+  },
+  {
+    name: "create_program",
+    description:
+      "Validate all templates first, then enqueue each template creation",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        templates: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: createTemplateProperties,
+            required: ["name", "exercises"],
+          },
+        },
+      },
+      required: ["templates"],
+    },
+  },
+  {
+    name: "create_custom_exercise",
+    description: "Enqueue creation of a custom exercise on the app",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: { type: "string" },
+        equipment: { type: "string" },
+        primaryMuscles: { type: "array", items: { type: "string" } },
+        secondaryMuscles: { type: "array", items: { type: "string" } },
+        instructions: { type: "array", items: { type: "string" } },
+        notes: { type: "string" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "list_pending_writes",
+    description:
+      "List inbox operations by status, including failures and their errors",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        status: {
+          type: "string",
+          enum: [
+            "pending",
+            "awaitingApproval",
+            "applied",
+            "rejected",
+            "failed",
+          ],
+          description: "Defaults to pending",
+        },
+      },
+    },
+  },
 ];
-
-const DISABLED_WRITE_TOOLS = new Set([
-  "create_template",
-  "update_template",
-  "delete_template",
-  "create_program",
-]);
-
-const WRITE_DISABLED_MESSAGE =
-  "This MCP server is read-only: write tools are disabled until the write " +
-  "path is redesigned (issue #79). The previous direct-to-Cosmos writes " +
-  "produced templates the iOS app could not resolve. Create or edit " +
-  "templates in the ClaudeLifter app instead.";
-
-const SEARCH_UNAVAILABLE_MESSAGE =
-  "search_exercises is unavailable: the exercise library is not synced to " +
-  "the cloud (the app bundles it locally), so the exercises container is " +
-  "empty and searches would return misleading empty results. Browse " +
-  "exercises in the ClaudeLifter app, or use get_exercise_history with a " +
-  "known exerciseId. (issue #79)";
 
 function textResult(value: unknown): ToolResult {
   return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
@@ -180,13 +298,6 @@ export async function handleToolCall(
   name: string,
   args?: Record<string, unknown>
 ): Promise<ToolResult> {
-  if (DISABLED_WRITE_TOOLS.has(name)) {
-    return errorResult(WRITE_DISABLED_MESSAGE);
-  }
-  if (name === "search_exercises") {
-    return errorResult(SEARCH_UNAVAILABLE_MESSAGE);
-  }
-
   try {
     switch (name) {
       case "list_templates":
@@ -240,6 +351,33 @@ export async function handleToolCall(
 
       case "health":
         return textResult(await health());
+
+      case "search_exercises":
+        return textResult(
+          await searchExercises(requireString(args, "query"))
+        );
+
+      case "create_template":
+        return textResult(await createTemplate(args));
+
+      case "update_template":
+        return textResult(await updateTemplate(args));
+
+      case "delete_template":
+        return textResult(await deleteTemplate(args));
+
+      case "create_program":
+        return textResult(await createProgram(args));
+
+      case "create_custom_exercise":
+        return textResult(await createCustomExercise(args));
+
+      case "list_pending_writes":
+        return textResult(
+          await listPendingWrites({
+            status: optionalString(args, "status"),
+          })
+        );
 
       default:
         return errorResult(`Unknown tool: ${name}`);

--- a/infra/mcp/src/server.ts
+++ b/infra/mcp/src/server.ts
@@ -1,10 +1,9 @@
 /**
  * ClaudeLifter workout MCP server — issue #79.
  *
- * v2: read-only, re-routed through the Azure Functions API with the shared
- * x-api-key auth (no more DefaultAzureCredential / Cosmos data-plane access).
- * Tool schemas and dispatch live in registry.ts so they can be unit-tested
- * without a stdio transport.
+ * Reads and durable inbox writes are routed through the Azure Functions API
+ * with shared x-api-key auth. Tool schemas and dispatch live in registry.ts
+ * so they can be unit-tested without a stdio transport.
  *
  * Required environment variables: FUNCTIONS_BASE_URL, FUNCTIONS_API_KEY.
  * See infra/mcp/README.md for Claude Code / Claude Desktop configuration.

--- a/infra/mcp/src/shared/customExerciseIdentity.ts
+++ b/infra/mcp/src/shared/customExerciseIdentity.ts
@@ -1,0 +1,24 @@
+export const MAX_CUSTOM_EXERCISE_SLUG_LENGTH = 64;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidCustomExerciseExternalId(
+  externalId: string,
+  operationId?: string
+): boolean {
+  const parts = externalId.split(":");
+  if (parts.length !== 3 || parts[0] !== "custom") return false;
+  const [, slug, suffix] = parts;
+  if (
+    slug.length === 0 ||
+    slug.length > MAX_CUSTOM_EXERCISE_SLUG_LENGTH ||
+    !SLUG_PATTERN.test(slug) ||
+    !UUID_PATTERN.test(suffix)
+  ) {
+    return false;
+  }
+  return operationId === undefined ||
+    suffix.toLowerCase() === operationId.toLowerCase();
+}

--- a/infra/mcp/src/shared/http.ts
+++ b/infra/mcp/src/shared/http.ts
@@ -84,3 +84,44 @@ export async function apiGet<T = unknown>(
 
   return (await response.json()) as T;
 }
+
+export async function apiPost<T = unknown>(
+  path: string,
+  body: unknown
+): Promise<T> {
+  const { baseUrl, apiKey } = getConfig();
+  const url = new URL(`${baseUrl}/api/${path}`);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Cannot reach Functions API at ${baseUrl}: ${detail}`);
+  }
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      const responseBody = (await response.json()) as { error?: string };
+      detail = responseBody?.error ?? "";
+    } catch {
+      // Non-JSON error body — status alone will have to do.
+    }
+    throw new ApiError(
+      response.status,
+      `Functions API returned ${response.status}` +
+        (detail ? `: ${detail}` : "") +
+        ` (POST /api/${path})`
+    );
+  }
+
+  return (await response.json()) as T;
+}

--- a/infra/mcp/src/tools/catalog.ts
+++ b/infra/mcp/src/tools/catalog.ts
@@ -1,0 +1,235 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { apiGet } from "../shared/http.js";
+
+export interface CatalogExercise {
+  externalId: string;
+  name: string;
+  primaryMuscles: string[];
+  equipment: string | null;
+  category: string | null;
+}
+
+export interface ExerciseSearchResult {
+  externalId: string;
+  name: string;
+  primaryMuscles: string[];
+  equipment: string | null;
+}
+
+interface SnapshotReadResponse {
+  snapshot?: {
+    customExercises?: unknown[];
+  };
+}
+
+let cachedCatalog: CatalogExercise[] | undefined;
+let cachedByExternalId: Map<string, CatalogExercise> | undefined;
+
+function indexPath(): string {
+  const candidates = [
+    // Compiled runtime: dist/src/tools/catalog.js -> dist/catalog-index.json
+    new URL("../../catalog-index.json", import.meta.url),
+    // Vitest source runtime: src/tools/catalog.ts -> dist/catalog-index.json
+    new URL("../../dist/catalog-index.json", import.meta.url),
+  ];
+  const found = candidates.find((candidate) =>
+    existsSync(fileURLToPath(candidate))
+  );
+  if (!found) {
+    throw new Error(
+      "Catalog index is missing. Run npm run build (or the catalog builder) first."
+    );
+  }
+  return fileURLToPath(found);
+}
+
+function isCatalogExercise(value: unknown): value is CatalogExercise {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const exercise = value as Record<string, unknown>;
+  return (
+    typeof exercise["externalId"] === "string" &&
+    typeof exercise["name"] === "string" &&
+    Array.isArray(exercise["primaryMuscles"]) &&
+    exercise["primaryMuscles"].every((muscle) => typeof muscle === "string") &&
+    (typeof exercise["equipment"] === "string" ||
+      exercise["equipment"] === null) &&
+    (typeof exercise["category"] === "string" ||
+      exercise["category"] === null)
+  );
+}
+
+export function loadCatalog(): CatalogExercise[] {
+  if (cachedCatalog) return cachedCatalog;
+
+  const parsed = JSON.parse(readFileSync(indexPath(), "utf8")) as unknown;
+  if (!Array.isArray(parsed) || !parsed.every(isCatalogExercise)) {
+    throw new Error("Catalog index has an invalid shape; rebuild it");
+  }
+
+  cachedCatalog = parsed;
+  cachedByExternalId = new Map(
+    parsed.map((exercise) => [exercise.externalId, exercise])
+  );
+  return cachedCatalog;
+}
+
+export function findExerciseByExternalId(
+  externalId: string
+): CatalogExercise | undefined {
+  loadCatalog();
+  return cachedByExternalId?.get(externalId);
+}
+
+function normalize(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[_:/-]+/g, " ")
+    .replace(/[^a-zA-Z0-9 ]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function levenshtein(left: string, right: string): number {
+  if (left.length === 0) return right.length;
+  if (right.length === 0) return left.length;
+
+  let previous = Array.from(
+    { length: right.length + 1 },
+    (_, index) => index
+  );
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    const current = [leftIndex];
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+      const substitution =
+        previous[rightIndex - 1] +
+        (left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1);
+      current[rightIndex] = Math.min(
+        previous[rightIndex] + 1,
+        current[rightIndex - 1] + 1,
+        substitution
+      );
+    }
+    previous = current;
+  }
+  return previous[right.length];
+}
+
+function nameScore(name: string, query: string): number {
+  const normalizedName = normalize(name);
+  const normalizedQuery = normalize(query);
+  if (normalizedQuery.length === 0) return 0;
+  if (normalizedName === normalizedQuery) return 10_000;
+
+  const nameWords = normalizedName.split(" ");
+  const queryWords = normalizedQuery.split(" ");
+  if (normalizedName.startsWith(normalizedQuery)) return 9_000;
+  const substringIndex = normalizedName.indexOf(normalizedQuery);
+  if (substringIndex >= 0) return 8_000 - substringIndex;
+
+  const allWordsMatch = queryWords.every((queryWord) =>
+    nameWords.some((nameWord) => nameWord.startsWith(queryWord))
+  );
+  if (allWordsMatch) {
+    return (
+      7_000 +
+      queryWords.reduce(
+        (score, queryWord) =>
+          score +
+          Math.max(
+            ...nameWords.map((nameWord) =>
+              nameWord === queryWord ? 100 : nameWord.startsWith(queryWord) ? 50 : 0
+            )
+          ),
+        0
+      )
+    );
+  }
+
+  const distance = levenshtein(normalizedName, normalizedQuery);
+  const maxLength = Math.max(normalizedName.length, normalizedQuery.length);
+  return maxLength === 0 ? 0 : 1_000 * (1 - distance / maxLength);
+}
+
+export function rankExercises(
+  exercises: readonly CatalogExercise[],
+  query: string,
+  limit = 10
+): CatalogExercise[] {
+  return exercises
+    .map((exercise) => ({
+      exercise,
+      score: nameScore(exercise.name, query),
+    }))
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.exercise.name.localeCompare(right.exercise.name)
+    )
+    .slice(0, Math.max(0, limit))
+    .map(({ exercise }) => exercise);
+}
+
+export function searchCatalog(query: string, limit = 10): CatalogExercise[] {
+  return rankExercises(loadCatalog(), query, limit);
+}
+
+function customExercise(value: unknown): CatalogExercise | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const exercise = value as Record<string, unknown>;
+  const externalId = exercise["externalId"];
+  const name = exercise["name"];
+  if (
+    typeof externalId !== "string" ||
+    externalId.length === 0 ||
+    typeof name !== "string" ||
+    name.length === 0
+  ) {
+    return undefined;
+  }
+  const primaryMuscles = exercise["primaryMuscles"];
+  const equipment = exercise["equipment"];
+  return {
+    externalId,
+    name,
+    primaryMuscles:
+      Array.isArray(primaryMuscles) &&
+      primaryMuscles.every((muscle) => typeof muscle === "string")
+        ? primaryMuscles
+        : [],
+    equipment: typeof equipment === "string" ? equipment : null,
+    category: "custom",
+  };
+}
+
+export async function searchExercises(
+  query: string,
+  limit = 10
+): Promise<ExerciseSearchResult[]> {
+  const response = await apiGet<SnapshotReadResponse>("sync/snapshot");
+  const custom = (response.snapshot?.customExercises ?? [])
+    .map(customExercise)
+    .filter((exercise): exercise is CatalogExercise => exercise !== undefined);
+
+  const byExternalId = new Map(
+    [...loadCatalog(), ...custom].map((exercise) => [
+      exercise.externalId,
+      exercise,
+    ])
+  );
+
+  return rankExercises([...byExternalId.values()], query, limit).map(
+    ({ externalId, name, primaryMuscles, equipment }) => ({
+      externalId,
+      name,
+      primaryMuscles,
+      equipment,
+    })
+  );
+}

--- a/infra/mcp/src/tools/catalog.ts
+++ b/infra/mcp/src/tools/catalog.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { isValidCustomExerciseExternalId } from "../shared/customExerciseIdentity.js";
 import { apiGet } from "../shared/http.js";
 
 export interface CatalogExercise {
@@ -21,6 +22,14 @@ interface SnapshotReadResponse {
   snapshot?: {
     customExercises?: unknown[];
   };
+}
+
+interface InboxListResponse {
+  operations?: {
+    id?: unknown;
+    op?: unknown;
+    payload?: unknown;
+  }[];
 }
 
 let cachedCatalog: CatalogExercise[] | undefined;
@@ -81,6 +90,36 @@ export function findExerciseByExternalId(
 ): CatalogExercise | undefined {
   loadCatalog();
   return cachedByExternalId?.get(externalId);
+}
+
+export async function resolveExerciseByExternalId(
+  externalId: string
+): Promise<CatalogExercise | undefined> {
+  const bundled = findExerciseByExternalId(externalId);
+  if (bundled) return bundled;
+  if (!externalId.startsWith("custom:")) return undefined;
+  if (!isValidCustomExerciseExternalId(externalId)) return undefined;
+
+  const snapshot = await apiGet<SnapshotReadResponse>("sync/snapshot");
+  const synced = (snapshot.snapshot?.customExercises ?? [])
+    .map((exercise) => customExercise(exercise))
+    .find((exercise) => exercise?.externalId === externalId);
+  if (synced) return synced;
+
+  for (const status of ["pending", "applied"] as const) {
+    const inbox = await apiGet<InboxListResponse>("inbox", { status });
+    const queued = (inbox.operations ?? [])
+      .filter((operation) => operation.op === "createCustomExercise")
+      .map((operation) =>
+        customExercise(
+          operation.payload,
+          typeof operation.id === "string" ? operation.id : undefined
+        )
+      )
+      .find((exercise) => exercise?.externalId === externalId);
+    if (queued) return queued;
+  }
+  return undefined;
 }
 
 function normalize(value: string): string {
@@ -178,16 +217,21 @@ export function searchCatalog(query: string, limit = 10): CatalogExercise[] {
   return rankExercises(loadCatalog(), query, limit);
 }
 
-function customExercise(value: unknown): CatalogExercise | undefined {
+function customExercise(
+  value: unknown,
+  operationId?: string
+): CatalogExercise | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
   const exercise = value as Record<string, unknown>;
+  const storedId = operationId ?? exercise["id"];
   const externalId = exercise["externalId"];
   const name = exercise["name"];
   if (
     typeof externalId !== "string" ||
-    externalId.length === 0 ||
+    typeof storedId !== "string" ||
+    !isValidCustomExerciseExternalId(externalId, storedId) ||
     typeof name !== "string" ||
     name.length === 0
   ) {
@@ -214,7 +258,7 @@ export async function searchExercises(
 ): Promise<ExerciseSearchResult[]> {
   const response = await apiGet<SnapshotReadResponse>("sync/snapshot");
   const custom = (response.snapshot?.customExercises ?? [])
-    .map(customExercise)
+    .map((exercise) => customExercise(exercise))
     .filter((exercise): exercise is CatalogExercise => exercise !== undefined);
 
   const byExternalId = new Map(

--- a/infra/mcp/src/tools/templates.ts
+++ b/infra/mcp/src/tools/templates.ts
@@ -1,8 +1,4 @@
-/**
- * Read-only template tools — issue #79.
- * Thin wrappers over the Functions API. Write operations (create/update/
- * delete) are disabled until the write path is redesigned.
- */
+/** Read-side template tools. Inbox write tools live in writes.ts. */
 
 import { apiGet, ApiError } from "../shared/http.js";
 import type { WorkoutTemplate } from "../shared/types.js";

--- a/infra/mcp/src/tools/writes.ts
+++ b/infra/mcp/src/tools/writes.ts
@@ -1,0 +1,302 @@
+import { apiGet, apiPost } from "../shared/http.js";
+import {
+  findExerciseByExternalId,
+  searchCatalog,
+} from "./catalog.js";
+
+export type InboxOperationType =
+  | "createTemplate"
+  | "updateTemplate"
+  | "deleteTemplate"
+  | "createCustomExercise";
+
+export type InboxOperationStatus =
+  | "pending"
+  | "awaitingApproval"
+  | "applied"
+  | "rejected"
+  | "failed";
+
+export interface TemplateExerciseWrite {
+  externalId: string;
+  order: number;
+  defaultSets: number;
+  defaultReps: number;
+  defaultWeight?: number;
+  defaultRestSeconds?: number;
+  notes?: string;
+}
+
+export interface CreateTemplatePayload {
+  name: string;
+  notes?: string;
+  exercises: TemplateExerciseWrite[];
+}
+
+export interface UpdateTemplatePayload {
+  id: string;
+  name?: string;
+  notes?: string;
+  exercises?: TemplateExerciseWrite[];
+}
+
+export interface DeleteTemplatePayload {
+  id: string;
+  name: string;
+}
+
+export interface CreateCustomExercisePayload {
+  name: string;
+  equipment?: string;
+  primaryMuscles?: string[];
+  secondaryMuscles?: string[];
+  instructions?: string[];
+  notes?: string;
+}
+
+export interface InboxOperation {
+  id: string;
+  createdAt: string;
+  op: InboxOperationType;
+  payload: Record<string, unknown>;
+  requiresApproval: boolean;
+  status: InboxOperationStatus;
+  appliedAt?: string;
+  error?: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`${field} must be a string`);
+  }
+}
+
+function optionalStringArray(value: unknown, field: string): void {
+  if (
+    value !== undefined &&
+    (!Array.isArray(value) ||
+      !value.every((entry) => typeof entry === "string"))
+  ) {
+    throw new Error(`${field} must be a string array`);
+  }
+}
+
+function assertKnownExternalId(externalId: string): void {
+  if (findExerciseByExternalId(externalId)) return;
+
+  const humanized = externalId.replace(/[_:/-]+/g, " ");
+  const suggestions = searchCatalog(humanized, 3)
+    .map((exercise) => `${exercise.name} (${exercise.externalId})`)
+    .join(", ");
+  throw new Error(
+    `Unknown externalId "${externalId}". Suggestions: ${suggestions}. ` +
+      "Call search_exercises and use an exact externalId from its results."
+  );
+}
+
+function validateTemplateExercises(
+  value: unknown,
+  field: string
+): TemplateExerciseWrite[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${field} must be an array`);
+  }
+
+  const orders = new Set<number>();
+  for (let index = 0; index < value.length; index += 1) {
+    const exercise = value[index];
+    const path = `${field}[${index}]`;
+    if (!isObject(exercise)) {
+      throw new Error(`${path} must be an object`);
+    }
+
+    const externalId = nonEmptyString(
+      exercise["externalId"],
+      `${path}.externalId`
+    );
+    const order = exercise["order"];
+    if (!Number.isInteger(order) || (order as number) < 0) {
+      throw new Error(`${path}.order must be a non-negative integer`);
+    }
+    if (orders.has(order as number)) {
+      throw new Error(`${field} contains duplicate order ${String(order)}`);
+    }
+    orders.add(order as number);
+
+    for (const fieldName of ["defaultSets", "defaultReps"] as const) {
+      const fieldValue = exercise[fieldName];
+      if (!Number.isInteger(fieldValue) || (fieldValue as number) <= 0) {
+        throw new Error(`${path}.${fieldName} must be a positive integer`);
+      }
+    }
+
+    const weight = exercise["defaultWeight"];
+    if (
+      weight !== undefined &&
+      (typeof weight !== "number" || !Number.isFinite(weight))
+    ) {
+      throw new Error(`${path}.defaultWeight must be a finite number`);
+    }
+    const restSeconds = exercise["defaultRestSeconds"];
+    if (
+      restSeconds !== undefined &&
+      (!Number.isInteger(restSeconds) || (restSeconds as number) < 0)
+    ) {
+      throw new Error(
+        `${path}.defaultRestSeconds must be a non-negative integer`
+      );
+    }
+    optionalString(exercise["notes"], `${path}.notes`);
+
+    // This must stay local and must run before the caller performs any POST.
+    assertKnownExternalId(externalId);
+  }
+
+  return value as TemplateExerciseWrite[];
+}
+
+function validateCreateTemplate(
+  value: unknown,
+  field = "template"
+): CreateTemplatePayload {
+  if (!isObject(value)) throw new Error(`${field} must be an object`);
+  nonEmptyString(value["name"], `${field}.name`);
+  optionalString(value["notes"], `${field}.notes`);
+  validateTemplateExercises(value["exercises"], `${field}.exercises`);
+  return value as unknown as CreateTemplatePayload;
+}
+
+function validateUpdateTemplate(value: unknown): UpdateTemplatePayload {
+  if (!isObject(value)) throw new Error("updateTemplate payload must be an object");
+  nonEmptyString(value["id"], "updateTemplate.id");
+  if (value["name"] !== undefined) {
+    nonEmptyString(value["name"], "updateTemplate.name");
+  }
+  optionalString(value["notes"], "updateTemplate.notes");
+  if (value["exercises"] !== undefined) {
+    validateTemplateExercises(
+      value["exercises"],
+      "updateTemplate.exercises"
+    );
+  }
+  return value as unknown as UpdateTemplatePayload;
+}
+
+function validateDeleteTemplate(value: unknown): DeleteTemplatePayload {
+  if (!isObject(value)) throw new Error("deleteTemplate payload must be an object");
+  nonEmptyString(value["id"], "deleteTemplate.id");
+  nonEmptyString(value["name"], "deleteTemplate.name");
+  return value as unknown as DeleteTemplatePayload;
+}
+
+function validateCreateCustomExercise(
+  value: unknown
+): CreateCustomExercisePayload {
+  if (!isObject(value)) {
+    throw new Error("createCustomExercise payload must be an object");
+  }
+  nonEmptyString(value["name"], "createCustomExercise.name");
+  optionalString(value["equipment"], "createCustomExercise.equipment");
+  optionalStringArray(
+    value["primaryMuscles"],
+    "createCustomExercise.primaryMuscles"
+  );
+  optionalStringArray(
+    value["secondaryMuscles"],
+    "createCustomExercise.secondaryMuscles"
+  );
+  optionalStringArray(
+    value["instructions"],
+    "createCustomExercise.instructions"
+  );
+  optionalString(value["notes"], "createCustomExercise.notes");
+  return value as unknown as CreateCustomExercisePayload;
+}
+
+async function enqueue(
+  op: InboxOperationType,
+  payload:
+    | CreateTemplatePayload
+    | UpdateTemplatePayload
+    | DeleteTemplatePayload
+    | CreateCustomExercisePayload
+): Promise<InboxOperation> {
+  return apiPost<InboxOperation>("inbox", { op, payload });
+}
+
+export async function createTemplate(
+  payload: unknown
+): Promise<InboxOperation> {
+  return enqueue("createTemplate", validateCreateTemplate(payload));
+}
+
+export async function updateTemplate(
+  payload: unknown
+): Promise<InboxOperation> {
+  return enqueue("updateTemplate", validateUpdateTemplate(payload));
+}
+
+export async function deleteTemplate(
+  payload: unknown
+): Promise<InboxOperation> {
+  return enqueue("deleteTemplate", validateDeleteTemplate(payload));
+}
+
+export async function createProgram(
+  value: unknown
+): Promise<InboxOperation[]> {
+  if (!isObject(value) || !Array.isArray(value["templates"])) {
+    throw new Error("templates must be an array");
+  }
+
+  // Validate every payload—including every externalId—before the first POST.
+  const templates = value["templates"].map((template, index) =>
+    validateCreateTemplate(template, `templates[${index}]`)
+  );
+
+  const operations: InboxOperation[] = [];
+  for (const template of templates) {
+    operations.push(await enqueue("createTemplate", template));
+  }
+  return operations;
+}
+
+export async function createCustomExercise(
+  payload: unknown
+): Promise<InboxOperation> {
+  return enqueue(
+    "createCustomExercise",
+    validateCreateCustomExercise(payload)
+  );
+}
+
+export async function listPendingWrites(options: {
+  status?: string;
+} = {}): Promise<InboxOperation[]> {
+  const statuses: readonly string[] = [
+    "pending",
+    "awaitingApproval",
+    "applied",
+    "rejected",
+    "failed",
+  ];
+  if (options.status !== undefined && !statuses.includes(options.status)) {
+    throw new Error(`Unknown inbox status: ${options.status}`);
+  }
+
+  const response = await apiGet<{ operations: InboxOperation[] }>("inbox", {
+    status: options.status,
+  });
+  return response.operations;
+}

--- a/infra/mcp/src/tools/writes.ts
+++ b/infra/mcp/src/tools/writes.ts
@@ -1,6 +1,6 @@
 import { apiGet, apiPost } from "../shared/http.js";
 import {
-  findExerciseByExternalId,
+  resolveExerciseByExternalId,
   searchCatalog,
 } from "./catalog.js";
 
@@ -92,8 +92,8 @@ function optionalStringArray(value: unknown, field: string): void {
   }
 }
 
-function assertKnownExternalId(externalId: string): void {
-  if (findExerciseByExternalId(externalId)) return;
+async function assertKnownExternalId(externalId: string): Promise<void> {
+  if (await resolveExerciseByExternalId(externalId)) return;
 
   const humanized = externalId.replace(/[_:/-]+/g, " ");
   const suggestions = searchCatalog(humanized, 3)
@@ -105,10 +105,10 @@ function assertKnownExternalId(externalId: string): void {
   );
 }
 
-function validateTemplateExercises(
+async function validateTemplateExercises(
   value: unknown,
   field: string
-): TemplateExerciseWrite[] {
+): Promise<TemplateExerciseWrite[]> {
   if (!Array.isArray(value)) {
     throw new Error(`${field} must be an array`);
   }
@@ -159,25 +159,27 @@ function validateTemplateExercises(
     }
     optionalString(exercise["notes"], `${path}.notes`);
 
-    // This must stay local and must run before the caller performs any POST.
-    assertKnownExternalId(externalId);
+    // Resolution must finish before the caller performs the template POST.
+    await assertKnownExternalId(externalId);
   }
 
   return value as TemplateExerciseWrite[];
 }
 
-function validateCreateTemplate(
+async function validateCreateTemplate(
   value: unknown,
   field = "template"
-): CreateTemplatePayload {
+): Promise<CreateTemplatePayload> {
   if (!isObject(value)) throw new Error(`${field} must be an object`);
   nonEmptyString(value["name"], `${field}.name`);
   optionalString(value["notes"], `${field}.notes`);
-  validateTemplateExercises(value["exercises"], `${field}.exercises`);
+  await validateTemplateExercises(value["exercises"], `${field}.exercises`);
   return value as unknown as CreateTemplatePayload;
 }
 
-function validateUpdateTemplate(value: unknown): UpdateTemplatePayload {
+async function validateUpdateTemplate(
+  value: unknown
+): Promise<UpdateTemplatePayload> {
   if (!isObject(value)) throw new Error("updateTemplate payload must be an object");
   nonEmptyString(value["id"], "updateTemplate.id");
   if (value["name"] !== undefined) {
@@ -185,7 +187,7 @@ function validateUpdateTemplate(value: unknown): UpdateTemplatePayload {
   }
   optionalString(value["notes"], "updateTemplate.notes");
   if (value["exercises"] !== undefined) {
-    validateTemplateExercises(
+    await validateTemplateExercises(
       value["exercises"],
       "updateTemplate.exercises"
     );
@@ -238,13 +240,13 @@ async function enqueue(
 export async function createTemplate(
   payload: unknown
 ): Promise<InboxOperation> {
-  return enqueue("createTemplate", validateCreateTemplate(payload));
+  return enqueue("createTemplate", await validateCreateTemplate(payload));
 }
 
 export async function updateTemplate(
   payload: unknown
 ): Promise<InboxOperation> {
-  return enqueue("updateTemplate", validateUpdateTemplate(payload));
+  return enqueue("updateTemplate", await validateUpdateTemplate(payload));
 }
 
 export async function deleteTemplate(
@@ -261,9 +263,15 @@ export async function createProgram(
   }
 
   // Validate every payload—including every externalId—before the first POST.
-  const templates = value["templates"].map((template, index) =>
-    validateCreateTemplate(template, `templates[${index}]`)
-  );
+  const templates: CreateTemplatePayload[] = [];
+  for (let index = 0; index < value["templates"].length; index += 1) {
+    templates.push(
+      await validateCreateTemplate(
+        value["templates"][index],
+        `templates[${index}]`
+      )
+    );
+  }
 
   const operations: InboxOperation[] = [];
   for (const template of templates) {

--- a/infra/mcp/tests/http.test.ts
+++ b/infra/mcp/tests/http.test.ts
@@ -8,7 +8,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { apiGet, ApiError } = await import("../src/shared/http.js");
+const http = await import("../src/shared/http.js");
+const { apiGet, ApiError } = http;
 
 const BASE_URL = "https://func-workout-prod.azurewebsites.net";
 const API_KEY = "super-secret-key";
@@ -118,5 +119,57 @@ describe("apiGet", () => {
       expect((err as Error).message).toContain(BASE_URL);
       expect((err as Error).message).not.toContain(API_KEY);
     }
+  });
+});
+
+describe("apiPost", () => {
+  it("is exposed by the shared HTTP layer", () => {
+    expect("apiPost" in http).toBe(true);
+  });
+
+  it("posts JSON to {base}/api/{path} with the API key", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ id: "op-1" }));
+
+    const apiPost = (
+      http as typeof http & {
+        apiPost<T>(path: string, body: unknown): Promise<T>;
+      }
+    ).apiPost;
+    const result = await apiPost<{ id: string }>("inbox", {
+      op: "deleteTemplate",
+      payload: { id: "template-1", name: "Push Day" },
+    });
+
+    expect(result).toEqual({ id: "op-1" });
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toBe(`${BASE_URL}/api/inbox`);
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": API_KEY,
+      },
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      op: "deleteTemplate",
+      payload: { id: "template-1", name: "Push Day" },
+    });
+  });
+
+  it("reports POST and the server detail for non-2xx responses", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ error: "Malformed payload: name is required" }, 400)
+    );
+
+    const apiPost = (
+      http as typeof http & {
+        apiPost<T>(path: string, body: unknown): Promise<T>;
+      }
+    ).apiPost;
+
+    await expect(apiPost("inbox", {})).rejects.toThrow(
+      /Malformed payload: name is required.*POST \/api\/inbox/
+    );
   });
 });

--- a/infra/mcp/tests/registry.test.ts
+++ b/infra/mcp/tests/registry.test.ts
@@ -54,16 +54,18 @@ describe("search_exercises", () => {
         bodyWeightEntries: [],
         customExercises: [
           {
-            id: "custom-uuid",
-            externalId: "custom:bench-pullover",
+            id: "10000000-0000-4000-8000-000000000008",
+            externalId:
+              "custom:bench-pullover:10000000-0000-4000-8000-000000000008",
             name: "Bench Pullover",
             primaryMuscles: ["chest"],
             equipment: "dumbbell",
             isCustom: true,
           },
           {
-            id: "other-uuid",
-            externalId: "custom:standing-calf-bounce",
+            id: "10000000-0000-4000-8000-000000000009",
+            externalId:
+              "custom:standing-calf-bounce:10000000-0000-4000-8000-000000000009",
             name: "Standing Calf Bounce",
             primaryMuscles: ["calves"],
             equipment: null,
@@ -86,7 +88,8 @@ describe("search_exercises", () => {
           equipment: "body only",
         }),
         expect.objectContaining({
-          externalId: "custom:bench-pullover",
+          externalId:
+            "custom:bench-pullover:10000000-0000-4000-8000-000000000008",
           name: "Bench Pullover",
           primaryMuscles: ["chest"],
           equipment: "dumbbell",
@@ -144,6 +147,140 @@ describe("inbox write dispatch", () => {
     );
     expect(mockApiGet).not.toHaveBeenCalled();
     expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("resolves a synced custom externalId before enqueueing a template", async () => {
+    const externalId =
+      "custom:deja-vu-row:10000000-0000-4000-8000-000000000006";
+    mockApiGet.mockResolvedValue({
+      snapshot: {
+        customExercises: [
+          {
+            id: "10000000-0000-4000-8000-000000000006",
+            externalId,
+            name: "Déjà Vu Row",
+            primaryMuscles: ["back"],
+            equipment: "cable",
+          },
+        ],
+      },
+    });
+    mockApiPost.mockResolvedValue({ id: "template-op", status: "pending" });
+    const payload = {
+      name: "Custom Pull",
+      exercises: [{ ...benchExercise, externalId }],
+    };
+
+    const result = await handleToolCall("create_template", payload);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockApiGet).toHaveBeenCalledWith("sync/snapshot");
+    expect(mockApiPost).toHaveBeenCalledWith("inbox", {
+      op: "createTemplate",
+      payload,
+    });
+  });
+
+  it("accepts a custom externalId with a 64-character slug", async () => {
+    const id = "10000000-0000-4000-8000-000000000010";
+    const externalId = `custom:${"a".repeat(64)}:${id}`;
+    mockApiGet.mockResolvedValue({
+      snapshot: {
+        customExercises: [
+          {
+            id,
+            externalId,
+            name: "Maximum Slug",
+            primaryMuscles: [],
+            equipment: null,
+          },
+        ],
+      },
+    });
+    mockApiPost.mockResolvedValue({ id: "template-op", status: "pending" });
+
+    const result = await handleToolCall("create_template", {
+      name: "Maximum Slug Template",
+      exercises: [{ ...benchExercise, externalId }],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockApiPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects the shared invalid custom externalId cases before enqueueing", async () => {
+    const operationId = "10000000-0000-4000-8000-000000000001";
+    const invalidExternalIds = [
+      "custom:",
+      "custom:row",
+      `custom:Bad_Slug:${operationId}`,
+      `custom:${"a".repeat(65)}:${operationId}`,
+      "custom:row:00000000-0000-4000-8000-000000000000",
+    ];
+
+    for (const externalId of invalidExternalIds) {
+      mockApiGet.mockReset();
+      mockApiPost.mockReset();
+      mockApiGet.mockResolvedValue({
+        snapshot: {
+          customExercises: [
+            {
+              id: operationId,
+              externalId,
+              name: "Invalid Custom Exercise",
+              primaryMuscles: [],
+              equipment: null,
+            },
+          ],
+        },
+      });
+
+      const result = await handleToolCall("create_template", {
+        name: "Invalid Custom Identity",
+        exercises: [{ ...benchExercise, externalId }],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("externalId");
+      expect(mockApiPost).not.toHaveBeenCalled();
+    }
+  });
+
+  it("resolves a custom externalId from its pending durable inbox operation", async () => {
+    const externalId =
+      "custom:pending-row:10000000-0000-4000-8000-000000000007";
+    mockApiGet.mockImplementation(
+      async (endpoint: string, options?: { status?: string }) => {
+        if (endpoint === "sync/snapshot") {
+          return { snapshot: { customExercises: [] } };
+        }
+        if (endpoint === "inbox" && options?.status === "pending") {
+          return {
+            operations: [
+              {
+                id: "10000000-0000-4000-8000-000000000007",
+                op: "createCustomExercise",
+                status: "pending",
+                payload: { name: "Pending Row", externalId },
+              },
+            ],
+          };
+        }
+        return { operations: [] };
+      }
+    );
+    mockApiPost.mockResolvedValue({ id: "template-op", status: "pending" });
+
+    const result = await handleToolCall("create_template", {
+      name: "Immediate Custom Pull",
+      exercises: [{ ...benchExercise, externalId }],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockApiGet).toHaveBeenCalledWith("inbox", {
+      status: "pending",
+    });
+    expect(mockApiPost).toHaveBeenCalledTimes(1);
   });
 
   it("create_program validates every template before enqueueing any", async () => {

--- a/infra/mcp/tests/registry.test.ts
+++ b/infra/mcp/tests/registry.test.ts
@@ -1,19 +1,13 @@
-/**
- * Tests for the MCP tool registry — issue #79.
- *
- * Read-only ship: 7 read tools + health are exposed. Write tools
- * (create_template, update_template, delete_template, create_program) are
- * hard-disabled with a clear error referencing issue #79, and
- * search_exercises explains that the exercise library is not synced.
- */
+/** Tests for the MCP tool registry and inbox write path — issue #88. */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
 
 vi.mock("../src/shared/http.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/shared/http.js")>();
-  return { ...actual, apiGet: mockApiGet };
+  return { ...actual, apiGet: mockApiGet, apiPost: mockApiPost };
 });
 
 const { ApiError } = await import("../src/shared/http.js");
@@ -21,65 +15,236 @@ const { TOOLS, handleToolCall } = await import("../src/registry.js");
 
 beforeEach(() => {
   mockApiGet.mockReset();
+  mockApiPost.mockReset();
 });
 
 describe("tool listing", () => {
-  it("exposes exactly the read-only toolset plus health", () => {
+  it("exposes the read and inbox-write toolsets with nothing disabled", () => {
     const names = TOOLS.map((t) => t.name).sort();
     expect(names).toEqual(
       [
+        "create_custom_exercise",
+        "create_program",
+        "create_template",
+        "delete_template",
         "get_calendar",
         "get_exercise_history",
         "get_stats",
         "get_template",
         "get_workout",
         "health",
+        "list_pending_writes",
         "list_templates",
         "list_workouts",
+        "search_exercises",
+        "update_template",
       ].sort()
     );
-  });
-
-  it("does not list write tools or search_exercises", () => {
-    const names = TOOLS.map((t) => t.name);
-    for (const removed of [
-      "create_template",
-      "update_template",
-      "delete_template",
-      "create_program",
-      "search_exercises",
-    ]) {
-      expect(names).not.toContain(removed);
-    }
-  });
-});
-
-describe("disabled write tools", () => {
-  it.each([
-    "create_template",
-    "update_template",
-    "delete_template",
-    "create_program",
-  ])("%s returns a clear disabled error referencing #79", async (name) => {
-    const result = await handleToolCall(name, {});
-
-    expect(result.isError).toBe(true);
-    const text = result.content[0].text;
-    expect(text).toMatch(/read-only/i);
-    expect(text).toContain("#79");
-    expect(mockApiGet).not.toHaveBeenCalled();
   });
 });
 
 describe("search_exercises", () => {
-  it("explains the exercise library is not synced instead of returning empty results", async () => {
-    const result = await handleToolCall("search_exercises", { name: "bench" });
+  it("returns real bundled exercises and merges matching cloud custom exercises", async () => {
+    mockApiGet.mockResolvedValue({
+      revision: 3,
+      serverTime: "2026-07-27T10:00:00Z",
+      snapshot: {
+        workouts: [],
+        templates: [],
+        bodyWeightEntries: [],
+        customExercises: [
+          {
+            id: "custom-uuid",
+            externalId: "custom:bench-pullover",
+            name: "Bench Pullover",
+            primaryMuscles: ["chest"],
+            equipment: "dumbbell",
+            isCustom: true,
+          },
+          {
+            id: "other-uuid",
+            externalId: "custom:standing-calf-bounce",
+            name: "Standing Calf Bounce",
+            primaryMuscles: ["calves"],
+            equipment: null,
+            isCustom: true,
+          },
+        ],
+      },
+    });
+
+    const result = await handleToolCall("search_exercises", { query: "bench" });
+
+    expect(result.isError).toBeUndefined();
+    const exercises = JSON.parse(result.content[0].text);
+    expect(exercises).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          externalId: "Bench_Dips",
+          name: "Bench Dips",
+          primaryMuscles: ["triceps"],
+          equipment: "body only",
+        }),
+        expect.objectContaining({
+          externalId: "custom:bench-pullover",
+          name: "Bench Pullover",
+          primaryMuscles: ["chest"],
+          equipment: "dumbbell",
+        }),
+      ])
+    );
+    expect(mockApiGet).toHaveBeenCalledWith("sync/snapshot");
+  });
+});
+
+const benchExercise = {
+  externalId: "Barbell_Bench_Press_-_Medium_Grip",
+  order: 0,
+  defaultSets: 3,
+  defaultReps: 8,
+  defaultWeight: 80,
+  defaultRestSeconds: 120,
+  notes: "Pause on chest",
+};
+
+describe("inbox write dispatch", () => {
+  it("create_template validates a real externalId and posts the wire body", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-1", status: "pending" });
+    const payload = {
+      name: "Push Day",
+      notes: "Heavy day",
+      exercises: [benchExercise],
+    };
+
+    const result = await handleToolCall("create_template", payload);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockApiPost).toHaveBeenCalledWith("inbox", {
+      op: "createTemplate",
+      payload,
+    });
+  });
+
+  it("rejects an invented externalId with named suggestions and no HTTP call", async () => {
+    const result = await handleToolCall("create_template", {
+      name: "Imaginary Day",
+      exercises: [
+        {
+          ...benchExercise,
+          externalId: "Totally_Made_Up_Exercise",
+        },
+      ],
+    });
 
     expect(result.isError).toBe(true);
-    const text = result.content[0].text;
-    expect(text).toMatch(/exercise library/i);
-    expect(text).toMatch(/not synced/i);
+    expect(result.content[0].text).toContain("Totally_Made_Up_Exercise");
+    expect(result.content[0].text).toMatch(/suggestions?:/i);
+    expect(result.content[0].text).toMatch(
+      /[A-Za-z]+ [A-Za-z]+.*\([A-Za-z0-9_:-]+\)/
+    );
     expect(mockApiGet).not.toHaveBeenCalled();
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("create_program validates every template before enqueueing any", async () => {
+    const result = await handleToolCall("create_program", {
+      templates: [
+        {
+          name: "Valid Push",
+          exercises: [benchExercise],
+        },
+        {
+          name: "Invalid Pull",
+          exercises: [
+            {
+              ...benchExercise,
+              externalId: "Totally_Made_Up_Exercise",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Totally_Made_Up_Exercise");
+    expect(mockApiGet).not.toHaveBeenCalled();
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("update_template and delete_template enqueue the right operations", async () => {
+    mockApiPost
+      .mockResolvedValueOnce({ id: "op-update", status: "pending" })
+      .mockResolvedValueOnce({ id: "op-delete", status: "pending" });
+
+    const updatePayload = {
+      id: "template-1",
+      name: "Push A",
+      exercises: [benchExercise],
+    };
+    const deletePayload = { id: "template-2", name: "Push B" };
+
+    const updateResult = await handleToolCall(
+      "update_template",
+      updatePayload
+    );
+    const deleteResult = await handleToolCall(
+      "delete_template",
+      deletePayload
+    );
+
+    expect(updateResult.isError).toBeUndefined();
+    expect(deleteResult.isError).toBeUndefined();
+    expect(mockApiPost).toHaveBeenNthCalledWith(1, "inbox", {
+      op: "updateTemplate",
+      payload: updatePayload,
+    });
+    expect(mockApiPost).toHaveBeenNthCalledWith(2, "inbox", {
+      op: "deleteTemplate",
+      payload: deletePayload,
+    });
+  });
+
+  it("create_custom_exercise enqueues the right operation", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-custom", status: "pending" });
+    const payload = {
+      name: "Cable Cross-body Raise",
+      equipment: "cable",
+      primaryMuscles: ["shoulders"],
+      secondaryMuscles: ["traps"],
+      instructions: ["Raise across the body."],
+      notes: "Keep it strict",
+    };
+
+    const result = await handleToolCall("create_custom_exercise", payload);
+
+    expect(result.isError).toBeUndefined();
+    expect(mockApiPost).toHaveBeenCalledWith("inbox", {
+      op: "createCustomExercise",
+      payload,
+    });
+  });
+
+  it("list_pending_writes surfaces failed operations and their errors", async () => {
+    mockApiGet.mockResolvedValue({
+      operations: [
+        {
+          id: "op-failed",
+          op: "createTemplate",
+          status: "failed",
+          error: "Unresolved externalIds: Missing_Lift",
+        },
+      ],
+    });
+
+    const result = await handleToolCall("list_pending_writes", {
+      status: "failed",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockApiGet).toHaveBeenCalledWith("inbox", { status: "failed" });
+    const operations = JSON.parse(result.content[0].text);
+    expect(operations[0].status).toBe("failed");
+    expect(operations[0].error).toContain("Missing_Lift");
   });
 });
 

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -93,6 +93,12 @@ var containers = [
     name: 'syncMeta'
     partitionKeyPath: '/id'
   }
+  // MCP write path (issue #88): durable operations drained by the phone.
+  // Deliberately separate from the snapshot-reconciled containers.
+  {
+    name: 'inbox'
+    partitionKeyPath: '/id'
+  }
 ]
 
 // Containers intentionally omit `options.throughput` and `options.autoscaleSettings`.


### PR DESCRIPTION
Completes the MCP write path (#88) and fixes the two defects that real use exposed.

Claude Code and claude.ai can now create templates through MCP. Writes cannot go straight to Cosmos — the phone is authoritative and its next snapshot would erase them — so they land in a durable inbox that the phone drains on sync. Design: `infra/MCP_WRITE_PATH.md`.

## Proven in production

The four gym-restart templates were created through this path, drained by the phone, and verified with full exercise lists — the #79 regression (templates arriving with zero exercises) did not recur.

## What this fixes

**#97 — the approval gate had no client implementation.** `InboxApplier` gated only on `status == "pending"` and never read `requiresApproval`, so an approval-required operation applied on-device with **no prompt** and then acked `pending -> applied`, which the server's state machine rejected. Three `deleteTemplate` operations were recorded `failed` in production while having fully succeeded — a destructive write with no consent, and an inbox status that lied about it.

Now: the applier acks `awaitingApproval` **before** any mutation, Home surfaces each pending approval, and the operation applies only on an explicit approve (`rejected` on decline). Approval is derived from the operation **type** on both phone and server, so a malformed or legacy envelope claiming `requiresApproval: false` cannot auto-apply an update or delete.

**#95 — a lost ack duplicated the write.** Creates now derive entity identity from the inbox operation id, so a re-served operation is an upsert rather than a duplicate. `deleteTemplate` was already idempotent.

**Ack semantics.** Retrying the current status is an idempotent no-op. An already-terminal operation receiving a different status is left unchanged and reported as a conflict rather than overwritten. An illegal transition from a *nonterminal* state still goes terminal — leaving it pending would re-serve it every sync forever — but responses now carry per-operation outcomes, so a conflict is attributable instead of hidden behind aggregate counts. The client validates the ack against the request it sent, and a conflict no longer blocks `pushSnapshot`: valid batch-mates still push and the error surfaces afterward.

**Snapshot-dirty marker.** `Exercise` has no per-record `syncStatus`, so an inbox-created custom exercise whose push then failed was applied, acked, and never reached the cloud. The trigger is now durable and cleared only after a successful push.

**Custom exercises.** `externalId` is server-issued as `custom:<slug>:<operation-uuid>` under one grammar enforced identically in MCP, Functions, and the phone, so a custom exercise can finally be referenced by a later template instead of being silently inert.

## Verification

| Suite | Result |
|---|---|
| Swift Testing (iPhone 13 Pro Max, iOS 26.5) | 650/650 |
| XCUITest | 4 failing — **pre-existing #96**, identical in the pre-change baseline |
| Functions (Jest) | 145/145 |
| MCP (vitest) | 52/52 |
| `tsc --noEmit`, MCP build | clean |

Note: `xcodebuild test` exits 65 overall because of the four #96 UI tests (they query `textFields` for a `.searchable` field). That failure is unrelated to this PR and reproduces on the pre-change baseline; every Swift Testing suite passes.

## Known limitations, deliberately not fixed here

Filed with file:line evidence rather than folded in, to keep this reviewable:

- **#103** — approval decisions are not durable. A lost *final* ack still lets the user contradict a decision already applied, and `updateTemplate` can replay over an intervening edit. The real fix is a local operation receipt; that is an architectural addition, not a patch.
- **#104** — UI-created custom exercises are never pushed (`Exercise` is absent from `hasPendingChanges`). **Pre-existing**, not introduced here; the dirty marker covers only the inbox case.
- **#98** partial `create_program` enqueue · **#99** import/sync ordering race · **#100** Home staleness · **#101** stale-write preconditions · **#102** producer-side enqueue idempotency · **#105** MCP trusting historical `applied` records · **#106** unconditional Cosmos replace on ack · **#107** approval prompt trusting the payload name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
