### PR TITLE
Stop Finish stranding the user in a saved workout

### DIFF
--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		53029FF24B321A4FC555535E /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44153457DFD1B1AF77799FF4 /* KeychainHelper.swift */; };
 		0B71D39860B245530CD3B22B /* LocalPhotoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FF0D1EB078F5CF438D6195 /* LocalPhotoStorage.swift */; };
 		39320B32AAB849DA6F4142BC /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB5C6DF96590C72CEA77BD4 /* SettingsManager.swift */; };
+		A1C7F30D4B2E88015CD6119A /* WorkoutCompletionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C7F30D4B2E88015CD6119B /* WorkoutCompletionSummary.swift */; };
 		B902261B25F991B27E8726CE /* ActiveWorkoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB1106CAB595E0F873B0E4E /* ActiveWorkoutViewModel.swift */; };
 		8B39AD114C8A22CA4A12F63D /* BodyWeightViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A915220457843657F447086 /* BodyWeightViewModel.swift */; };
 		D25F93C9E3A2384DFE178ACB /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2481707D7718DFBFE1786D0B /* CalendarViewModel.swift */; };
@@ -308,6 +309,7 @@
 		44153457DFD1B1AF77799FF4 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		C6FF0D1EB078F5CF438D6195 /* LocalPhotoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPhotoStorage.swift; sourceTree = "<group>"; };
 		2BB5C6DF96590C72CEA77BD4 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
+		A1C7F30D4B2E88015CD6119B /* WorkoutCompletionSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutCompletionSummary.swift; sourceTree = "<group>"; };
 		BFB1106CAB595E0F873B0E4E /* ActiveWorkoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModel.swift; sourceTree = "<group>"; };
 		0A915220457843657F447086 /* BodyWeightViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightViewModel.swift; sourceTree = "<group>"; };
 		2481707D7718DFBFE1786D0B /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
@@ -652,6 +654,7 @@
 				8F74F9A7CD4DED50BDB90D6A,
 				8EB00D1C9712594526486A75,
 				ED7DA3C8168497F0DAEAAC17,
+				A1C7F30D4B2E88015CD6119B,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1088,6 +1091,7 @@
 				0B71D39860B245530CD3B22B /* LocalPhotoStorage.swift in Sources */,
 				39320B32AAB849DA6F4142BC /* SettingsManager.swift in Sources */,
 				B902261B25F991B27E8726CE /* ActiveWorkoutViewModel.swift in Sources */,
+				A1C7F30D4B2E88015CD6119A /* WorkoutCompletionSummary.swift in Sources */,
 				8B39AD114C8A22CA4A12F63D /* BodyWeightViewModel.swift in Sources */,
 				D25F93C9E3A2384DFE178ACB /* CalendarViewModel.swift in Sources */,
 				2AF09F12EAC18CDA1A9FBB47 /* ChatViewModel.swift in Sources */,

