### PR TITLE
Fix build/test recipes that no longer run

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -9,14 +9,26 @@ Build the ClaudeLifter Xcode project.
 
 ## Steps
 
-1. Run the build:
+1. Run the build, capturing the real exit code rather than piping into `tail`
+   (without `set -o pipefail` that reports `tail`'s status, not xcodebuild's):
    ```bash
+   set -o pipefail
+   LOG=$(mktemp -t claudelifter-build)
    xcodebuild \
      -scheme ClaudeLifter \
-     -destination 'platform=iOS Simulator,name=iPhone 16e' \
-     build 2>&1 | tail -30
+     -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max' \
+     build > "$LOG" 2>&1
+   echo "EXIT=$?"
+   grep -E "error: " "$LOG" | head -20
    ```
 
 2. Report results:
    - If successful: "Build succeeded"
    - If failed: show compiler errors with file:line references
+
+## Notes
+
+The destination must be **iPhone 13 Pro Max**, matching Evan's phone — don't
+substitute whatever simulator ships newest. If it's missing, create it (command
+in CLAUDE.md). To build for the phone itself, see the install recipe in
+CONTINUATION.md; the phone must be unlocked.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -12,24 +12,38 @@ If `$ARGUMENTS` is provided, use it to filter which tests to run (e.g., "ModelTe
 
 ## Steps
 
-1. If `$ARGUMENTS` is provided, run only matching tests:
+Write the full log to a file and grep it. Do NOT pipe `xcodebuild` straight
+into `tail` — without `set -o pipefail` that reports `tail`'s exit code, and a
+run that returned 65 reads as success.
+
+1. Run the tests, capturing the real exit code:
    ```bash
+   set -o pipefail
+   LOG=$(mktemp -t claudelifter-test)
    xcodebuild test \
      -scheme ClaudeLifter \
-     -destination 'platform=iOS Simulator,name=iPhone 16e' \
-     -only-testing:"ClaudeLifterTests/$ARGUMENTS" \
-     2>&1 | tail -50
+     -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max' \
+     ${ARGUMENTS:+-only-testing:"ClaudeLifterTests/$ARGUMENTS"} \
+     > "$LOG" 2>&1
+   echo "EXIT=$?"
    ```
 
-2. If no arguments, run all tests:
+2. Extract results from `$LOG` — **both** frameworks, since they report
+   differently and grepping one format hides the other:
    ```bash
-   xcodebuild test \
-     -scheme ClaudeLifter \
-     -destination 'platform=iOS Simulator,name=iPhone 16e' \
-     2>&1 | tail -50
+   grep -E "Test run with" "$LOG" | tail -2          # Swift Testing totals
+   grep -E "^✘" "$LOG"                               # Swift Testing failures
+   grep -cE "^Test Case .* passed" "$LOG"            # XCUITest passes
+   grep -E "^Test Case .* failed" "$LOG"             # XCUITest failures
    ```
 
-3. Parse the output and report:
-   - Total tests run, passed, failed, skipped
-   - For failures: show the test name, file:line, and assertion message
-   - End with a clear PASS or FAIL summary
+3. Report total run/passed/failed, each failure's name and file:line, and a
+   clear PASS or FAIL. **`EXIT=0` is the verdict** — a summary line is not.
+
+## Notes
+
+- The destination must be **iPhone 13 Pro Max**, matching Evan's phone. Do not
+  substitute a newer simulator; an iPhone 17 run once produced a false
+  `ChatCoachTests` failure. If it is missing, create it (command in CLAUDE.md).
+- For the highest-fidelity run, target the phone itself — but it must be
+  **unlocked**, or the build is interrupted before it starts.

--- a/CONTINUATION.md
+++ b/CONTINUATION.md
@@ -1,14 +1,18 @@
 # ClaudeLifter — Deep refactor session handoff
 
-Last active: 2026-04-24. Work paused by user; app is on-device and behaving.
+> **HISTORICAL — 2026-04-24.** Kept for the fix-by-fix record below. Its session
+> state and test baseline are long superseded; for current pickup state read
+> `HANDOFF.md`, not this file. The commands at the bottom have been refreshed.
 
-## Session state
+## Session state (as of 2026-04-24)
 
-**15 commits on `main` ahead of `origin/main`, all local, nothing pushed yet.**
-Run `git push origin main` when you want to publish.
+15 commits were local and unpushed at the time. **Long since pushed** — `main`
+is published.
 
-Test baseline: **534 unit tests + 11 `WorkoutFlowTests` UI tests** — all green
-in the iPhone 16e (iOS 26.2) simulator. Zero fatal errors, zero failures.
+Test baseline then: **534 unit tests + 11 `WorkoutFlowTests` UI tests**, green
+on an iPhone 16e (iOS 26.2) simulator. Both are stale: that simulator no longer
+exists in Xcode, and the suite is now 681 unit + 69 UI on iPhone 13 Pro Max /
+iOS 26.5.
 
 Plan file (can archive when you're satisfied):
 `/Users/eddelord/.claude/plans/i-d-like-you-to-ticklish-hickey.md`
@@ -79,26 +83,27 @@ Nothing is broken; these are genuinely "next sprint" items, roughly in priority 
 
 ```bash
 # Full baseline (unit + key UI flow)
+set -o pipefail
 xcodebuild -scheme ClaudeLifter \
-  -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 16e' test \
+  -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max' test \
   -only-testing:ClaudeLifterTests \
   -only-testing:ClaudeLifterUITests/WorkoutFlowTests
 
-# Just the new regression suites
-xcodebuild -scheme ClaudeLifter \
-  -destination 'platform=iOS Simulator,OS=26.2,name=iPhone 16e' test \
-  -only-testing:ClaudeLifterTests/LastModifiedPropagationTests \
-  -only-testing:ClaudeLifterTests/ChatViewModelTests \
-  -only-testing:ClaudeLifterTests/BuildInfoTests \
-  -only-testing:ClaudeLifterTests/PaginationBoundsTests
-
-# Build & install on the plugged-in phone
-xcodebuild -scheme ClaudeLifter \
-  -destination 'platform=iOS,id=00008110-001E1D8114F3801E' build
-xcrun devicectl device install app \
-  --device 00008110-001E1D8114F3801E \
+# Build & install on the plugged-in phone (it must be UNLOCKED — a locked
+# screen gives "Waiting for the destination to become ready" and
+# ** BUILD INTERRUPTED ** before the build even starts)
+DEVICE=$(xcrun devicectl list devices 2>/dev/null | grep -i iphone \
+  | grep -oE '[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}' | head -1)
+# Don't hardcode the id — the one previously written here (00008110-...) is a
+# hardware UDID and no longer matches what devicectl reports.
+xcodebuild -scheme ClaudeLifter -destination "platform=iOS,id=$DEVICE" build
+xcrun devicectl device install app --device "$DEVICE" \
   ~/Library/Developer/Xcode/DerivedData/ClaudeLifter-hksekbwiejlwszcjbxmhraxgbzaf/Build/Products/Debug-iphoneos/ClaudeLifter.app
 
 # Publish when ready
 git push origin main
 ```
+
+Never pipe `xcodebuild` into `tail` without `set -o pipefail` — you get `tail`'s
+exit code, and a run that returned 65 reads as success. Capture `EXIT=$?` from
+the redirect instead.


### PR DESCRIPTION
Follow-up to #133. Three docs that would misdirect the next session.

## `/build` and `/test` could not run at all

Both targeted `iPhone 16e`, which no longer exists in Xcode — `CLAUDE.md` has said so since 2026-07-27, but the skills were never updated. Now `iPhone 13 Pro Max`, matching Evan's phone.

## Both masked failures

They piped `xcodebuild` into `tail` with no `set -o pipefail`, so the reported exit code was `tail`'s. This is not hypothetical — it masked a real exit 65 during the #133 sprint, and `CLAUDE.md` warns about it two files away.

They now redirect to a log, echo the real `EXIT`, and grep **both** frameworks: Swift Testing prints `✘`, XCUITest prints `Test Case '-[...]' failed`, and checking one hides the other.

## `CONTINUATION.md` read as current state

Dated 2026-04-24 but presented as pickup state, claiming 15 unpushed commits and a 534-test baseline. Now marked historical and pointed at `HANDOFF.md`.

Its install recipe hardcoded `00008110-001E1D8114F3801E` — a hardware UDID that no longer matches what `devicectl` reports (`676B845C-…`), so the documented install would fail. The id is now looked up.

## Verified, not assumed

Both corrected recipes were run verbatim: build `EXIT=0` / `BUILD SUCCEEDED`, test `EXIT=0` / 56 tests passed. The first device-id lookup I wrote returned `13` — parsed out of "iPhone 13 Pro Max" — and was caught by checking it against the real identifier before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)