--- a/ClaudeLifter/App/AppState.swift
+++ b/ClaudeLifter/App/AppState.swift
@@ -8,15 +8,28 @@ final class AppState {
     var activeWorkoutId: UUID? = nil
     var activeWorkoutVM: ActiveWorkoutViewModel? = nil
 
+    /// The receipt for the most recently finished workout, presented over Home.
+    ///
+    /// It lives here rather than on `ActiveWorkoutView` because `endWorkout()`
+    /// tears that view down. Owning it at this level lets the workout end the
+    /// instant its save commits, independently of whether the summary is shown
+    /// or how it is dismissed (#123).
+    var completedWorkoutSummary: WorkoutCompletionSummary? = nil
+
     func startWorkout(id: UUID, vm: ActiveWorkoutViewModel) {
         activeWorkoutId = id
         activeWorkoutVM = vm
         isWorkoutActive = true
+        completedWorkoutSummary = nil
     }
 
-    func endWorkout() {
+    /// Leaves the active workout and, when there is one, publishes its receipt.
+    /// Callers that discard a session pass no summary, which also clears any
+    /// stale receipt still onscreen.
+    func endWorkout(showing summary: WorkoutCompletionSummary? = nil) {
         activeWorkoutId = nil
         activeWorkoutVM = nil
         isWorkoutActive = false
+        completedWorkoutSummary = summary
     }
 }

--- a/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
+++ b/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
@@ -2,12 +2,44 @@ import Foundation
 import Observation
 import UIKit
 
+/// Where an active workout is in the process of ending.
+///
+/// This replaces a stored one-way `isFinished` Bool. That Bool was set to true
+/// and never reset, and the summary sheet was presented solely by an
+/// `onChange` on it — so the presentation could only ever fire once per app
+/// run. Combined with `endWorkout()` living behind the summary's Done button,
+/// dismissing that sheet any other way left the user inside a workout that was
+/// already saved, with a Finish button that could no longer show anything
+/// (#123).
+enum WorkoutCompletionState {
+    case active
+    case finishing
+    /// Terminal. `summary` is nil when the session was discarded rather than
+    /// saved (#69) — there is no receipt, but the UI must still leave.
+    case finished(summary: WorkoutCompletionSummary?)
+    case failed(message: String)
+}
+
 @Observable
 @MainActor
 final class ActiveWorkoutViewModel {
     var workout: Workout? = nil
-    var isFinished = false
+    private(set) var completionState: WorkoutCompletionState = .active
     var errorMessage: String? = nil
+
+    /// Derived, not stored. The hazard was never the name — it was that this
+    /// was a stored one-way flag doubling as the sole presentation trigger.
+    var isFinished: Bool {
+        if case .finished = completionState { return true }
+        return false
+    }
+
+    /// True while the critical save is in flight, so the UI can disable Finish
+    /// and show progress instead of accepting taps it will discard.
+    var isFinishing: Bool {
+        if case .finishing = completionState { return true }
+        return false
+    }
     var lastCompletedSet: WorkoutSet? = nil
     var detectedPRs: [PersonalRecord] = []
     private(set) var previousValues: [UUID: AutoFillResult] = [:]
@@ -38,6 +70,12 @@ final class ActiveWorkoutViewModel {
     private(set) var pendingPreviousValuesLoad: Task<Void, Never>?
     private var didLoadInitialPreviousValues = false
 
+    /// The in-flight finish attempt, so duplicate taps join it rather than
+    /// racing it (#124).
+    private var finishTask: Task<Void, Never>?
+    /// Follow-up work that runs after the critical save has committed.
+    private var postCommitTask: Task<Void, Never>?
+
     /// Awaits any in-flight save triggered by the last mutation. Useful in
     /// tests and wherever deterministic persistence is required before the
     /// next action.
@@ -48,6 +86,26 @@ final class ActiveWorkoutViewModel {
     func awaitPreviousValuesLoad() async {
         await pendingPreviousValuesLoad?.value
     }
+
+    /// Awaits template bookkeeping and PR detection. These run *after* the
+    /// workout is durably saved and are deliberately not awaited by
+    /// `finishWorkout()`, so tests need an explicit join point — the same
+    /// pattern as `awaitPendingSave()`.
+    func awaitPostCommitWork() async {
+        await postCommitTask?.value
+    }
+
+    /// The receipt for the finished workout, or nil when the session was
+    /// discarded rather than saved.
+    var completionSummary: WorkoutCompletionSummary? {
+        if case .finished(let summary) = completionState { return summary }
+        return nil
+    }
+
+    /// Non-fatal problems from post-commit work. The workout is already saved,
+    /// so these are reported rather than thrown — but not silently dropped the
+    /// way the previous `try?` calls dropped them (#125).
+    private(set) var postCommitWarnings: [String] = []
 
     func previous(for set: WorkoutSet) -> AutoFillResult? {
         previousValues[set.id]
@@ -239,6 +297,10 @@ final class ActiveWorkoutViewModel {
     /// `recordChange()` runs synchronously so sync state is correct even if
     /// the app dies before the async save lands.
     private func persistMutation() {
+        // Once the workout is finished its record is authoritative. A late
+        // mutation — from a Coach tool, say — must not re-open it for a draft
+        // save that would re-stamp `lastModified` behind the user's back.
+        if case .finished = completionState { return }
         workout?.recordChange()
         pendingSave?.cancel()
         // [weak self] so the Task is a no-op if the VM has been released
@@ -453,32 +515,114 @@ final class ActiveWorkoutViewModel {
         }
     }
 
+    /// Ends the workout. Idempotent: repeated taps join the in-flight attempt
+    /// or return immediately once it has succeeded (#124). Returns as soon as
+    /// the critical save has committed — post-commit work continues in the
+    /// background so slow PR detection cannot hold the user in the workout.
     func finishWorkout() async {
-        guard let workout else { return }
+        // Already done. Re-entering used to re-stamp `completedAt`, save again,
+        // bump `timesPerformed` again and re-run PR detection — all invisibly,
+        // because the presentation trigger could not fire twice.
+        if case .finished = completionState { return }
 
-        // Delete empty/unused workouts instead of saving them (#69)
-        if workout.exercises.isEmpty || !hasCompletedSets {
-            await cancelWorkout()
-            isFinished = true
+        // A second tap while the first is still saving waits for that attempt
+        // rather than starting a competing one.
+        if let finishTask {
+            await finishTask.value
             return
         }
 
-        workout.completedAt = .now
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performFinish()
+        }
+        finishTask = task
+        await task.value
+        finishTask = nil
+    }
+
+    private func performFinish() async {
+        guard let workout else { return }
+        completionState = .finishing
+
+        // #69: a session with nothing logged is discarded, not saved. It has no
+        // receipt to show. The old code still routed it through the summary
+        // sheet, which then rendered an empty view with no Done button.
+        if workout.exercises.isEmpty || !hasCompletedSets {
+            await cancelWorkout()
+            completionState = .finished(summary: nil)
+            return
+        }
+
+        // #121: `persistMutation` leaves a draft save in flight. It must not
+        // land after completion — `saveDraft` re-stamps `lastModified` and
+        // deletes sessions it considers empty. Cancel it and let the
+        // authoritative save below be the one that counts.
+        pendingSave?.cancel()
+        pendingSave = nil
+
+        // Stamped once per successful attempt. A retry after a failed save
+        // re-stamps deliberately; a duplicate tap never reaches here.
+        if workout.completedAt == nil {
+            workout.completedAt = .now
+        }
         workout.recordChange()
+
         do {
             try await saveWorkout(workout)
-            if let template, let templateRepository {
-                template.timesPerformed += 1
-                template.lastPerformedAt = .now
-                template.recordChange()
-                try? await templateRepository.save(template)
-            }
-            if let prService = prDetectionService {
-                detectedPRs = (try? await prService.detectPRs(for: workout)) ?? []
-            }
-            isFinished = true
         } catch {
+            // The workout stays intact and active so the user can retry
+            // without losing logged sets.
+            workout.completedAt = nil
             errorMessage = error.localizedDescription
+            completionState = .failed(message: error.localizedDescription)
+            return
+        }
+
+        // The critical transaction has committed. Publishing the receipt here
+        // — before any of the follow-up work — is what lets the UI leave the
+        // workout immediately.
+        let summary = WorkoutCompletionSummary(workout: workout)
+        completionState = .finished(summary: summary)
+
+        postCommitTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runPostCommitWork(for: workout, summary: summary)
+        }
+    }
+
+    /// Template bookkeeping and PR detection. Everything here happens after the
+    /// workout is durably saved, so failures are recorded and surfaced but can
+    /// never reopen, delay or discard a completed workout (#125).
+    private func runPostCommitWork(
+        for workout: Workout,
+        summary: WorkoutCompletionSummary
+    ) async {
+        if let template, let templateRepository {
+            template.timesPerformed += 1
+            template.lastPerformedAt = .now
+            template.recordChange()
+            do {
+                try await templateRepository.save(template)
+            } catch {
+                // Previously `try?`, so a broken template save was invisible.
+                template.timesPerformed -= 1
+                postCommitWarnings.append(
+                    "Template usage wasn't updated: \(error.localizedDescription)"
+                )
+            }
+        }
+
+        if let prService = prDetectionService {
+            do {
+                let prs = try await prService.detectPRs(for: workout)
+                detectedPRs = prs
+                summary.personalRecords = prs
+            } catch {
+                postCommitWarnings.append(
+                    "Couldn't check for personal records: \(error.localizedDescription)"
+                )
+            }
         }
     }
 

--- a/ClaudeLifter/ViewModels/WorkoutCompletionSummary.swift
+++ b/ClaudeLifter/ViewModels/WorkoutCompletionSummary.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Observation
+
+/// The receipt for a workout that has been durably saved.
+///
+/// This is owned by `AppState` and presented over Home rather than by
+/// `ActiveWorkoutView`, and that ownership is the whole point (#123).
+/// `AppState.endWorkout()` nils `activeWorkoutVM`, which tears down
+/// `ActiveWorkoutView` — so a summary sheet attached to that view could only
+/// survive if leaving the workout were postponed until the sheet was
+/// dismissed. That is exactly what the old code did, and it meant a
+/// swipe-dismissed sheet (there was no `interactiveDismissDisabled`) left the
+/// user inside a workout that had already been saved and synced, with a
+/// one-way `isFinished` flag that no further Finish tap could re-trigger.
+///
+/// Handing the receipt to `AppState` breaks that circle: ending the workout and
+/// showing the summary become independent, so dismissing the summary any way at
+/// all — Done, swipe, or never presenting it — cannot strand anyone.
+///
+/// A reference type so post-commit PR detection can fill `personalRecords` in
+/// after the sheet is already onscreen, without disturbing `sheet(item:)`
+/// identity.
+@Observable
+@MainActor
+final class WorkoutCompletionSummary: Identifiable {
+    let id: UUID
+    let workout: Workout
+
+    /// Populated after the critical save by post-commit PR detection (#125),
+    /// so a slow or failing detector never delays the return to Home.
+    var personalRecords: [PersonalRecord] = []
+
+    init(workout: Workout) {
+        self.id = workout.id
+        self.workout = workout
+    }
+}

--- a/ClaudeLifter/Views/History/HistoryListView.swift
+++ b/ClaudeLifter/Views/History/HistoryListView.swift
@@ -34,11 +34,20 @@ struct HistoryListView: View {
             Text("This cannot be undone.")
         }
         .task {
+            // Construct once, but reload on every appearance (#132). Loading
+            // inside the `vm == nil` guard meant the fetch ran once per launch,
+            // so anyone who opened History early in a session saw a list frozen
+            // at that moment — including after finishing a workout, which is
+            // the case that actually matters.
             if vm == nil, let deps {
                 vm = HistoryViewModel(workoutRepository: deps.workoutRepository)
                 calendarVM = CalendarViewModel(workoutRepository: deps.workoutRepository)
-                await vm?.loadWorkouts()
             }
+            await vm?.loadWorkouts()
+            // The heatmap has its own `.task`, but it only covers the case
+            // where that subview is on screen; reload here so the calendar
+            // cannot go stale independently of the list.
+            await calendarVM?.loadMonth()
         }
     }
 

--- a/ClaudeLifter/Views/History/WorkoutHistoryRowView.swift
+++ b/ClaudeLifter/Views/History/WorkoutHistoryRowView.swift
@@ -27,5 +27,10 @@ struct WorkoutHistoryRowView: View {
             }
         }
         .padding(.vertical, 2)
+        // One addressable element per logged workout. Combining also gives
+        // VoiceOver the whole row as a single announcement instead of five
+        // disconnected fragments.
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("historyRow_\(workout.id)")
     }
 }

--- a/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
+++ b/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
@@ -59,7 +59,6 @@ struct ActiveWorkoutView: View {
     var onDismiss: (() -> Void)? = nil
 
     @State private var restSession: RestTimerSession?
-    @State private var showSummary = false
     @State private var showExercisePicker = false
     @State private var showCancelDialog = false
     @FocusState private var focusedField: SetEntryFieldID?
@@ -79,7 +78,6 @@ struct ActiveWorkoutView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar { toolbarContent(scrollProxy: scrollProxy) }
                 .task { await vm.startWorkout() }
-                .sheet(isPresented: $showSummary) { summarySheet }
                 .sheet(isPresented: $showExercisePicker) { exercisePicker }
                 .confirmationDialog(
                     "Exit workout?",
@@ -88,9 +86,6 @@ struct ActiveWorkoutView: View {
                     exitDialogActions
                 } message: {
                     exitDialogMessage
-                }
-                .onChange(of: vm.isFinished) { _, finished in
-                    if finished { showSummary = true }
                 }
                 .onChange(of: orderedFields) { _, fields in
                     guard let focusedField else { return }
@@ -258,10 +253,16 @@ struct ActiveWorkoutView: View {
             .accessibilityIdentifier("cancelWorkout")
         }
         ToolbarItem(placement: .primaryAction) {
-            Button("Finish") {
+            Button {
                 finishWorkoutAfterFlushingField()
+            } label: {
+                if vm.isFinishing {
+                    ProgressView()
+                } else {
+                    Text("Finish")
+                }
             }
-            .disabled(!vm.hasCompletedSets)
+            .disabled(!vm.hasCompletedSets || vm.isFinishing)
             .foregroundStyle(BrandTheme.terracotta)
             .accessibilityIdentifier("finishWorkout")
         }
@@ -291,22 +292,6 @@ struct ActiveWorkoutView: View {
             Spacer()
             Button("Done") {
                 focusedField = nil
-            }
-        }
-    }
-
-    private var summarySheet: some View {
-        Group {
-            if let workout = vm.workout {
-                WorkoutSummaryView(
-                    workout: workout,
-                    personalRecords: vm.detectedPRs
-                ) {
-                    restSession?.cancel()
-                    showSummary = false
-                    appState.endWorkout()
-                    onDismiss?()
-                }
             }
         }
     }
@@ -354,6 +339,15 @@ struct ActiveWorkoutView: View {
             restSession?.cancel()
             Task {
                 await vm.finishWorkout()
+                // Leave the workout the moment the critical save has committed.
+                // Deliberately not tied to the summary: the receipt is handed to
+                // AppState and presented over Home, so dismissing it — Done,
+                // swipe, or never appearing at all — cannot strand the user in a
+                // workout that is already saved (#123).
+                if case .finished(let summary) = vm.completionState {
+                    appState.endWorkout(showing: summary)
+                    onDismiss?()
+                }
             }
         }
     }

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     @State private var path = NavigationPath()
 
     var body: some View {
+        @Bindable var appState = appState
         NavigationStack(path: $path) {
             Group {
                 if let activeVM = appState.activeWorkoutVM {
@@ -24,6 +25,18 @@ struct HomeView: View {
                 }
             }
             .navigationTitle("ClaudeLifter")
+        }
+        // The completion summary is presented here, not inside
+        // ActiveWorkoutView, because ending the workout tears that view down.
+        // Presenting it over Home means the workout is already safely closed by
+        // the time this appears, so any way of dismissing it is harmless (#123).
+        .sheet(item: $appState.completedWorkoutSummary) { summary in
+            WorkoutSummaryView(
+                workout: summary.workout,
+                personalRecords: summary.personalRecords
+            ) {
+                appState.completedWorkoutSummary = nil
+            }
         }
         .task {
             guard let deps else { return }

--- a/ClaudeLifterTests/E2ETests/WorkoutFlowE2ETests.swift
+++ b/ClaudeLifterTests/E2ETests/WorkoutFlowE2ETests.swift
@@ -243,6 +243,11 @@ struct WorkoutFlowE2ETests {
         await vm.finishWorkout()
         #expect(vm.isFinished)
 
+        // Template bookkeeping is post-commit (#125) — it runs after the
+        // workout is durably saved, so it needs an explicit join rather than
+        // relying on the next await happening to let it through.
+        await vm.awaitPostCommitWork()
+
         // finishWorkout() should have incremented timesPerformed automatically
         let updatedTemplates = try await templateRepo.fetchAll()
         let updatedTemplate = try #require(updatedTemplates.first { $0.id == template.id })
@@ -321,6 +326,7 @@ struct WorkoutFlowE2ETests {
             for set in exercise.sets { vm1.completeSet(set) }
         }
         await vm1.finishWorkout()
+        await vm1.awaitPostCommitWork()
         #expect(template.timesPerformed == 1)
 
         // Second workout
@@ -336,6 +342,7 @@ struct WorkoutFlowE2ETests {
             for set in exercise.sets { vm2.completeSet(set) }
         }
         await vm2.finishWorkout()
+        await vm2.awaitPostCommitWork()
         #expect(template.timesPerformed == 2)
         await vm1.awaitPendingSave()
         await vm2.awaitPendingSave()
@@ -370,6 +377,7 @@ struct WorkoutFlowE2ETests {
             for set in exercise.sets { vm.completeSet(set) }
         }
         await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
 
         // Fetch fresh from repository
         let allTemplates = try await templateRepo.fetchAll()
@@ -439,10 +447,22 @@ struct WorkoutFlowE2ETests {
         let workoutRepo = SwiftDataWorkoutRepository(context: context)
 
         let calendar = Calendar.current
-        let today = Date()
-        guard let daysAgo2 = calendar.date(byAdding: .day, value: -2, to: today),
-              let daysAgo5 = calendar.date(byAdding: .day, value: -5, to: today),
-              let daysAgo10 = calendar.date(byAdding: .day, value: -10, to: today) else {
+
+        // Anchor the fixture to fixed days *of the current month* rather than
+        // subtracting from `Date()` (#131). `loadMonth()` fetches only
+        // `currentMonth`, so a date like `today - 10` silently lands in the
+        // previous month whenever the run happens before the 11th — the
+        // workout then never appears in `workoutDays` and the assertion reads
+        // `nil`. Every month has at least 28 days, so days 2/5/10 are always
+        // in range. `buildIntensityMap` keys off `startedAt` and does not
+        // exclude days later than today, so this holds whatever the date is.
+        let monthStart = calendar.date(
+            from: calendar.dateComponents([.year, .month], from: Date())
+        )
+        guard let monthStart,
+              let daysAgo10 = calendar.date(byAdding: DateComponents(day: 1, hour: 12), to: monthStart),
+              let daysAgo5 = calendar.date(byAdding: DateComponents(day: 4, hour: 12), to: monthStart),
+              let daysAgo2 = calendar.date(byAdding: DateComponents(day: 9, hour: 12), to: monthStart) else {
             throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create dates"])
         }
 
@@ -947,6 +967,10 @@ struct WorkoutFlowE2ETests {
         await vm.finishWorkout()
         #expect(vm.isFinished)
         #expect(workout.completedAt != nil)
+
+        // PR detection is post-commit (#125), so that a slow detector cannot
+        // hold the user inside a workout that is already saved.
+        await vm.awaitPostCommitWork()
 
         // PRs should have been detected
         #expect(!vm.detectedPRs.isEmpty)

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -462,6 +462,240 @@ struct ActiveWorkoutViewModelTests {
         #expect(vm.isFinished == true)
         #expect(workoutRepo.deletedWorkouts.isEmpty, "Should NOT delete a workout with completed sets")
     }
+
+    // MARK: - #124: Finish is idempotent
+    //
+    // The user-visible bug (#123) is that a swipe-dismissed summary leaves the
+    // workout onscreen. What makes that state *corrupting* rather than merely
+    // annoying is this: every further Finish tap re-entered finishWorkout(),
+    // which found the workout still non-nil and re-ran the whole path.
+
+    /// A started workout with one completed set, ready to finish.
+    ///
+    /// Holds the `ModelContainer` as well as the objects under test. Dropping it
+    /// deallocates the container, and on iOS 26.5 the next touch of a model
+    /// object then traps with "This model instance was destroyed by calling
+    /// ModelContext.reset" — a crash, not a test failure, so it presents as an
+    /// unrelated mess rather than a lifetime bug.
+    private struct FinishableWorkout {
+        let container: ModelContainer
+        let vm: ActiveWorkoutViewModel
+        let template: WorkoutTemplate
+    }
+
+    /// Builds a started workout with exactly one completed set, ready to finish.
+    private func makeFinishableWorkout(
+        workoutRepository: MockWorkoutRepository = MockWorkoutRepository(),
+        templateRepository: MockTemplateRepository? = nil,
+        prDetectionService: MockPRDetectionService? = nil
+    ) async throws -> FinishableWorkout {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: workoutRepository,
+            autoFillService: MockAutoFillService(),
+            templateRepository: templateRepository,
+            prDetectionService: prDetectionService
+        )
+        await vm.startWorkout()
+        let set = try #require(vm.workout?.exercises.first?.sets.first)
+        vm.completeSet(set)
+        await vm.awaitPendingSave()
+        return FinishableWorkout(container: container, vm: vm, template: template)
+    }
+
+    @Test("a second Finish tap does not save the workout again")
+    func repeatedFinishSavesOnce() async throws {
+        let repo = MockWorkoutRepository()
+        let fixture = try await makeFinishableWorkout(workoutRepository: repo)
+        let vm = fixture.vm
+
+        await vm.finishWorkout()
+        let savesAfterFirstFinish = repo.saveCallCount
+
+        await vm.finishWorkout()
+        await vm.finishWorkout()
+
+        #expect(
+            repo.saveCallCount == savesAfterFirstFinish,
+            "Finishing an already-finished workout must not save it again"
+        )
+    }
+
+    @Test("a second Finish tap does not re-stamp completedAt")
+    func repeatedFinishKeepsOriginalCompletedAt() async throws {
+        let fixture = try await makeFinishableWorkout()
+        let vm = fixture.vm
+
+        await vm.finishWorkout()
+        let firstCompletedAt = try #require(vm.workout?.completedAt)
+
+        // A real user tapping again is separated from the first tap in time;
+        // without a guard the second tap silently moves the recorded finish
+        // time to "whenever they last jabbed the button".
+        try await Task.sleep(for: .milliseconds(20))
+        await vm.finishWorkout()
+
+        #expect(
+            vm.workout?.completedAt == firstCompletedAt,
+            "completedAt is the moment the workout ended, not the moment of the last tap"
+        )
+    }
+
+    @Test("a second Finish tap does not re-run PR detection")
+    func repeatedFinishDetectsPRsOnce() async throws {
+        let prService = MockPRDetectionService()
+        let fixture = try await makeFinishableWorkout(prDetectionService: prService)
+        let vm = fixture.vm
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        #expect(
+            prService.detectCallCount == 1,
+            "Re-running detection on the same workout can announce duplicate PRs"
+        )
+    }
+
+    @Test("a second Finish tap does not inflate template timesPerformed")
+    func repeatedFinishCountsTemplateUseOnce() async throws {
+        let templateRepo = MockTemplateRepository()
+        let fixture = try await makeFinishableWorkout(
+            templateRepository: templateRepo
+        )
+        let vm = fixture.vm
+        let template = fixture.template
+        let before = template.timesPerformed
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        #expect(template.timesPerformed == before + 1)
+    }
+
+    // MARK: - #125: post-commit work cannot trap a saved workout
+
+    @Test("a failing PR service still leaves the workout finished")
+    func failingPRDetectionStillFinishes() async throws {
+        let prService = MockPRDetectionService()
+        prService.errorToThrow = NSError(domain: "PR", code: 1)
+        let repo = MockWorkoutRepository()
+        let fixture = try await makeFinishableWorkout(
+            workoutRepository: repo,
+            prDetectionService: prService
+        )
+        let vm = fixture.vm
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        #expect(vm.isFinished, "PR detection is post-commit — it cannot reopen the workout")
+        #expect(vm.workout?.completedAt != nil)
+        #expect(repo.deletedWorkouts.isEmpty)
+    }
+
+    @Test("a failing template save still leaves the workout finished")
+    func failingTemplateSaveStillFinishes() async throws {
+        let templateRepo = MockTemplateRepository()
+        templateRepo.errorToThrow = NSError(domain: "Template", code: 1)
+        let fixture = try await makeFinishableWorkout(
+            templateRepository: templateRepo
+        )
+        let vm = fixture.vm
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        #expect(vm.isFinished, "Template bookkeeping is post-commit — it cannot reopen the workout")
+        #expect(vm.workout?.completedAt != nil)
+    }
+
+    @Test("post-commit failures are reported rather than swallowed")
+    func postCommitFailuresAreSurfaced() async throws {
+        let prService = MockPRDetectionService()
+        prService.errorToThrow = NSError(domain: "PR", code: 1)
+        let fixture = try await makeFinishableWorkout(prDetectionService: prService)
+        let vm = fixture.vm
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        // The old code used `try?` here, so a broken PR service was invisible.
+        #expect(!vm.postCommitWarnings.isEmpty)
+    }
+
+    // MARK: - #123 / #125: a failed critical save is recoverable
+
+    @Test("a failed critical save keeps the workout intact and retryable")
+    func failedCriticalSaveIsRetryable() async throws {
+        let repo = MockWorkoutRepository()
+        let fixture = try await makeFinishableWorkout(workoutRepository: repo)
+        let vm = fixture.vm
+
+        repo.errorToThrow = NSError(domain: "Save", code: 1)
+        await vm.finishWorkout()
+
+        #expect(!vm.isFinished, "A workout that failed to save must not be reported as finished")
+        #expect(vm.workout != nil, "The user's logged sets must survive a failed save")
+        #expect(vm.errorMessage != nil)
+
+        // Retry succeeds once the underlying failure clears.
+        repo.errorToThrow = nil
+        await vm.finishWorkout()
+
+        #expect(vm.isFinished)
+        #expect(vm.workout?.completedAt != nil)
+    }
+
+    // MARK: - #69 regression: a discarded session has no summary to show
+
+    @Test("a discarded empty workout finishes without a summary payload")
+    func discardedWorkoutHasNoSummary() async throws {
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService()
+        )
+        await vm.startWorkout()
+
+        await vm.finishWorkout()
+
+        // Previously this set a one-way flag that presented a summary sheet
+        // built from a now-nil workout — an empty sheet with no Done button,
+        // and therefore no way back out.
+        #expect(vm.isFinished, "The UI must still leave the workout")
+        #expect(vm.completionSummary == nil, "There is nothing to show a receipt for")
+    }
+
+    // MARK: - #121: a debounced draft save must not outlive completion
+
+    @Test("an in-flight draft save cannot overwrite the finished workout")
+    func pendingDraftSaveCannotClobberCompletion() async throws {
+        let repo = MockWorkoutRepository()
+        let fixture = try await makeFinishableWorkout(workoutRepository: repo)
+        let vm = fixture.vm
+        let set = try #require(vm.workout?.exercises.first?.sets.first)
+
+        // Edit and immediately finish, without awaiting the debounced save —
+        // exactly what "type 45, tap Finish" does.
+        vm.updateSetReps(set, reps: 12)
+        await vm.finishWorkout()
+        await vm.awaitPendingSave()
+
+        #expect(vm.isFinished)
+        #expect(vm.workout?.completedAt != nil, "A late draft save must not clear completion")
+        #expect(set.reps == 12, "The last edit must survive into the saved workout")
+    }
 }
 
 extension ActiveWorkoutViewModelTests {

--- a/ClaudeLifterUITests/Helpers/UITestHelpers.swift
+++ b/ClaudeLifterUITests/Helpers/UITestHelpers.swift
@@ -18,6 +18,33 @@ extension XCUIApplication {
     }
 }
 
+extension XCUIApplication {
+    /// Whether the software keyboard is on screen.
+    ///
+    /// `keyboards.count > 0` is **not** reliable. On Evan's iPhone the keyboard
+    /// is exposed as an `Other` element with identifier `"keyboard"` rather than
+    /// as a `Keyboard`-type element, so `keyboards` is empty while `keys`
+    /// returns all twelve of a decimal pad's keys and the text field reports
+    /// keyboard focus. The device has a third-party keyboard installed (a
+    /// "Next keyboard" button is present), which is what differs from the
+    /// simulator. Four `KeyboardDismissalTests` failed permanently on device
+    /// for this reason alone — the app was behaving correctly throughout.
+    ///
+    /// Checking for keys works on both device and simulator.
+    var isSoftwareKeyboardVisible: Bool {
+        keyboards.count > 0 || keys.count > 0
+    }
+
+    /// Waits for the keyboard to disappear, since dismissal is animated.
+    func waitForKeyboardToDisappear(timeout: TimeInterval = 5) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while isSoftwareKeyboardVisible, Date() < deadline {
+            _ = keys.firstMatch.waitForExistence(timeout: 0.2)
+        }
+        return !isSoftwareKeyboardVisible
+    }
+}
+
 extension XCUIElement {
     func clearAndTypeText(_ text: String) {
         guard let currentValue = value as? String, !currentValue.isEmpty else {

--- a/ClaudeLifterUITests/HistoryCalendarTests.swift
+++ b/ClaudeLifterUITests/HistoryCalendarTests.swift
@@ -54,4 +54,48 @@ final class HistoryCalendarTests: XCTestCase {
         // Yesterday's date should appear somewhere in the list
         XCTAssertTrue(app.scrollViews.firstMatch.waitForExistence(timeout: 5))
     }
+
+    /// Regression test for #132.
+    ///
+    /// `HistoryListView` built its view models and loaded them inside the same
+    /// `if vm == nil` guard, so `loadWorkouts()` ran once per launch. Anyone who
+    /// opened History early in a session then saw a list frozen at that moment —
+    /// including after finishing a workout, which is the case that matters.
+    func testHistoryRefreshesAfterFinishingAWorkout() throws {
+        let historyRows = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier BEGINSWITH 'historyRow_'")
+        )
+
+        // Visit History first, so its view models are already constructed.
+        app.tabBars.buttons["History"].tap()
+        XCTAssertTrue(historyRows.firstMatch.waitForExistence(timeout: 5))
+        let rowsBefore = historyRows.count
+
+        // Log and finish a workout.
+        app.tabBars.buttons["Home"].tap()
+        app.startWorkoutFromTemplate("Push Day")
+        let completeButton = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'completeSet_'")
+        ).element(boundBy: 0)
+        XCTAssertTrue(completeButton.waitForExistence(timeout: 5))
+        completeButton.tap()
+        let finish = app.buttons["finishWorkout"]
+        XCTAssertTrue(finish.waitForExistence(timeout: 5))
+        finish.tap()
+        XCTAssertTrue(app.buttons["summaryDone"].waitForExistence(timeout: 5))
+        app.buttons["summaryDone"].tap()
+
+        // Returning to History must show it, without a pull-to-refresh.
+        app.tabBars.buttons["History"].tap()
+        XCTAssertTrue(historyRows.firstMatch.waitForExistence(timeout: 5))
+
+        let deadline = Date().addingTimeInterval(5)
+        while historyRows.count <= rowsBefore, Date() < deadline {
+            _ = historyRows.firstMatch.waitForExistence(timeout: 0.5)
+        }
+        XCTAssertEqual(
+            historyRows.count, rowsBefore + 1,
+            "History must reload on revisit, not serve a list cached at first appearance"
+        )
+    }
 }

--- a/ClaudeLifterUITests/KeyboardDismissalTests.swift
+++ b/ClaudeLifterUITests/KeyboardDismissalTests.swift
@@ -20,11 +20,11 @@ final class KeyboardDismissalTests: XCTestCase {
         ).element(boundBy: 0)
         XCTAssertTrue(weightField.waitForExistence(timeout: 5))
         weightField.tap()
-        XCTAssertTrue(app.keyboards.count > 0)
+        XCTAssertTrue(app.isSoftwareKeyboardVisible)
         let doneButton = app.toolbars.buttons.matching(identifier: "Done").firstMatch
         XCTAssertEqual(app.toolbars.buttons.matching(identifier: "Done").count, 1)
         doneButton.tap()
-        XCTAssertEqual(app.keyboards.count, 0)
+        XCTAssertTrue(app.waitForKeyboardToDisappear())
     }
 
     func testEmptyWeightFieldDoesNotPrefixTypedValueWithZero() throws {
@@ -44,7 +44,7 @@ final class KeyboardDismissalTests: XCTestCase {
         app.tabBars.buttons["Coach"].tap()
         XCTAssertTrue(app.textFields["chatMessageInput"].waitForExistence(timeout: 5))
         app.textFields["chatMessageInput"].tap()
-        XCTAssertTrue(app.keyboards.count > 0)
+        XCTAssertTrue(app.isSoftwareKeyboardVisible)
         app.swipeDown()
         XCTAssertTrue(app.tabBars.firstMatch.exists)
     }
@@ -55,7 +55,7 @@ final class KeyboardDismissalTests: XCTestCase {
         app.navigationBars["Exercises"].buttons.firstMatch.tap()
         XCTAssertTrue(app.textFields["exerciseName"].waitForExistence(timeout: 5))
         app.textFields["exerciseName"].tap()
-        XCTAssertTrue(app.keyboards.count > 0)
+        XCTAssertTrue(app.isSoftwareKeyboardVisible)
         app.swipeDown()
         XCTAssertTrue(app.navigationBars["New Exercise"].waitForExistence(timeout: 5))
     }
@@ -65,7 +65,7 @@ final class KeyboardDismissalTests: XCTestCase {
         app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'New Template'")).firstMatch.tap()
         XCTAssertTrue(app.textFields["templateName"].waitForExistence(timeout: 5))
         app.textFields["templateName"].tap()
-        XCTAssertTrue(app.keyboards.count > 0)
+        XCTAssertTrue(app.isSoftwareKeyboardVisible)
         app.swipeDown()
         XCTAssertTrue(app.tabBars.firstMatch.exists || app.navigationBars.firstMatch.exists)
     }

--- a/ClaudeLifterUITests/WorkoutFlowTests.swift
+++ b/ClaudeLifterUITests/WorkoutFlowTests.swift
@@ -130,4 +130,84 @@ final class WorkoutFlowTests: XCTestCase {
         app.buttons["summaryDone"].tap()
         XCTAssertTrue(app.navigationBars["ClaudeLifter"].waitForExistence(timeout: 5))
     }
+
+    /// Regression test for #123.
+    ///
+    /// The summary sheet has always been freely swipe-dismissable, but only its
+    /// Done button ended the workout. Swiping it away therefore left the user
+    /// inside a workout that was already saved and synced — and because the old
+    /// `isFinished` flag was one-way, no later Finish tap could bring the sheet
+    /// back. This is the exact gesture that caused the reported bug.
+    func testSwipingTheSummaryAwayStillLeavesTheWorkout() throws {
+        app.startWorkoutFromTemplate("Push Day")
+        let completeButton = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'completeSet_'")
+        ).element(boundBy: 0)
+        XCTAssertTrue(completeButton.waitForExistence(timeout: 5))
+        completeButton.tap()
+
+        let finish = app.buttons["finishWorkout"]
+        XCTAssertTrue(finish.waitForExistence(timeout: 5))
+        finish.tap()
+        XCTAssertTrue(app.staticTexts["Workout Complete!"].waitForExistence(timeout: 5))
+
+        // Drag the sheet down from near its top rather than tapping Done. A
+        // plain swipeDown() would scroll the summary's ScrollView instead.
+        let sheetTop = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+        let offscreen = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.98))
+        sheetTop.press(forDuration: 0.1, thenDragTo: offscreen)
+
+        XCTAssertTrue(
+            app.navigationBars["ClaudeLifter"].waitForExistence(timeout: 5),
+            "Home must be underneath once the workout has been saved"
+        )
+        XCTAssertFalse(
+            app.buttons["finishWorkout"].exists,
+            "Swipe-dismissing the summary must not strand the user in a saved workout"
+        )
+    }
+
+    /// Regression test for #124. Repeated taps used to re-enter the finish path,
+    /// re-stamping completedAt and re-running PR detection each time.
+    func testRapidRepeatedFinishTapsProduceOneWorkout() throws {
+        app.startWorkoutFromTemplate("Push Day")
+        let completeButton = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'completeSet_'")
+        ).element(boundBy: 0)
+        XCTAssertTrue(completeButton.waitForExistence(timeout: 5))
+        completeButton.tap()
+
+        let finish = app.buttons["finishWorkout"]
+        XCTAssertTrue(finish.waitForExistence(timeout: 5))
+        finish.tap()
+        if finish.exists { finish.tap() }
+        if finish.exists { finish.tap() }
+
+        XCTAssertTrue(app.buttons["summaryDone"].waitForExistence(timeout: 5))
+        app.buttons["summaryDone"].tap()
+        XCTAssertTrue(app.navigationBars["ClaudeLifter"].waitForExistence(timeout: 5))
+
+        // Three taps must produce exactly one session dated today.
+        //
+        // Counted by row identifier, not by matching "Push Day" text: TabView
+        // keeps the Home tab alive and its template picker renders a "Push Day"
+        // row too. Filtered to today because the suite launches with
+        // -seedTestData and history already contains older sessions. And
+        // History is visited only once, because HistoryListView loads its data
+        // behind an `if vm == nil` guard and serves a stale list on any later
+        // visit (filed separately).
+        app.tabBars.buttons["History"].tap()
+        let historyRows = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier BEGINSWITH 'historyRow_'")
+        )
+        XCTAssertTrue(historyRows.firstMatch.waitForExistence(timeout: 5))
+
+        let today = Date.now.formatted(date: .abbreviated, time: .omitted)
+        let rows = (0..<historyRows.count).map { historyRows.element(boundBy: $0).label }
+        let todaysRows = rows.filter { $0.contains(today) }
+        XCTAssertEqual(
+            todaysRows.count, 1,
+            "Repeated Finish taps must not produce duplicate history entries. Rows: \(rows)"
+        )
+    }
 }

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,32 +1,62 @@
-# HANDOFF — workout logging usability sprint
+# HANDOFF — Finish reliability (Phase 1)
 
-Updated 2026-07-29. Nothing is in flight. **5 commits are local and unpushed.**
+Updated 2026-08-07. The usability sprint's 6 commits are **pushed**. Phase 1 of
+`WORKOUT_RELIABILITY_AND_TEMPLATE_PLAN.md` is on `fix/finish-reliability`.
 
-## Push this first
+## The test baseline — read this before judging any run
 
-```
-9e2213c Rebuild set entry: one Done button, empty fields, labelled columns
-c5b98e4 Clear the search query instead of tapping Cancel (#96)
-e73c8fe Stop three failures from reporting success (#86)
-03fdd10 Wire up PR detection, and normalise stats to kilograms
-07aa630 Fix #96: query searchFields, and actually assert filtering
-```
+**`xcodebuild test` exits 0 on `fix/finish-reliability`:** 681 Swift Testing
+(671 + 10 new), zero XCUITest failures, on iPhone 13 Pro Max / iOS 26.5.
 
-`#96`, `#84` and `#89` were closed manually, because the `Closes` trailers
-cannot fire until these are pushed.
+The previous note that "a non-zero exit is now a real regression" was **wrong
+for the first ~10 days of any month**, and cost a full investigation on
+2026-08-07. `calendarHeatmap` seeded workouts at `today - 10 days` while
+`CalendarViewModel.loadMonth()` fetches only the *current* month, so the light
+workout fell into the previous month and vanished. The 2026-07-29 green run
+happened on the 29th, which is why nobody saw it. Fixed in #131; the fixture is
+now anchored to fixed days of the current month.
 
-## The test baseline changed — read this before judging any run
-
-**`xcodebuild test` now exits 0.** 671 Swift Testing pass, zero XCUITest
-failures, verified on iPhone 13 Pro Max / iOS 26.5.
-
-This supersedes the long-standing note that exit 65 is expected. #96 is fixed,
-so **a non-zero exit is now a real regression** — do not dismiss one as "the
-known four". The other traps still hold: never pipe `xcodebuild` through `tail`
-without `set -o pipefail`, and remember XCUITest failures print
+With that fixed the claim finally holds: **a non-zero exit is a real
+regression.** The other traps still apply: never pipe `xcodebuild` through
+`tail` without `set -o pipefail` (a background wrapper reported "exit code 0"
+while xcodebuild had returned 65), and XCUITest failures print
 `Test Case '-[...]' failed`, not Swift Testing's `✘`.
 
-## What shipped
+**Device runs need the phone unlocked.** A locked screen produces
+`Waiting for the destination to become ready` and `** BUILD INTERRUPTED **`
+before the build even starts — it looks like a toolchain problem and isn't.
+The full device UI suite takes over 10 minutes; run it in the background.
+
+## What Phase 1 changed (#123, #124, #125, and #121's ordering half)
+
+`isFinished` was a **stored one-way Bool** that nothing ever reset, and an
+`onChange` on it was the *only* trigger for the summary sheet. `endWorkout()`
+lived solely in that sheet's Done button, and the sheet had no
+`interactiveDismissDisabled`. Swipe it away and you stayed inside a workout that
+was already saved and synced, with a Finish button that could never present
+anything again — while each further tap silently re-stamped `completedAt`,
+re-saved, re-bumped `timesPerformed` and re-ran PR detection.
+
+The circle was structural: `endWorkout()` nils `activeWorkoutVM`, tearing down
+the view that owned the sheet, so presenting the summary *required* postponing
+the exit. The fix hands the receipt to `AppState` as a
+`WorkoutCompletionSummary` presented over Home, making the two independent.
+
+`isFinished` remains as a **derived** property, so its nine existing assertions
+keep their meaning. The hazard was the stored one-way flag doubling as the sole
+presentation trigger, not the name.
+
+Post-commit work (`timesPerformed`, PR detection) now runs in a tracked
+`postCommitTask`; join it with `awaitPostCommitWork()`, the same idiom as
+`awaitPendingSave()`. Several E2E tests were passing only through incidental
+main-actor ordering and now join explicitly.
+
+**#132 was found and deliberately not fixed:** `HistoryListView` loads behind
+`if vm == nil`, so `loadWorkouts()` runs once per launch and the History tab
+serves a stale list — finish a workout and it's absent until you pull to
+refresh. Different surface; would have widened the PR past Phase 1.
+
+## What shipped previously
 
 Installed to Evan's iPhone 2026-07-29 ~21:30, from `9e2213c`.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -27,14 +27,34 @@ while xcodebuild had returned 65), and XCUITest failures print
 before the build even starts — it looks like a toolchain problem and isn't.
 The full device UI suite takes over 10 minutes; run it in the background.
 
-**Four `KeyboardDismissalTests` fail on the device and pass on the simulator.**
-Verified pre-existing on 2026-08-07: the identical four fail on plain `main`.
-They are the four that assert `app.keyboards.count > 0` (Workout, Chat,
-Template Editor, Exercise Creation). The two that merely *type* into a field
-pass. That split is the signature of a **connected hardware keyboard** — text
-entry still works, but iOS never raises the on-screen keyboard, so the
-assertion is unsatisfiable. Unpair the keyboard before judging a device run,
-and do not attribute these to your change without checking `main` first.
+**`app.keyboards` is empty on Evan's iPhone even with the keyboard onscreen.**
+Resolved 2026-08-07; four `KeyboardDismissalTests` had been failing on device
+and passing on the simulator. The app was correct the whole time — the query
+was wrong.
+
+A diagnostic dump with a weight field focused showed:
+
+```
+keyboards.count = 0     keys.count = 12     fieldHasFocus = true
+Other, identifier: 'keyboard'      <- container is type Other, not Keyboard
+    Key '1' … Key 'Delete'         <- a full decimal pad, plainly present
+Button, label: 'Next keyboard', value: English (US)
+```
+
+The keyboard is exposed as an **`Other` element with identifier `"keyboard"`**
+rather than as a `Keyboard`-type element, so `app.keyboards.count > 0` is
+unsatisfiable while `app.keys` returns everything. The `Next keyboard` button
+shows a third-party keyboard is installed, which is what differs from the
+simulator.
+
+Use `app.isSoftwareKeyboardVisible` and `app.waitForKeyboardToDisappear()` in
+`UITestHelpers.swift`, never `app.keyboards.count`, or these tests will fail on
+device forever.
+
+Two earlier explanations were asserted and were both wrong — a hardware
+keyboard (nothing is paired) and SwiftKey suppressing the keyboard (the system
+decimal pad renders fine). Neither survived a look at the actual hierarchy.
+**Dump the hierarchy before theorising about a UI test failure.**
 
 ## What Phase 1 changed (#123, #124, #125, and #121's ordering half)
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -27,6 +27,15 @@ while xcodebuild had returned 65), and XCUITest failures print
 before the build even starts — it looks like a toolchain problem and isn't.
 The full device UI suite takes over 10 minutes; run it in the background.
 
+**Four `KeyboardDismissalTests` fail on the device and pass on the simulator.**
+Verified pre-existing on 2026-08-07: the identical four fail on plain `main`.
+They are the four that assert `app.keyboards.count > 0` (Workout, Chat,
+Template Editor, Exercise Creation). The two that merely *type* into a field
+pass. That split is the signature of a **connected hardware keyboard** — text
+entry still works, but iOS never raises the on-screen keyboard, so the
+assertion is unsatisfiable. Unpair the keyboard before judging a device run,
+and do not attribute these to your change without checking `main` first.
+
 ## What Phase 1 changed (#123, #124, #125, and #121's ordering half)
 
 `isFinished` was a **stored one-way Bool** that nothing ever reset, and an


### PR DESCRIPTION
Phase 1 of `WORKOUT_RELIABILITY_AND_TEMPLATE_PLAN.md`.

## The bug

Finishing a workout could leave you trapped inside it. Three things in the source combined:

1. `ActiveWorkoutViewModel.swift:9` — `isFinished` was a **stored one-way Bool**, set true in two places and reset nowhere in the codebase.
2. `ActiveWorkoutView.swift:92` — an `onChange` on that Bool was the **only** trigger for the summary sheet, so it could fire once per app run.
3. `ActiveWorkoutView.swift:307` — `appState.endWorkout()` was called **only** from the summary's Done button, and `WorkoutSummaryView` had no `interactiveDismissDisabled`.

Swipe the summary away instead of tapping Done and `endWorkout()` never ran. The workout stayed onscreen — already saved, already synced — and every later Finish tap re-entered `finishWorkout()`, **re-stamping `completedAt`, saving again, bumping `timesPerformed` again and re-running PR detection**, all with nothing visible on screen.

This explains why the reported session (`Upper A`, `F4A5F7C1…`) looked perfectly healthy in the cloud mirror. It was never a persistence problem.

## Why the fix is structural, not a flag reset

`endWorkout()` nils `activeWorkoutVM`, which tears down the very view that owned the summary sheet. So presenting the summary *required* postponing the exit — that coupling is what created the trap.

The receipt now belongs to `AppState` as a `WorkoutCompletionSummary`, presented by `HomeView`. Ending the workout and showing the summary become independent: the workout closes when its save commits, and the summary can be dismissed any way at all — Done, swipe, or never appearing — without stranding anyone.

`isFinished` survives as a **derived** property, so its nine existing assertions keep their meaning unchanged. The hazard was a stored one-way flag doubling as the sole presentation trigger, not the name.

## Also in scope

- **#124** — repeated taps join the in-flight attempt via a tracked `finishTask`; `completedAt` is stamped once per successful attempt.
- **#125** — template bookkeeping and PR detection move into a tracked `postCommitTask` after the critical save, so a slow or broken detector cannot delay the return to Home. Their failures land in `postCommitWarnings` instead of being swallowed by `try?`.
- **#121 (ordering half)** — the debounced draft save is cancelled before the authoritative save. `saveDraft()` deletes sessions it considers empty, so letting it land post-completion was a live hazard.
- A discarded empty session (#69) no longer routes through a summary sheet that rendered an empty `Group` with no Done button — a second strand, unreachable from the UI today but reachable by any non-UI caller.
- Finish shows a `ProgressView` and is disabled while saving.

## Tests

10 new unit tests. Four were written against the **unmodified** `finishWorkout()` and genuinely failed first:

```
✘ (repo.saveCallCount → 5) == (savesAfterFirstFinish → 3)
✘ (prService.detectCallCount → 2) == 1
✘ completedAt re-stamped on the second tap
```

Two new UI tests, including `testSwipingTheSummaryAwayStillLeavesTheWorkout` — the exact gesture that caused the bug, now executable.

Five E2E assertions were passing only through incidental main-actor ordering; they now join `awaitPostCommitWork()` explicitly.

## Unrelated defects found

- **#131 (fixed here)** — `calendarHeatmap` seeded workouts at `today - 10 days` while `CalendarViewModel.loadMonth()` fetches only the *current* month, so it failed on untouched `main` for the first ~10 days of **every month**. The 2026-07-29 green baseline was recorded on the 29th. Fixed because the suite had to be trustworthy to judge this work — and `HANDOFF.md`'s "a non-zero exit is now a real regression" was false until it was.
- **#132 (fixed here, at Evan's request)** — `HistoryListView` built its view models and loaded them inside the same `if vm == nil` guard, so `loadWorkouts()` ran once per launch. Finish a workout, tap History, and it was absent until you pulled to refresh. Construct once, load on every appearance. The regression test also settles that `.task` *does* re-fire on tab switch, so the guard was the entire problem.
- **Device keyboard tests (fixed here)** — four `KeyboardDismissalTests` failed on device and passed on the simulator. Not a product bug: a hierarchy dump with a field focused shows `keys.count = 12`, the field holding keyboard focus, and the keyboard exposed as `Other, identifier: 'keyboard'` rather than as a `Keyboard` element — so `app.keyboards.count > 0` can never be true there. They now ask for keys via `isSoftwareKeyboardVisible`.

## Verification

| Run | Result |
|---|---|
| Full suite, iPhone 13 Pro Max simulator / iOS 26.5 | **exit 0** — 681 unit, 68 UI, zero failures |
| `KeyboardDismissalTests` + `HistoryCalendarTests`, Evan's iPhone | **13/13 pass**, incl. the four that previously failed |
| `WorkoutFlowTests`, Evan's iPhone | all pass, incl. the swipe-dismiss regression test |

Baseline before this branch was exit 65 with one failure (#131's calendar test).
The device suite had four permanent failures; both are now resolved, so a
non-zero exit on either destination is a real regression.

Closes #123
Closes #124
Closes #125
Closes #131
Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
