### PR TITLE
Gym-feedback batch: notes, reps, history edits, and post-workout template review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+# First CI in this repo (#138). The Swift suite needs macOS + Xcode and is run
+# on the machine that has the right simulator; this covers the two TypeScript
+# packages, which had no automated run at all.
+#
+# Note what this does NOT catch: a stale `infra/mcp/dist/` on a developer
+# machine. `dist/` is gitignored, so there is nothing here to diff against.
+# That is what the runtime staleness guard in `src/shared/build-info.ts` is
+# for — CI and the guard cover different halves of the same problem.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  functions:
+    name: Azure Functions (jest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/functions
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  mcp:
+    name: MCP server (vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # The catalog builder reads ClaudeLifter/Resources/exercises.json, so the
+      # full checkout above is required — not a sparse one.
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,13 @@ See `.claude/rules/tdd.md` for the full workflow.
 
 - **Typechecking is not testing.** A clean `tsc`/`swiftc` parse says nothing about behavior — on 2026-07-27 two rounds of write-path work typechecked cleanly and still failed the simulator suite. Run `xcodebuild test` before claiming a change works, and beware piping it through `tail` without `set -o pipefail`, which masks the real exit code.
 
+- **Versioning**: three-part semver, bumped on **every device install** (patch
+  for fixes, minor for features). Edit `APP_VERSION` and `BUILD_NUMBER` in
+  **`generate_project.py`** — never `ClaudeLifter.xcodeproj/project.pbxproj`,
+  which that script regenerates, silently discarding any bump made there. The
+  Settings footer shows the version, so the bump is the visible proof that the
+  new build actually landed on the phone.
+
 - **Architecture**: MVVM with `@Observable` ViewModels
 - **DI**: Protocol-based. Every service/repository has a protocol. Tests inject mocks.
 - **Testing**: Swift Testing (`@Test`, `#expect`) — NOT XCTest (`XCTAssert*`)

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		5872FF64569B72EAD5E9180C /* ProxiedAnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6B91FD5E20633DE9D9909 /* ProxiedAnthropicService.swift */; };
 		1B40FA3DB92FCB0E44DD5F7F /* RestTimerNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534E1D6A2B20EBF345BA4056 /* RestTimerNotificationScheduler.swift */; };
 		80C31B958DED2E5A665DC426 /* RestTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340E3D45C26DFC6DD81D572 /* RestTimerService.swift */; };
+		E39C47F31F01196784EEB454 /* TemplateChangeApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F645B38C21D9F46FAA9D587F /* TemplateChangeApplier.swift */; };
 		590BE78D9A91C8154AAEB0BB /* TemplateChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618CAD37CCFE0BE0E16C4048 /* TemplateChangeDetector.swift */; };
 		1D314075C6BBC031825BD896 /* AddExerciseTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434300F5979D665A9FEDEAB8 /* AddExerciseTool.swift */; };
 		384D47CAE7729162CFA82571 /* ClaudeTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C3D02A87E8873628EED035 /* ClaudeTool.swift */; };
@@ -135,6 +136,7 @@
 		0063A185AE0B214715BA9FBA /* RestTimerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251A036C35AA00E683BDB9BD /* RestTimerOverlayView.swift */; };
 		790A2E66A6B1A9D8A9CDFB78 /* ResumeWorkoutCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E66131E8982224C5E417AE /* ResumeWorkoutCard.swift */; };
 		2A214A37B94DED7CBCD858C8 /* SetRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312CDB66507E64087F645623 /* SetRowView.swift */; };
+		6F7C27E60227226ACB04F72D /* TemplateReviewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4804291D4923A41D21B0A1 /* TemplateReviewSection.swift */; };
 		39ED1AD66A8E287CBEAB90AC /* WorkoutSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9112E64C3083491FD6334D9B /* WorkoutSummaryView.swift */; };
 		6B13333443AEDD7615DC85AA /* ClaudeLifterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A37442BD01F482A5FA2B78 /* ClaudeLifterTests.swift */; };
 		3E19873FCAF2E3B514476A20 /* CoachTemplateE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B049E3F754C1EBFBAD0B1E99 /* CoachTemplateE2ETests.swift */; };
@@ -197,6 +199,7 @@
 		A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */; };
 		74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */; };
 		AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A31E123184E639F96BB6D /* SyncMapperTests.swift */; };
+		31FCEC5B57478F2DF0365842 /* TemplateChangeApplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50EC424A0540A6B9082B35A5 /* TemplateChangeApplierTests.swift */; };
 		A869D101A452B583D089B911 /* TemplateChangeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2121CB0A9FCD9A54E34FAE4 /* TemplateChangeDetectorTests.swift */; };
 		DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */; };
 		ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */; };
@@ -301,6 +304,7 @@
 		3DB6B91FD5E20633DE9D9909 /* ProxiedAnthropicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxiedAnthropicService.swift; sourceTree = "<group>"; };
 		534E1D6A2B20EBF345BA4056 /* RestTimerNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerNotificationScheduler.swift; sourceTree = "<group>"; };
 		7340E3D45C26DFC6DD81D572 /* RestTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerService.swift; sourceTree = "<group>"; };
+		F645B38C21D9F46FAA9D587F /* TemplateChangeApplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateChangeApplier.swift; sourceTree = "<group>"; };
 		618CAD37CCFE0BE0E16C4048 /* TemplateChangeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateChangeDetector.swift; sourceTree = "<group>"; };
 		434300F5979D665A9FEDEAB8 /* AddExerciseTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddExerciseTool.swift; sourceTree = "<group>"; };
 		43C3D02A87E8873628EED035 /* ClaudeTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTool.swift; sourceTree = "<group>"; };
@@ -381,6 +385,7 @@
 		251A036C35AA00E683BDB9BD /* RestTimerOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerOverlayView.swift; sourceTree = "<group>"; };
 		47E66131E8982224C5E417AE /* ResumeWorkoutCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeWorkoutCard.swift; sourceTree = "<group>"; };
 		312CDB66507E64087F645623 /* SetRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetRowView.swift; sourceTree = "<group>"; };
+		BD4804291D4923A41D21B0A1 /* TemplateReviewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateReviewSection.swift; sourceTree = "<group>"; };
 		9112E64C3083491FD6334D9B /* WorkoutSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSummaryView.swift; sourceTree = "<group>"; };
 		B5A37442BD01F482A5FA2B78 /* ClaudeLifterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeLifterTests.swift; sourceTree = "<group>"; };
 		B049E3F754C1EBFBAD0B1E99 /* CoachTemplateE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoachTemplateE2ETests.swift; sourceTree = "<group>"; };
@@ -443,6 +448,7 @@
 		063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDTOTests.swift; sourceTree = "<group>"; };
 		1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManagerTests.swift; sourceTree = "<group>"; };
 		980A31E123184E639F96BB6D /* SyncMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMapperTests.swift; sourceTree = "<group>"; };
+		50EC424A0540A6B9082B35A5 /* TemplateChangeApplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateChangeApplierTests.swift; sourceTree = "<group>"; };
 		B2121CB0A9FCD9A54E34FAE4 /* TemplateChangeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateChangeDetectorTests.swift; sourceTree = "<group>"; };
 		F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModelTests.swift; sourceTree = "<group>"; };
 		BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
@@ -620,6 +626,7 @@
 				3DB6B91FD5E20633DE9D9909,
 				534E1D6A2B20EBF345BA4056,
 				7340E3D45C26DFC6DD81D572,
+				F645B38C21D9F46FAA9D587F,
 				618CAD37CCFE0BE0E16C4048,
 			);
 			path = Services;
@@ -791,6 +798,7 @@
 				251A036C35AA00E683BDB9BD,
 				47E66131E8982224C5E417AE,
 				312CDB66507E64087F645623,
+				BD4804291D4923A41D21B0A1,
 				9112E64C3083491FD6334D9B,
 			);
 			path = Workout;
@@ -910,6 +918,7 @@
 				063A59D9339A3ED9F05E1365,
 				1C0617F4620F537F4CD40042,
 				980A31E123184E639F96BB6D,
+				50EC424A0540A6B9082B35A5,
 				B2121CB0A9FCD9A54E34FAE4,
 			);
 			path = ServiceTests;
@@ -1122,6 +1131,7 @@
 				5872FF64569B72EAD5E9180C /* ProxiedAnthropicService.swift in Sources */,
 				1B40FA3DB92FCB0E44DD5F7F /* RestTimerNotificationScheduler.swift in Sources */,
 				80C31B958DED2E5A665DC426 /* RestTimerService.swift in Sources */,
+				E39C47F31F01196784EEB454 /* TemplateChangeApplier.swift in Sources */,
 				590BE78D9A91C8154AAEB0BB /* TemplateChangeDetector.swift in Sources */,
 				1D314075C6BBC031825BD896 /* AddExerciseTool.swift in Sources */,
 				384D47CAE7729162CFA82571 /* ClaudeTool.swift in Sources */,
@@ -1202,6 +1212,7 @@
 				0063A185AE0B214715BA9FBA /* RestTimerOverlayView.swift in Sources */,
 				790A2E66A6B1A9D8A9CDFB78 /* ResumeWorkoutCard.swift in Sources */,
 				2A214A37B94DED7CBCD858C8 /* SetRowView.swift in Sources */,
+				6F7C27E60227226ACB04F72D /* TemplateReviewSection.swift in Sources */,
 				39ED1AD66A8E287CBEAB90AC /* WorkoutSummaryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1271,6 +1282,7 @@
 				A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */,
 				74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */,
 				AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */,
+				31FCEC5B57478F2DF0365842 /* TemplateChangeApplierTests.swift in Sources */,
 				A869D101A452B583D089B911 /* TemplateChangeDetectorTests.swift in Sources */,
 				DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */,
 				ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */,
@@ -1395,7 +1407,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1405,7 +1417,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1420,7 +1432,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1430,7 +1442,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1444,10 +1456,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1462,10 +1474,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1479,10 +1491,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1496,10 +1508,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -31,12 +31,14 @@
 		C78D7A98D0AA30F79102838D /* WorkoutExercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7905C925C6C006FF8CEE1ED0 /* WorkoutExercise.swift */; };
 		D87C78F984FB86FED5A8255B /* WorkoutSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116A6C18610DBE99BE98C132 /* WorkoutSet.swift */; };
 		EAFB41C44B257060FF76DF6B /* WorkoutTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BAB77C072B33EBD475C6CD /* WorkoutTemplate.swift */; };
+		E3F0AD60769AB289E23F9A8C /* WorkoutTemplateBaseline.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2020300CA62A5B2AFB0A3BB /* WorkoutTemplateBaseline.swift */; };
 		0D11B927E277E9E76DE1A237 /* BodyWeightRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D4AA065E061FDD6E757E17 /* BodyWeightRepository.swift */; };
 		EE0992E9F590EB4E1670EC9C /* ChatMessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27388103483B9A103008FDCE /* ChatMessageRepository.swift */; };
 		7915759038B1ECD8C71B7503 /* ExerciseReportRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78A51D0B0F20213755CCD97 /* ExerciseReportRepository.swift */; };
 		C0D933E2006873407AE1C4DB /* ExerciseRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B88BBCC49AB084C279ED7C /* ExerciseRepository.swift */; };
 		3CF6BAFDC30A7131796543A7 /* InsightRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8845129EF032F4B5DA730398 /* InsightRepository.swift */; };
 		9BC06D370E2B607A3492039E /* PersonalRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD4F3111987CDFCA3AABA95 /* PersonalRecordRepository.swift */; };
+		20E182FF5A208A646749C9CC /* TemplateBaselineRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB83F2B7FA04725178CA28D3 /* TemplateBaselineRepository.swift */; };
 		B7FFD6EC5484CB4038AA35C7 /* TemplateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7B18FB69F18DFF7DA48E04 /* TemplateRepository.swift */; };
 		0651D93926E18DE3AA5CD55E /* TrainingPreferenceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3B80C2BEB5BC0F6E894241 /* TrainingPreferenceRepository.swift */; };
 		FD68D28B701FE08BA0E5BA00 /* WorkoutRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9569B8BB3DB37C69AD9727C /* WorkoutRepository.swift */; };
@@ -149,6 +151,7 @@
 		C443511381F97AA1A4AF91DF /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB615C09D872B5642099AE /* MockNetworkService.swift */; };
 		ED11E6E44FEBA57CF6B25039 /* MockNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2A4B1B64DC6C4A0351FED4 /* MockNotificationScheduler.swift */; };
 		4A511DC84B22381F76C649F3 /* MockPRDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E536544FD38BA651DBDA6B /* MockPRDetectionService.swift */; };
+		501B88C6B8209E0CBF663FFF /* MockTemplateBaselineRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A4292014B03C3D952432821 /* MockTemplateBaselineRepository.swift */; };
 		8D92469E5160C8F834DF5551 /* MockTemplateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957BB74AD69F17E7FB43F720 /* MockTemplateRepository.swift */; };
 		8B66BC2F8398E1784EC7864F /* MockTrainingPreferenceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3164B4FD512A54F95A65DD /* MockTrainingPreferenceRepository.swift */; };
 		AC4CFE654B3A691F563544A9 /* MockWorkoutRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A97C484F178B08B9373F3A /* MockWorkoutRepository.swift */; };
@@ -161,6 +164,7 @@
 		6B44DAF3C5BAF6884EB5ECA1 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C11CA3831DC6337201E1D9 /* ModelTests.swift */; };
 		C74F930BFBDB72D0335A9E3E /* PersonalRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2F2D26B503E4DA6C56F201 /* PersonalRecordTests.swift */; };
 		57A3D163990B3217BBEE0E9E /* SyncFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596B7259BB2A729958FDC14E /* SyncFieldTests.swift */; };
+		BB3A617F2B48BC2705764A8D /* TemplateProvenanceMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6CF200168DFC82E1CF452E /* TemplateProvenanceMigrationTests.swift */; };
 		9D3BE9EED86A1527C1CFD894 /* BodyWeightRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D284207770C8E54D8900F7 /* BodyWeightRepositoryTests.swift */; };
 		0211AE6F42D041771E4834FE /* ChatMessageRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85D59F4A1B39E264539D4E2 /* ChatMessageRepositoryTests.swift */; };
 		88C907C03E7855E42ADFA820 /* ExerciseReportRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3FE667152DCD778275FBA8 /* ExerciseReportRepositoryTests.swift */; };
@@ -271,12 +275,14 @@
 		7905C925C6C006FF8CEE1ED0 /* WorkoutExercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutExercise.swift; sourceTree = "<group>"; };
 		116A6C18610DBE99BE98C132 /* WorkoutSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSet.swift; sourceTree = "<group>"; };
 		53BAB77C072B33EBD475C6CD /* WorkoutTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutTemplate.swift; sourceTree = "<group>"; };
+		A2020300CA62A5B2AFB0A3BB /* WorkoutTemplateBaseline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutTemplateBaseline.swift; sourceTree = "<group>"; };
 		46D4AA065E061FDD6E757E17 /* BodyWeightRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightRepository.swift; sourceTree = "<group>"; };
 		27388103483B9A103008FDCE /* ChatMessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRepository.swift; sourceTree = "<group>"; };
 		D78A51D0B0F20213755CCD97 /* ExerciseReportRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseReportRepository.swift; sourceTree = "<group>"; };
 		31B88BBCC49AB084C279ED7C /* ExerciseRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepository.swift; sourceTree = "<group>"; };
 		8845129EF032F4B5DA730398 /* InsightRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRepository.swift; sourceTree = "<group>"; };
 		3FD4F3111987CDFCA3AABA95 /* PersonalRecordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalRecordRepository.swift; sourceTree = "<group>"; };
+		CB83F2B7FA04725178CA28D3 /* TemplateBaselineRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateBaselineRepository.swift; sourceTree = "<group>"; };
 		BD7B18FB69F18DFF7DA48E04 /* TemplateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateRepository.swift; sourceTree = "<group>"; };
 		AD3B80C2BEB5BC0F6E894241 /* TrainingPreferenceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingPreferenceRepository.swift; sourceTree = "<group>"; };
 		E9569B8BB3DB37C69AD9727C /* WorkoutRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRepository.swift; sourceTree = "<group>"; };
@@ -389,6 +395,7 @@
 		32EB615C09D872B5642099AE /* MockNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkService.swift; sourceTree = "<group>"; };
 		8E2A4B1B64DC6C4A0351FED4 /* MockNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNotificationScheduler.swift; sourceTree = "<group>"; };
 		D8E536544FD38BA651DBDA6B /* MockPRDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPRDetectionService.swift; sourceTree = "<group>"; };
+		2A4292014B03C3D952432821 /* MockTemplateBaselineRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemplateBaselineRepository.swift; sourceTree = "<group>"; };
 		957BB74AD69F17E7FB43F720 /* MockTemplateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemplateRepository.swift; sourceTree = "<group>"; };
 		AB3164B4FD512A54F95A65DD /* MockTrainingPreferenceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrainingPreferenceRepository.swift; sourceTree = "<group>"; };
 		D2A97C484F178B08B9373F3A /* MockWorkoutRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWorkoutRepository.swift; sourceTree = "<group>"; };
@@ -401,6 +408,7 @@
 		55C11CA3831DC6337201E1D9 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 		ED2F2D26B503E4DA6C56F201 /* PersonalRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalRecordTests.swift; sourceTree = "<group>"; };
 		596B7259BB2A729958FDC14E /* SyncFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncFieldTests.swift; sourceTree = "<group>"; };
+		CD6CF200168DFC82E1CF452E /* TemplateProvenanceMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateProvenanceMigrationTests.swift; sourceTree = "<group>"; };
 		16D284207770C8E54D8900F7 /* BodyWeightRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightRepositoryTests.swift; sourceTree = "<group>"; };
 		C85D59F4A1B39E264539D4E2 /* ChatMessageRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRepositoryTests.swift; sourceTree = "<group>"; };
 		CC3FE667152DCD778275FBA8 /* ExerciseReportRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseReportRepositoryTests.swift; sourceTree = "<group>"; };
@@ -568,6 +576,7 @@
 				7905C925C6C006FF8CEE1ED0,
 				116A6C18610DBE99BE98C132,
 				53BAB77C072B33EBD475C6CD,
+				A2020300CA62A5B2AFB0A3BB,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -581,6 +590,7 @@
 				31B88BBCC49AB084C279ED7C,
 				8845129EF032F4B5DA730398,
 				3FD4F3111987CDFCA3AABA95,
+				CB83F2B7FA04725178CA28D3,
 				BD7B18FB69F18DFF7DA48E04,
 				AD3B80C2BEB5BC0F6E894241,
 				E9569B8BB3DB37C69AD9727C,
@@ -829,6 +839,7 @@
 				32EB615C09D872B5642099AE,
 				8E2A4B1B64DC6C4A0351FED4,
 				D8E536544FD38BA651DBDA6B,
+				2A4292014B03C3D952432821,
 				957BB74AD69F17E7FB43F720,
 				AB3164B4FD512A54F95A65DD,
 				D2A97C484F178B08B9373F3A,
@@ -848,6 +859,7 @@
 				55C11CA3831DC6337201E1D9,
 				ED2F2D26B503E4DA6C56F201,
 				596B7259BB2A729958FDC14E,
+				CD6CF200168DFC82E1CF452E,
 			);
 			path = ModelTests;
 			sourceTree = "<group>";
@@ -1080,12 +1092,14 @@
 				C78D7A98D0AA30F79102838D /* WorkoutExercise.swift in Sources */,
 				D87C78F984FB86FED5A8255B /* WorkoutSet.swift in Sources */,
 				EAFB41C44B257060FF76DF6B /* WorkoutTemplate.swift in Sources */,
+				E3F0AD60769AB289E23F9A8C /* WorkoutTemplateBaseline.swift in Sources */,
 				0D11B927E277E9E76DE1A237 /* BodyWeightRepository.swift in Sources */,
 				EE0992E9F590EB4E1670EC9C /* ChatMessageRepository.swift in Sources */,
 				7915759038B1ECD8C71B7503 /* ExerciseReportRepository.swift in Sources */,
 				C0D933E2006873407AE1C4DB /* ExerciseRepository.swift in Sources */,
 				3CF6BAFDC30A7131796543A7 /* InsightRepository.swift in Sources */,
 				9BC06D370E2B607A3492039E /* PersonalRecordRepository.swift in Sources */,
+				20E182FF5A208A646749C9CC /* TemplateBaselineRepository.swift in Sources */,
 				B7FFD6EC5484CB4038AA35C7 /* TemplateRepository.swift in Sources */,
 				0651D93926E18DE3AA5CD55E /* TrainingPreferenceRepository.swift in Sources */,
 				FD68D28B701FE08BA0E5BA00 /* WorkoutRepository.swift in Sources */,
@@ -1205,6 +1219,7 @@
 				C443511381F97AA1A4AF91DF /* MockNetworkService.swift in Sources */,
 				ED11E6E44FEBA57CF6B25039 /* MockNotificationScheduler.swift in Sources */,
 				4A511DC84B22381F76C649F3 /* MockPRDetectionService.swift in Sources */,
+				501B88C6B8209E0CBF663FFF /* MockTemplateBaselineRepository.swift in Sources */,
 				8D92469E5160C8F834DF5551 /* MockTemplateRepository.swift in Sources */,
 				8B66BC2F8398E1784EC7864F /* MockTrainingPreferenceRepository.swift in Sources */,
 				AC4CFE654B3A691F563544A9 /* MockWorkoutRepository.swift in Sources */,
@@ -1217,6 +1232,7 @@
 				6B44DAF3C5BAF6884EB5ECA1 /* ModelTests.swift in Sources */,
 				C74F930BFBDB72D0335A9E3E /* PersonalRecordTests.swift in Sources */,
 				57A3D163990B3217BBEE0E9E /* SyncFieldTests.swift in Sources */,
+				BB3A617F2B48BC2705764A8D /* TemplateProvenanceMigrationTests.swift in Sources */,
 				9D3BE9EED86A1527C1CFD894 /* BodyWeightRepositoryTests.swift in Sources */,
 				0211AE6F42D041771E4834FE /* ChatMessageRepositoryTests.swift in Sources */,
 				88C907C03E7855E42ADFA820 /* ExerciseReportRepositoryTests.swift in Sources */,

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		22808144F86FCDCD4967FD58 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C44B0FA03C14D20C9389468 /* HomeViewModelTests.swift */; };
 		6B23B904FEB12E4CC377B8E2 /* LocalPhotoStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C999AB43A1EBD631D51A1240 /* LocalPhotoStorageTests.swift */; };
 		BC062055415B9F5F2AA218D4 /* ProgressChartsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7146F35021932829001C2176 /* ProgressChartsViewModelTests.swift */; };
+		11BCB4FAEB0CF65CB75E4B9C /* ReportListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36FBA282E430397FDB1DAB7 /* ReportListViewModelTests.swift */; };
 		4B340AF9EDD47AEC71F6BF34 /* ReportSheetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39712B7C0FCDE4D7097EDA8D /* ReportSheetViewModelTests.swift */; };
 		6192B90B42FCA84FFD2BDD3F /* RestTimerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF1E2ACFA475EC9FC3A8195 /* RestTimerViewModelTests.swift */; };
 		9EA086F04073CE8260011E36 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F56BFC5255D1A1D68459C3 /* SettingsViewModelTests.swift */; };
@@ -464,6 +465,7 @@
 		1C44B0FA03C14D20C9389468 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		C999AB43A1EBD631D51A1240 /* LocalPhotoStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPhotoStorageTests.swift; sourceTree = "<group>"; };
 		7146F35021932829001C2176 /* ProgressChartsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressChartsViewModelTests.swift; sourceTree = "<group>"; };
+		E36FBA282E430397FDB1DAB7 /* ReportListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListViewModelTests.swift; sourceTree = "<group>"; };
 		39712B7C0FCDE4D7097EDA8D /* ReportSheetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportSheetViewModelTests.swift; sourceTree = "<group>"; };
 		2FF1E2ACFA475EC9FC3A8195 /* RestTimerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerViewModelTests.swift; sourceTree = "<group>"; };
 		84F56BFC5255D1A1D68459C3 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -941,6 +943,7 @@
 				1C44B0FA03C14D20C9389468,
 				C999AB43A1EBD631D51A1240,
 				7146F35021932829001C2176,
+				E36FBA282E430397FDB1DAB7,
 				39712B7C0FCDE4D7097EDA8D,
 				2FF1E2ACFA475EC9FC3A8195,
 				84F56BFC5255D1A1D68459C3,
@@ -1298,6 +1301,7 @@
 				22808144F86FCDCD4967FD58 /* HomeViewModelTests.swift in Sources */,
 				6B23B904FEB12E4CC377B8E2 /* LocalPhotoStorageTests.swift in Sources */,
 				BC062055415B9F5F2AA218D4 /* ProgressChartsViewModelTests.swift in Sources */,
+				11BCB4FAEB0CF65CB75E4B9C /* ReportListViewModelTests.swift in Sources */,
 				4B340AF9EDD47AEC71F6BF34 /* ReportSheetViewModelTests.swift in Sources */,
 				6192B90B42FCA84FFD2BDD3F /* RestTimerViewModelTests.swift in Sources */,
 				9EA086F04073CE8260011E36 /* SettingsViewModelTests.swift in Sources */,
@@ -1407,7 +1411,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1417,7 +1421,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1432,7 +1436,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1442,7 +1446,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1456,10 +1460,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1474,10 +1478,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1491,10 +1495,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1508,10 +1512,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 1.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		5872FF64569B72EAD5E9180C /* ProxiedAnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB6B91FD5E20633DE9D9909 /* ProxiedAnthropicService.swift */; };
 		1B40FA3DB92FCB0E44DD5F7F /* RestTimerNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534E1D6A2B20EBF345BA4056 /* RestTimerNotificationScheduler.swift */; };
 		80C31B958DED2E5A665DC426 /* RestTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7340E3D45C26DFC6DD81D572 /* RestTimerService.swift */; };
+		590BE78D9A91C8154AAEB0BB /* TemplateChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618CAD37CCFE0BE0E16C4048 /* TemplateChangeDetector.swift */; };
 		1D314075C6BBC031825BD896 /* AddExerciseTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434300F5979D665A9FEDEAB8 /* AddExerciseTool.swift */; };
 		384D47CAE7729162CFA82571 /* ClaudeTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C3D02A87E8873628EED035 /* ClaudeTool.swift */; };
 		C47B9E6DD445FAB9AE4A5B32 /* CreateProgramTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF035B0B0B8C6A5934269C1 /* CreateProgramTool.swift */; };
@@ -196,6 +197,7 @@
 		A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */; };
 		74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */; };
 		AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A31E123184E639F96BB6D /* SyncMapperTests.swift */; };
+		A869D101A452B583D089B911 /* TemplateChangeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2121CB0A9FCD9A54E34FAE4 /* TemplateChangeDetectorTests.swift */; };
 		DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */; };
 		ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */; };
 		BD88CA8763EA48B6DF5EA1C0 /* BodyWeightViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A754765C32959052E27AC76D /* BodyWeightViewModelTests.swift */; };
@@ -299,6 +301,7 @@
 		3DB6B91FD5E20633DE9D9909 /* ProxiedAnthropicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxiedAnthropicService.swift; sourceTree = "<group>"; };
 		534E1D6A2B20EBF345BA4056 /* RestTimerNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerNotificationScheduler.swift; sourceTree = "<group>"; };
 		7340E3D45C26DFC6DD81D572 /* RestTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerService.swift; sourceTree = "<group>"; };
+		618CAD37CCFE0BE0E16C4048 /* TemplateChangeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateChangeDetector.swift; sourceTree = "<group>"; };
 		434300F5979D665A9FEDEAB8 /* AddExerciseTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddExerciseTool.swift; sourceTree = "<group>"; };
 		43C3D02A87E8873628EED035 /* ClaudeTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeTool.swift; sourceTree = "<group>"; };
 		FBF035B0B0B8C6A5934269C1 /* CreateProgramTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProgramTool.swift; sourceTree = "<group>"; };
@@ -440,6 +443,7 @@
 		063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDTOTests.swift; sourceTree = "<group>"; };
 		1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManagerTests.swift; sourceTree = "<group>"; };
 		980A31E123184E639F96BB6D /* SyncMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMapperTests.swift; sourceTree = "<group>"; };
+		B2121CB0A9FCD9A54E34FAE4 /* TemplateChangeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateChangeDetectorTests.swift; sourceTree = "<group>"; };
 		F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModelTests.swift; sourceTree = "<group>"; };
 		BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		A754765C32959052E27AC76D /* BodyWeightViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightViewModelTests.swift; sourceTree = "<group>"; };
@@ -616,6 +620,7 @@
 				3DB6B91FD5E20633DE9D9909,
 				534E1D6A2B20EBF345BA4056,
 				7340E3D45C26DFC6DD81D572,
+				618CAD37CCFE0BE0E16C4048,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -905,6 +910,7 @@
 				063A59D9339A3ED9F05E1365,
 				1C0617F4620F537F4CD40042,
 				980A31E123184E639F96BB6D,
+				B2121CB0A9FCD9A54E34FAE4,
 			);
 			path = ServiceTests;
 			sourceTree = "<group>";
@@ -1116,6 +1122,7 @@
 				5872FF64569B72EAD5E9180C /* ProxiedAnthropicService.swift in Sources */,
 				1B40FA3DB92FCB0E44DD5F7F /* RestTimerNotificationScheduler.swift in Sources */,
 				80C31B958DED2E5A665DC426 /* RestTimerService.swift in Sources */,
+				590BE78D9A91C8154AAEB0BB /* TemplateChangeDetector.swift in Sources */,
 				1D314075C6BBC031825BD896 /* AddExerciseTool.swift in Sources */,
 				384D47CAE7729162CFA82571 /* ClaudeTool.swift in Sources */,
 				C47B9E6DD445FAB9AE4A5B32 /* CreateProgramTool.swift in Sources */,
@@ -1264,6 +1271,7 @@
 				A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */,
 				74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */,
 				AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */,
+				A869D101A452B583D089B911 /* TemplateChangeDetectorTests.swift in Sources */,
 				DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */,
 				ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */,
 				BD88CA8763EA48B6DF5EA1C0 /* BodyWeightViewModelTests.swift in Sources */,

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		CFF5040874B3F6A54D3E919B /* AIChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF1483C96C693BAE5F110A9 /* AIChatMessage.swift */; };
 		3140EA1B9B87CF460F9B6833 /* BodyWeightEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6B793D764DD53B20A681C4 /* BodyWeightEntry.swift */; };
 		52382BB861D4B80F34875E8C /* Exercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079CEF0C4674D4D8CCA2AE1F /* Exercise.swift */; };
+		72CE2EE271E6E12D3C0761F3 /* ExerciseReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E2424089BBF208809AA65A /* ExerciseReport.swift */; };
 		60CEBBD6C03E9F037F61CD0B /* ExerciseTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A076A2A8717D2613A9E55E9 /* ExerciseTag.swift */; };
 		04319E32EFCAF08BF95526B4 /* InsightType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5035DD798098E41C5606543D /* InsightType.swift */; };
 		7A2CD1E1BB714C1E3A67D8F1 /* MessageRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47B27C6D366AC6B5B841C41 /* MessageRole.swift */; };
@@ -32,6 +33,7 @@
 		EAFB41C44B257060FF76DF6B /* WorkoutTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BAB77C072B33EBD475C6CD /* WorkoutTemplate.swift */; };
 		0D11B927E277E9E76DE1A237 /* BodyWeightRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D4AA065E061FDD6E757E17 /* BodyWeightRepository.swift */; };
 		EE0992E9F590EB4E1670EC9C /* ChatMessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27388103483B9A103008FDCE /* ChatMessageRepository.swift */; };
+		7915759038B1ECD8C71B7503 /* ExerciseReportRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78A51D0B0F20213755CCD97 /* ExerciseReportRepository.swift */; };
 		C0D933E2006873407AE1C4DB /* ExerciseRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B88BBCC49AB084C279ED7C /* ExerciseRepository.swift */; };
 		3CF6BAFDC30A7131796543A7 /* InsightRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8845129EF032F4B5DA730398 /* InsightRepository.swift */; };
 		9BC06D370E2B607A3492039E /* PersonalRecordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD4F3111987CDFCA3AABA95 /* PersonalRecordRepository.swift */; };
@@ -66,11 +68,11 @@
 		A408611E843D70F6B2D646B3 /* StartWorkoutTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C20ABB32B60986D79D033B /* StartWorkoutTool.swift */; };
 		A694F7F7C295536EF45CD4DB /* SuggestWeightTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74B2285A532C2309640289 /* SuggestWeightTool.swift */; };
 		6AE4A5E440358996B5520B8C /* ToolContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDC5F360A390AA0040AFC21 /* ToolContext.swift */; };
+		8FF138856D23FE64E52BDC22 /* InboxApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BF7CB7DF3294D9DAFF7C65E /* InboxApplier.swift */; };
+		7E786F2B1B7569A6E43B3B14 /* InboxDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71BAF2B39DA6C199B12A17A /* InboxDTOs.swift */; };
 		7FCB344C018E65A2B3F68ADB /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B1A9F545D493DBBC868FA7 /* NetworkService.swift */; };
 		FB0247EC69FD3FB4F904EC26 /* NetworkServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED2D3A491B300D7F75FB92 /* NetworkServiceProtocol.swift */; };
 		85EF683A8D5CD5A5463743F9 /* SyncDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BCD31C7FFC0403D006A026 /* SyncDTOs.swift */; };
-		88A200000000000000000003 /* InboxDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B200000000000000000003 /* InboxDTOs.swift */; };
-		88A200000000000000000004 /* InboxApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B200000000000000000004 /* InboxApplier.swift */; };
 		367E44EFD711971EE9F26E88 /* SyncError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF8ADEB5FD7877F7B7421B6 /* SyncError.swift */; };
 		9E26B7F9F296082858EC69A4 /* SyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE7D363C6D2F123079F0F22 /* SyncManager.swift */; };
 		713C33F9CEAFFD78A9316763 /* SyncMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FB222B5EBDBA88E426695A /* SyncMapper.swift */; };
@@ -79,21 +81,23 @@
 		53029FF24B321A4FC555535E /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44153457DFD1B1AF77799FF4 /* KeychainHelper.swift */; };
 		0B71D39860B245530CD3B22B /* LocalPhotoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6FF0D1EB078F5CF438D6195 /* LocalPhotoStorage.swift */; };
 		39320B32AAB849DA6F4142BC /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB5C6DF96590C72CEA77BD4 /* SettingsManager.swift */; };
-		A1C7F30D4B2E88015CD6119A /* WorkoutCompletionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C7F30D4B2E88015CD6119B /* WorkoutCompletionSummary.swift */; };
 		B902261B25F991B27E8726CE /* ActiveWorkoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB1106CAB595E0F873B0E4E /* ActiveWorkoutViewModel.swift */; };
 		8B39AD114C8A22CA4A12F63D /* BodyWeightViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A915220457843657F447086 /* BodyWeightViewModel.swift */; };
 		D25F93C9E3A2384DFE178ACB /* CalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2481707D7718DFBFE1786D0B /* CalendarViewModel.swift */; };
 		2AF09F12EAC18CDA1A9FBB47 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F447D4EB6221AD59A7EDF9F /* ChatViewModel.swift */; };
 		1D0BB7D76144B34AA7B0C931 /* CreateExerciseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794E0D261A757CCB7E6E0782 /* CreateExerciseViewModel.swift */; };
-		74C62D6A710D7358991AD100 /* ExercisePhotoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2598E869D1A7AC1D9626F7 /* ExercisePhotoViewModel.swift */; };
 		F394DC69C45FDC37F529D60B /* ExerciseLibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A4FBCE77A01C5F9E62C376 /* ExerciseLibraryViewModel.swift */; };
+		4A361BFFB88AECECD572EB8E /* ExercisePhotoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72666A78F14FF2C57846319F /* ExercisePhotoViewModel.swift */; };
 		A18AFE68B9F7A6C5DA63C7B7 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B65EEC4D65C7299EC739E6 /* HistoryViewModel.swift */; };
 		831BCA92C9335364B839B29E /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44408B76370ECDD1BBB38427 /* HomeViewModel.swift */; };
 		AFB61D6A7330C78EAF1CE4C0 /* ProgressChartsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFEBACB7D0929B1ADBBAD73 /* ProgressChartsViewModel.swift */; };
+		4846E886CAD6B57A39E22797 /* ReportListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224167822A323D284DE3CC52 /* ReportListViewModel.swift */; };
+		18C1EFC1A651DF8BE7FBA15F /* ReportSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F63FE6D3F14F76EBBCF1D49 /* ReportSheetViewModel.swift */; };
 		BF380AD7F3AB5A74946D1F95 /* RestTimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73D05E44D2568C801C89B3D /* RestTimerViewModel.swift */; };
 		8F9257365CF1E518C234E289 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F74F9A7CD4DED50BDB90D6A /* SettingsViewModel.swift */; };
 		8F0C66D0DB17D96C05B52072 /* TemplateEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB00D1C9712594526486A75 /* TemplateEditorViewModel.swift */; };
 		CCE185F5CDFE404D29055941 /* TemplateListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7DA3C8168497F0DAEAAC17 /* TemplateListViewModel.swift */; };
+		79296A6352563B20FA8C08A4 /* WorkoutCompletionSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20E59C316D5D955F0E978F2 /* WorkoutCompletionSummary.swift */; };
 		EB9E00C84758623B715B6097 /* ChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5364572CD0945B9DF34712 /* ChatInputView.swift */; };
 		11DFC7181F7270821F944347 /* ChatMessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46741BA3580C948FD432F3B /* ChatMessageBubbleView.swift */; };
 		1A30DE9F3233FF21726315FD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFF909A710BB9CD11A583E7 /* ChatView.swift */; };
@@ -112,6 +116,9 @@
 		442302FEEFDC74F7B9C701FB /* HistoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E621B3B1FF74887269E973E4 /* HistoryListView.swift */; };
 		8327400F40E3350C8CFDBA05 /* WorkoutDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D92145A78D0FA8A249849A3 /* WorkoutDetailView.swift */; };
 		F46C48E4C16636361D3A777C /* WorkoutHistoryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECB6AB68CCB0415E16DF315 /* WorkoutHistoryRowView.swift */; };
+		EC0759F124992E0E65F631F7 /* OpenReportsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA7065CC5E2AAC8BC9E1D7A /* OpenReportsCard.swift */; };
+		C5C1EA82A96B640A6F68F358 /* ReportListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC146910EFFD530F0A3C235A /* ReportListView.swift */; };
+		262F99908A108A499AD1D2E7 /* ReportSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D09714E078FA91D037F834 /* ReportSheetView.swift */; };
 		24C64726CC9FD0CC88781422 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5C760E0A9E33E67C052E0B /* SettingsView.swift */; };
 		EDAC6BCC4964DAAA766B5405 /* TemplateEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396B9924D1F6E8824EDB5821 /* TemplateEditorView.swift */; };
 		EFB1A7B68E44523C5CA91DB2 /* TemplateListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACCD8DACF85395BDF3B7C740 /* TemplateListView.swift */; };
@@ -132,10 +139,10 @@
 		67F2BC41FA8B4BD6EF7D26B6 /* MockAnthropicService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED5C3AB824D34919DA2D319 /* MockAnthropicService.swift */; };
 		ED5F7FB462E07461B1B2D14B /* MockAutoFillService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91456C9AD6483E9EC173B6F /* MockAutoFillService.swift */; };
 		EF0190BDBED8D17D8409E895 /* MockChatMessageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21483199A38B51BC7C2521CF /* MockChatMessageRepository.swift */; };
+		0063611710BE35E7D91E79AC /* MockExercisePhotoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2234A5D7496F3A79D4F68721 /* MockExercisePhotoStorage.swift */; };
 		4173888D7CE008476D62C6D0 /* MockExerciseRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7F1C030210B4FD9412C102 /* MockExerciseRepository.swift */; };
 		0B8CD0F4F223571D13245A83 /* MockHealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6A8AB21975CD8D41A8F00E /* MockHealthKitService.swift */; };
 		2458247201216B2D168155DC /* MockImageUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E43F0552150DFE1A459FF1 /* MockImageUploadService.swift */; };
-		530C839B2A1761609B0613D1 /* MockExercisePhotoStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A677A412D9556764B25F390 /* MockExercisePhotoStorage.swift */; };
 		57B50D38BFC35B9CE81137C1 /* MockInsightGenerationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9E610DA69697073FA94F75 /* MockInsightGenerationService.swift */; };
 		8DF037FDBBFA11DCD4918753 /* MockInsightRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF5085E2591D9D33466039F /* MockInsightRepository.swift */; };
 		C443511381F97AA1A4AF91DF /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32EB615C09D872B5642099AE /* MockNetworkService.swift */; };
@@ -155,6 +162,7 @@
 		57A3D163990B3217BBEE0E9E /* SyncFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596B7259BB2A729958FDC14E /* SyncFieldTests.swift */; };
 		9D3BE9EED86A1527C1CFD894 /* BodyWeightRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D284207770C8E54D8900F7 /* BodyWeightRepositoryTests.swift */; };
 		0211AE6F42D041771E4834FE /* ChatMessageRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85D59F4A1B39E264539D4E2 /* ChatMessageRepositoryTests.swift */; };
+		88C907C03E7855E42ADFA820 /* ExerciseReportRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3FE667152DCD778275FBA8 /* ExerciseReportRepositoryTests.swift */; };
 		0B819C2A0607708C104BB84A /* ExerciseRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D397321C7BF71C14D13348 /* ExerciseRepositoryTests.swift */; };
 		26892DD31B4A2B5F7A0E0BA5 /* FetchPendingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E1E1D54384F6EF73FF85F4 /* FetchPendingTests.swift */; };
 		6AFC4450FF6B44B100A2BC6B /* InsightRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B3665C32CDEA6750F79050 /* InsightRepositoryTests.swift */; };
@@ -169,6 +177,7 @@
 		F6103383559FD5F2FC1F941C /* ChatToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D8413498DFA6B11B17332D /* ChatToolTests.swift */; };
 		707EF5220C619208E9562C65 /* ExerciseImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1699F48EE9B58D4C4FFD8188 /* ExerciseImportServiceTests.swift */; };
 		2D5A983A04F68C5DB57AB82C /* ImageUploadServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEAA6CFA06236E0849598A44 /* ImageUploadServiceTests.swift */; };
+		B22BDFB1E4DBA95BDE829311 /* InboxApplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2EA5C4834BDD04FD51A152 /* InboxApplierTests.swift */; };
 		CCC3D50FD4AF845EE7C23FCB /* InsightGenerationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8E0A6F5B9612A9FD2543C0 /* InsightGenerationServiceTests.swift */; };
 		32CA73C513F6D134204FF792 /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB1BA0FAD7D48CF98800F41 /* KeychainHelperTests.swift */; };
 		5F8BA2A9D7D40C20D07BFB42 /* LogSetToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB61131FBE4F8E956A8F5D4 /* LogSetToolTests.swift */; };
@@ -182,7 +191,6 @@
 		A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */; };
 		74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */; };
 		AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A31E123184E639F96BB6D /* SyncMapperTests.swift */; };
-		88A100000000000000000001 /* InboxApplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B100000000000000000001 /* InboxApplierTests.swift */; };
 		DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */; };
 		ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */; };
 		BD88CA8763EA48B6DF5EA1C0 /* BodyWeightViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A754765C32959052E27AC76D /* BodyWeightViewModelTests.swift */; };
@@ -192,11 +200,12 @@
 		28426E8743F9BFFA58D03268 /* CrashRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0CEBE64639FAD70716AA1D /* CrashRecoveryTests.swift */; };
 		9D77C0AD9475269F6392DC6F /* CreateExerciseViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33FCCC2826B84E9B95FC84 /* CreateExerciseViewModelTests.swift */; };
 		20F178975B299F43207CA68E /* ExerciseLibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E508D41C1E0E51EDCAE86FCD /* ExerciseLibraryViewModelTests.swift */; };
-		D65BC9F93784AD5672813E74 /* ExercisePhotoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38C23CDBB2111BFC7B3F888 /* ExercisePhotoViewModelTests.swift */; };
+		0F69BBEFB87750BD31FD5684 /* ExercisePhotoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF9D20853AA8F48C04A012C /* ExercisePhotoViewModelTests.swift */; };
 		4813B1ECDEF37E3FECE94FD5 /* HistoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F62B35213EBC9B0E172B26 /* HistoryViewModelTests.swift */; };
 		22808144F86FCDCD4967FD58 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C44B0FA03C14D20C9389468 /* HomeViewModelTests.swift */; };
 		6B23B904FEB12E4CC377B8E2 /* LocalPhotoStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C999AB43A1EBD631D51A1240 /* LocalPhotoStorageTests.swift */; };
 		BC062055415B9F5F2AA218D4 /* ProgressChartsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7146F35021932829001C2176 /* ProgressChartsViewModelTests.swift */; };
+		4B340AF9EDD47AEC71F6BF34 /* ReportSheetViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39712B7C0FCDE4D7097EDA8D /* ReportSheetViewModelTests.swift */; };
 		6192B90B42FCA84FFD2BDD3F /* RestTimerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF1E2ACFA475EC9FC3A8195 /* RestTimerViewModelTests.swift */; };
 		9EA086F04073CE8260011E36 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F56BFC5255D1A1D68459C3 /* SettingsViewModelTests.swift */; };
 		F32875CBA3923465ACB2286C /* TemplateEditorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53EAC91BAAC97F5A12CBFB4 /* TemplateEditorViewModelTests.swift */; };
@@ -246,6 +255,7 @@
 		2BF1483C96C693BAE5F110A9 /* AIChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMessage.swift; sourceTree = "<group>"; };
 		7A6B793D764DD53B20A681C4 /* BodyWeightEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightEntry.swift; sourceTree = "<group>"; };
 		079CEF0C4674D4D8CCA2AE1F /* Exercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exercise.swift; sourceTree = "<group>"; };
+		80E2424089BBF208809AA65A /* ExerciseReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseReport.swift; sourceTree = "<group>"; };
 		8A076A2A8717D2613A9E55E9 /* ExerciseTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseTag.swift; sourceTree = "<group>"; };
 		5035DD798098E41C5606543D /* InsightType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightType.swift; sourceTree = "<group>"; };
 		A47B27C6D366AC6B5B841C41 /* MessageRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRole.swift; sourceTree = "<group>"; };
@@ -262,6 +272,7 @@
 		53BAB77C072B33EBD475C6CD /* WorkoutTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutTemplate.swift; sourceTree = "<group>"; };
 		46D4AA065E061FDD6E757E17 /* BodyWeightRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightRepository.swift; sourceTree = "<group>"; };
 		27388103483B9A103008FDCE /* ChatMessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRepository.swift; sourceTree = "<group>"; };
+		D78A51D0B0F20213755CCD97 /* ExerciseReportRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseReportRepository.swift; sourceTree = "<group>"; };
 		31B88BBCC49AB084C279ED7C /* ExerciseRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepository.swift; sourceTree = "<group>"; };
 		8845129EF032F4B5DA730398 /* InsightRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRepository.swift; sourceTree = "<group>"; };
 		3FD4F3111987CDFCA3AABA95 /* PersonalRecordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonalRecordRepository.swift; sourceTree = "<group>"; };
@@ -296,11 +307,11 @@
 		03C20ABB32B60986D79D033B /* StartWorkoutTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartWorkoutTool.swift; sourceTree = "<group>"; };
 		DC74B2285A532C2309640289 /* SuggestWeightTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestWeightTool.swift; sourceTree = "<group>"; };
 		CDDC5F360A390AA0040AFC21 /* ToolContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolContext.swift; sourceTree = "<group>"; };
+		1BF7CB7DF3294D9DAFF7C65E /* InboxApplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxApplier.swift; sourceTree = "<group>"; };
+		A71BAF2B39DA6C199B12A17A /* InboxDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDTOs.swift; sourceTree = "<group>"; };
 		F9B1A9F545D493DBBC868FA7 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		2CED2D3A491B300D7F75FB92 /* NetworkServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceProtocol.swift; sourceTree = "<group>"; };
 		C9BCD31C7FFC0403D006A026 /* SyncDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDTOs.swift; sourceTree = "<group>"; };
-		88B200000000000000000003 /* InboxDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDTOs.swift; sourceTree = "<group>"; };
-		88B200000000000000000004 /* InboxApplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxApplier.swift; sourceTree = "<group>"; };
 		4FF8ADEB5FD7877F7B7421B6 /* SyncError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncError.swift; sourceTree = "<group>"; };
 		4AE7D363C6D2F123079F0F22 /* SyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManager.swift; sourceTree = "<group>"; };
 		16FB222B5EBDBA88E426695A /* SyncMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMapper.swift; sourceTree = "<group>"; };
@@ -309,21 +320,23 @@
 		44153457DFD1B1AF77799FF4 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		C6FF0D1EB078F5CF438D6195 /* LocalPhotoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPhotoStorage.swift; sourceTree = "<group>"; };
 		2BB5C6DF96590C72CEA77BD4 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
-		A1C7F30D4B2E88015CD6119B /* WorkoutCompletionSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutCompletionSummary.swift; sourceTree = "<group>"; };
 		BFB1106CAB595E0F873B0E4E /* ActiveWorkoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModel.swift; sourceTree = "<group>"; };
 		0A915220457843657F447086 /* BodyWeightViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightViewModel.swift; sourceTree = "<group>"; };
 		2481707D7718DFBFE1786D0B /* CalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewModel.swift; sourceTree = "<group>"; };
 		7F447D4EB6221AD59A7EDF9F /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
 		794E0D261A757CCB7E6E0782 /* CreateExerciseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateExerciseViewModel.swift; sourceTree = "<group>"; };
-		2B2598E869D1A7AC1D9626F7 /* ExercisePhotoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExercisePhotoViewModel.swift; sourceTree = "<group>"; };
 		E4A4FBCE77A01C5F9E62C376 /* ExerciseLibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseLibraryViewModel.swift; sourceTree = "<group>"; };
+		72666A78F14FF2C57846319F /* ExercisePhotoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExercisePhotoViewModel.swift; sourceTree = "<group>"; };
 		83B65EEC4D65C7299EC739E6 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
 		44408B76370ECDD1BBB38427 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		8FFEBACB7D0929B1ADBBAD73 /* ProgressChartsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressChartsViewModel.swift; sourceTree = "<group>"; };
+		224167822A323D284DE3CC52 /* ReportListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListViewModel.swift; sourceTree = "<group>"; };
+		0F63FE6D3F14F76EBBCF1D49 /* ReportSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportSheetViewModel.swift; sourceTree = "<group>"; };
 		F73D05E44D2568C801C89B3D /* RestTimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerViewModel.swift; sourceTree = "<group>"; };
 		8F74F9A7CD4DED50BDB90D6A /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		8EB00D1C9712594526486A75 /* TemplateEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEditorViewModel.swift; sourceTree = "<group>"; };
 		ED7DA3C8168497F0DAEAAC17 /* TemplateListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListViewModel.swift; sourceTree = "<group>"; };
+		F20E59C316D5D955F0E978F2 /* WorkoutCompletionSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutCompletionSummary.swift; sourceTree = "<group>"; };
 		7A5364572CD0945B9DF34712 /* ChatInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInputView.swift; sourceTree = "<group>"; };
 		F46741BA3580C948FD432F3B /* ChatMessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageBubbleView.swift; sourceTree = "<group>"; };
 		7DFF909A710BB9CD11A583E7 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
@@ -342,6 +355,9 @@
 		E621B3B1FF74887269E973E4 /* HistoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryListView.swift; sourceTree = "<group>"; };
 		8D92145A78D0FA8A249849A3 /* WorkoutDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutDetailView.swift; sourceTree = "<group>"; };
 		CECB6AB68CCB0415E16DF315 /* WorkoutHistoryRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutHistoryRowView.swift; sourceTree = "<group>"; };
+		ECA7065CC5E2AAC8BC9E1D7A /* OpenReportsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenReportsCard.swift; sourceTree = "<group>"; };
+		AC146910EFFD530F0A3C235A /* ReportListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListView.swift; sourceTree = "<group>"; };
+		57D09714E078FA91D037F834 /* ReportSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportSheetView.swift; sourceTree = "<group>"; };
 		BC5C760E0A9E33E67C052E0B /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		396B9924D1F6E8824EDB5821 /* TemplateEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEditorView.swift; sourceTree = "<group>"; };
 		ACCD8DACF85395BDF3B7C740 /* TemplateListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateListView.swift; sourceTree = "<group>"; };
@@ -362,10 +378,10 @@
 		2ED5C3AB824D34919DA2D319 /* MockAnthropicService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnthropicService.swift; sourceTree = "<group>"; };
 		A91456C9AD6483E9EC173B6F /* MockAutoFillService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAutoFillService.swift; sourceTree = "<group>"; };
 		21483199A38B51BC7C2521CF /* MockChatMessageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockChatMessageRepository.swift; sourceTree = "<group>"; };
+		2234A5D7496F3A79D4F68721 /* MockExercisePhotoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExercisePhotoStorage.swift; sourceTree = "<group>"; };
 		3D7F1C030210B4FD9412C102 /* MockExerciseRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExerciseRepository.swift; sourceTree = "<group>"; };
 		FD6A8AB21975CD8D41A8F00E /* MockHealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHealthKitService.swift; sourceTree = "<group>"; };
 		17E43F0552150DFE1A459FF1 /* MockImageUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageUploadService.swift; sourceTree = "<group>"; };
-		1A677A412D9556764B25F390 /* MockExercisePhotoStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExercisePhotoStorage.swift; sourceTree = "<group>"; };
 		AF9E610DA69697073FA94F75 /* MockInsightGenerationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInsightGenerationService.swift; sourceTree = "<group>"; };
 		FEF5085E2591D9D33466039F /* MockInsightRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInsightRepository.swift; sourceTree = "<group>"; };
 		32EB615C09D872B5642099AE /* MockNetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkService.swift; sourceTree = "<group>"; };
@@ -385,6 +401,7 @@
 		596B7259BB2A729958FDC14E /* SyncFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncFieldTests.swift; sourceTree = "<group>"; };
 		16D284207770C8E54D8900F7 /* BodyWeightRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightRepositoryTests.swift; sourceTree = "<group>"; };
 		C85D59F4A1B39E264539D4E2 /* ChatMessageRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageRepositoryTests.swift; sourceTree = "<group>"; };
+		CC3FE667152DCD778275FBA8 /* ExerciseReportRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseReportRepositoryTests.swift; sourceTree = "<group>"; };
 		E7D397321C7BF71C14D13348 /* ExerciseRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRepositoryTests.swift; sourceTree = "<group>"; };
 		97E1E1D54384F6EF73FF85F4 /* FetchPendingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPendingTests.swift; sourceTree = "<group>"; };
 		F1B3665C32CDEA6750F79050 /* InsightRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightRepositoryTests.swift; sourceTree = "<group>"; };
@@ -399,6 +416,7 @@
 		C8D8413498DFA6B11B17332D /* ChatToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatToolTests.swift; sourceTree = "<group>"; };
 		1699F48EE9B58D4C4FFD8188 /* ExerciseImportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseImportServiceTests.swift; sourceTree = "<group>"; };
 		EEAA6CFA06236E0849598A44 /* ImageUploadServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadServiceTests.swift; sourceTree = "<group>"; };
+		1B2EA5C4834BDD04FD51A152 /* InboxApplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxApplierTests.swift; sourceTree = "<group>"; };
 		8C8E0A6F5B9612A9FD2543C0 /* InsightGenerationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightGenerationServiceTests.swift; sourceTree = "<group>"; };
 		BFB1BA0FAD7D48CF98800F41 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
 		AAB61131FBE4F8E956A8F5D4 /* LogSetToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSetToolTests.swift; sourceTree = "<group>"; };
@@ -412,7 +430,6 @@
 		063A59D9339A3ED9F05E1365 /* SyncDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncDTOTests.swift; sourceTree = "<group>"; };
 		1C0617F4620F537F4CD40042 /* SyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManagerTests.swift; sourceTree = "<group>"; };
 		980A31E123184E639F96BB6D /* SyncMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncMapperTests.swift; sourceTree = "<group>"; };
-		88B100000000000000000001 /* InboxApplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxApplierTests.swift; sourceTree = "<group>"; };
 		F77C5DC8DB64B19B3FF94B84 /* ActiveWorkoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModelTests.swift; sourceTree = "<group>"; };
 		BC4BA4258EB06839B1EB14BE /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		A754765C32959052E27AC76D /* BodyWeightViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightViewModelTests.swift; sourceTree = "<group>"; };
@@ -422,11 +439,12 @@
 		4F0CEBE64639FAD70716AA1D /* CrashRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashRecoveryTests.swift; sourceTree = "<group>"; };
 		BD33FCCC2826B84E9B95FC84 /* CreateExerciseViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateExerciseViewModelTests.swift; sourceTree = "<group>"; };
 		E508D41C1E0E51EDCAE86FCD /* ExerciseLibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseLibraryViewModelTests.swift; sourceTree = "<group>"; };
-		A38C23CDBB2111BFC7B3F888 /* ExercisePhotoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExercisePhotoViewModelTests.swift; sourceTree = "<group>"; };
+		0AF9D20853AA8F48C04A012C /* ExercisePhotoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExercisePhotoViewModelTests.swift; sourceTree = "<group>"; };
 		27F62B35213EBC9B0E172B26 /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
 		1C44B0FA03C14D20C9389468 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		C999AB43A1EBD631D51A1240 /* LocalPhotoStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPhotoStorageTests.swift; sourceTree = "<group>"; };
 		7146F35021932829001C2176 /* ProgressChartsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressChartsViewModelTests.swift; sourceTree = "<group>"; };
+		39712B7C0FCDE4D7097EDA8D /* ReportSheetViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportSheetViewModelTests.swift; sourceTree = "<group>"; };
 		2FF1E2ACFA475EC9FC3A8195 /* RestTimerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerViewModelTests.swift; sourceTree = "<group>"; };
 		84F56BFC5255D1A1D68459C3 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		A53EAC91BAAC97F5A12CBFB4 /* TemplateEditorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateEditorViewModelTests.swift; sourceTree = "<group>"; };
@@ -533,6 +551,7 @@
 				2BF1483C96C693BAE5F110A9,
 				7A6B793D764DD53B20A681C4,
 				079CEF0C4674D4D8CCA2AE1F,
+				80E2424089BBF208809AA65A,
 				8A076A2A8717D2613A9E55E9,
 				5035DD798098E41C5606543D,
 				A47B27C6D366AC6B5B841C41,
@@ -556,6 +575,7 @@
 			children = (
 				46D4AA065E061FDD6E757E17,
 				27388103483B9A103008FDCE,
+				D78A51D0B0F20213755CCD97,
 				31B88BBCC49AB084C279ED7C,
 				8845129EF032F4B5DA730398,
 				3FD4F3111987CDFCA3AABA95,
@@ -613,11 +633,11 @@
 		D9CEC1664156BEADAFFC3182 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				1BF7CB7DF3294D9DAFF7C65E,
+				A71BAF2B39DA6C199B12A17A,
 				F9B1A9F545D493DBBC868FA7,
 				2CED2D3A491B300D7F75FB92,
 				C9BCD31C7FFC0403D006A026,
-				88B200000000000000000003,
-				88B200000000000000000004,
 				4FF8ADEB5FD7877F7B7421B6,
 				4AE7D363C6D2F123079F0F22,
 				16FB222B5EBDBA88E426695A,
@@ -645,16 +665,18 @@
 				2481707D7718DFBFE1786D0B,
 				7F447D4EB6221AD59A7EDF9F,
 				794E0D261A757CCB7E6E0782,
-				2B2598E869D1A7AC1D9626F7,
 				E4A4FBCE77A01C5F9E62C376,
+				72666A78F14FF2C57846319F,
 				83B65EEC4D65C7299EC739E6,
 				44408B76370ECDD1BBB38427,
 				8FFEBACB7D0929B1ADBBAD73,
+				224167822A323D284DE3CC52,
+				0F63FE6D3F14F76EBBCF1D49,
 				F73D05E44D2568C801C89B3D,
 				8F74F9A7CD4DED50BDB90D6A,
 				8EB00D1C9712594526486A75,
 				ED7DA3C8168497F0DAEAAC17,
-				A1C7F30D4B2E88015CD6119B,
+				F20E59C316D5D955F0E978F2,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -665,6 +687,7 @@
 				8FF6457819B0F022F37DA4DF,
 				D0D42FA13FCA147F22B9E0ED,
 				002F92DA9AB9E5A16710E136,
+				355CDF924A985D2B3CBBA62E,
 				DBC1C87C299823EAD050C9E6,
 				5E7093741836CAD53D653A92,
 				FA504820E8335059816FAD47,
@@ -709,6 +732,16 @@
 				CECB6AB68CCB0415E16DF315,
 			);
 			path = History;
+			sourceTree = "<group>";
+		};
+		355CDF924A985D2B3CBBA62E /* Reports */ = {
+			isa = PBXGroup;
+			children = (
+				ECA7065CC5E2AAC8BC9E1D7A,
+				AC146910EFFD530F0A3C235A,
+				57D09714E078FA91D037F834,
+			);
+			path = Reports;
 			sourceTree = "<group>";
 		};
 		DBC1C87C299823EAD050C9E6 /* Settings */ = {
@@ -784,10 +817,10 @@
 				2ED5C3AB824D34919DA2D319,
 				A91456C9AD6483E9EC173B6F,
 				21483199A38B51BC7C2521CF,
+				2234A5D7496F3A79D4F68721,
 				3D7F1C030210B4FD9412C102,
 				FD6A8AB21975CD8D41A8F00E,
 				17E43F0552150DFE1A459FF1,
-				1A677A412D9556764B25F390,
 				AF9E610DA69697073FA94F75,
 				FEF5085E2591D9D33466039F,
 				32EB615C09D872B5642099AE,
@@ -821,6 +854,7 @@
 			children = (
 				16D284207770C8E54D8900F7,
 				C85D59F4A1B39E264539D4E2,
+				CC3FE667152DCD778275FBA8,
 				E7D397321C7BF71C14D13348,
 				97E1E1D54384F6EF73FF85F4,
 				F1B3665C32CDEA6750F79050,
@@ -842,6 +876,7 @@
 				C8D8413498DFA6B11B17332D,
 				1699F48EE9B58D4C4FFD8188,
 				EEAA6CFA06236E0849598A44,
+				1B2EA5C4834BDD04FD51A152,
 				8C8E0A6F5B9612A9FD2543C0,
 				BFB1BA0FAD7D48CF98800F41,
 				AAB61131FBE4F8E956A8F5D4,
@@ -855,7 +890,6 @@
 				063A59D9339A3ED9F05E1365,
 				1C0617F4620F537F4CD40042,
 				980A31E123184E639F96BB6D,
-				88B100000000000000000001,
 			);
 			path = ServiceTests;
 			sourceTree = "<group>";
@@ -872,11 +906,12 @@
 				4F0CEBE64639FAD70716AA1D,
 				BD33FCCC2826B84E9B95FC84,
 				E508D41C1E0E51EDCAE86FCD,
-				A38C23CDBB2111BFC7B3F888,
+				0AF9D20853AA8F48C04A012C,
 				27F62B35213EBC9B0E172B26,
 				1C44B0FA03C14D20C9389468,
 				C999AB43A1EBD631D51A1240,
 				7146F35021932829001C2176,
+				39712B7C0FCDE4D7097EDA8D,
 				2FF1E2ACFA475EC9FC3A8195,
 				84F56BFC5255D1A1D68459C3,
 				A53EAC91BAAC97F5A12CBFB4,
@@ -1027,6 +1062,7 @@
 				CFF5040874B3F6A54D3E919B /* AIChatMessage.swift in Sources */,
 				3140EA1B9B87CF460F9B6833 /* BodyWeightEntry.swift in Sources */,
 				52382BB861D4B80F34875E8C /* Exercise.swift in Sources */,
+				72CE2EE271E6E12D3C0761F3 /* ExerciseReport.swift in Sources */,
 				60CEBBD6C03E9F037F61CD0B /* ExerciseTag.swift in Sources */,
 				04319E32EFCAF08BF95526B4 /* InsightType.swift in Sources */,
 				7A2CD1E1BB714C1E3A67D8F1 /* MessageRole.swift in Sources */,
@@ -1043,6 +1079,7 @@
 				EAFB41C44B257060FF76DF6B /* WorkoutTemplate.swift in Sources */,
 				0D11B927E277E9E76DE1A237 /* BodyWeightRepository.swift in Sources */,
 				EE0992E9F590EB4E1670EC9C /* ChatMessageRepository.swift in Sources */,
+				7915759038B1ECD8C71B7503 /* ExerciseReportRepository.swift in Sources */,
 				C0D933E2006873407AE1C4DB /* ExerciseRepository.swift in Sources */,
 				3CF6BAFDC30A7131796543A7 /* InsightRepository.swift in Sources */,
 				9BC06D370E2B607A3492039E /* PersonalRecordRepository.swift in Sources */,
@@ -1077,11 +1114,11 @@
 				A408611E843D70F6B2D646B3 /* StartWorkoutTool.swift in Sources */,
 				A694F7F7C295536EF45CD4DB /* SuggestWeightTool.swift in Sources */,
 				6AE4A5E440358996B5520B8C /* ToolContext.swift in Sources */,
+				8FF138856D23FE64E52BDC22 /* InboxApplier.swift in Sources */,
+				7E786F2B1B7569A6E43B3B14 /* InboxDTOs.swift in Sources */,
 				7FCB344C018E65A2B3F68ADB /* NetworkService.swift in Sources */,
 				FB0247EC69FD3FB4F904EC26 /* NetworkServiceProtocol.swift in Sources */,
 				85EF683A8D5CD5A5463743F9 /* SyncDTOs.swift in Sources */,
-				88A200000000000000000003 /* InboxDTOs.swift in Sources */,
-				88A200000000000000000004 /* InboxApplier.swift in Sources */,
 				367E44EFD711971EE9F26E88 /* SyncError.swift in Sources */,
 				9E26B7F9F296082858EC69A4 /* SyncManager.swift in Sources */,
 				713C33F9CEAFFD78A9316763 /* SyncMapper.swift in Sources */,
@@ -1091,20 +1128,22 @@
 				0B71D39860B245530CD3B22B /* LocalPhotoStorage.swift in Sources */,
 				39320B32AAB849DA6F4142BC /* SettingsManager.swift in Sources */,
 				B902261B25F991B27E8726CE /* ActiveWorkoutViewModel.swift in Sources */,
-				A1C7F30D4B2E88015CD6119A /* WorkoutCompletionSummary.swift in Sources */,
 				8B39AD114C8A22CA4A12F63D /* BodyWeightViewModel.swift in Sources */,
 				D25F93C9E3A2384DFE178ACB /* CalendarViewModel.swift in Sources */,
 				2AF09F12EAC18CDA1A9FBB47 /* ChatViewModel.swift in Sources */,
 				1D0BB7D76144B34AA7B0C931 /* CreateExerciseViewModel.swift in Sources */,
-				74C62D6A710D7358991AD100 /* ExercisePhotoViewModel.swift in Sources */,
 				F394DC69C45FDC37F529D60B /* ExerciseLibraryViewModel.swift in Sources */,
+				4A361BFFB88AECECD572EB8E /* ExercisePhotoViewModel.swift in Sources */,
 				A18AFE68B9F7A6C5DA63C7B7 /* HistoryViewModel.swift in Sources */,
 				831BCA92C9335364B839B29E /* HomeViewModel.swift in Sources */,
 				AFB61D6A7330C78EAF1CE4C0 /* ProgressChartsViewModel.swift in Sources */,
+				4846E886CAD6B57A39E22797 /* ReportListViewModel.swift in Sources */,
+				18C1EFC1A651DF8BE7FBA15F /* ReportSheetViewModel.swift in Sources */,
 				BF380AD7F3AB5A74946D1F95 /* RestTimerViewModel.swift in Sources */,
 				8F9257365CF1E518C234E289 /* SettingsViewModel.swift in Sources */,
 				8F0C66D0DB17D96C05B52072 /* TemplateEditorViewModel.swift in Sources */,
 				CCE185F5CDFE404D29055941 /* TemplateListViewModel.swift in Sources */,
+				79296A6352563B20FA8C08A4 /* WorkoutCompletionSummary.swift in Sources */,
 				EB9E00C84758623B715B6097 /* ChatInputView.swift in Sources */,
 				11DFC7181F7270821F944347 /* ChatMessageBubbleView.swift in Sources */,
 				1A30DE9F3233FF21726315FD /* ChatView.swift in Sources */,
@@ -1123,6 +1162,9 @@
 				442302FEEFDC74F7B9C701FB /* HistoryListView.swift in Sources */,
 				8327400F40E3350C8CFDBA05 /* WorkoutDetailView.swift in Sources */,
 				F46C48E4C16636361D3A777C /* WorkoutHistoryRowView.swift in Sources */,
+				EC0759F124992E0E65F631F7 /* OpenReportsCard.swift in Sources */,
+				C5C1EA82A96B640A6F68F358 /* ReportListView.swift in Sources */,
+				262F99908A108A499AD1D2E7 /* ReportSheetView.swift in Sources */,
 				24C64726CC9FD0CC88781422 /* SettingsView.swift in Sources */,
 				EDAC6BCC4964DAAA766B5405 /* TemplateEditorView.swift in Sources */,
 				EFB1A7B68E44523C5CA91DB2 /* TemplateListView.swift in Sources */,
@@ -1150,10 +1192,10 @@
 				67F2BC41FA8B4BD6EF7D26B6 /* MockAnthropicService.swift in Sources */,
 				ED5F7FB462E07461B1B2D14B /* MockAutoFillService.swift in Sources */,
 				EF0190BDBED8D17D8409E895 /* MockChatMessageRepository.swift in Sources */,
+				0063611710BE35E7D91E79AC /* MockExercisePhotoStorage.swift in Sources */,
 				4173888D7CE008476D62C6D0 /* MockExerciseRepository.swift in Sources */,
 				0B8CD0F4F223571D13245A83 /* MockHealthKitService.swift in Sources */,
 				2458247201216B2D168155DC /* MockImageUploadService.swift in Sources */,
-				530C839B2A1761609B0613D1 /* MockExercisePhotoStorage.swift in Sources */,
 				57B50D38BFC35B9CE81137C1 /* MockInsightGenerationService.swift in Sources */,
 				8DF037FDBBFA11DCD4918753 /* MockInsightRepository.swift in Sources */,
 				C443511381F97AA1A4AF91DF /* MockNetworkService.swift in Sources */,
@@ -1173,6 +1215,7 @@
 				57A3D163990B3217BBEE0E9E /* SyncFieldTests.swift in Sources */,
 				9D3BE9EED86A1527C1CFD894 /* BodyWeightRepositoryTests.swift in Sources */,
 				0211AE6F42D041771E4834FE /* ChatMessageRepositoryTests.swift in Sources */,
+				88C907C03E7855E42ADFA820 /* ExerciseReportRepositoryTests.swift in Sources */,
 				0B819C2A0607708C104BB84A /* ExerciseRepositoryTests.swift in Sources */,
 				26892DD31B4A2B5F7A0E0BA5 /* FetchPendingTests.swift in Sources */,
 				6AFC4450FF6B44B100A2BC6B /* InsightRepositoryTests.swift in Sources */,
@@ -1187,6 +1230,7 @@
 				F6103383559FD5F2FC1F941C /* ChatToolTests.swift in Sources */,
 				707EF5220C619208E9562C65 /* ExerciseImportServiceTests.swift in Sources */,
 				2D5A983A04F68C5DB57AB82C /* ImageUploadServiceTests.swift in Sources */,
+				B22BDFB1E4DBA95BDE829311 /* InboxApplierTests.swift in Sources */,
 				CCC3D50FD4AF845EE7C23FCB /* InsightGenerationServiceTests.swift in Sources */,
 				32CA73C513F6D134204FF792 /* KeychainHelperTests.swift in Sources */,
 				5F8BA2A9D7D40C20D07BFB42 /* LogSetToolTests.swift in Sources */,
@@ -1200,7 +1244,6 @@
 				A5147B46731B2F78F2A3F97D /* SyncDTOTests.swift in Sources */,
 				74736A8284DBA4537E5CC97D /* SyncManagerTests.swift in Sources */,
 				AFA073FE14BE32FC6DA97DD0 /* SyncMapperTests.swift in Sources */,
-				88A100000000000000000001 /* InboxApplierTests.swift in Sources */,
 				DFDE6819BDCEC50649598092 /* ActiveWorkoutViewModelTests.swift in Sources */,
 				ABF6205F7428FC8856011767 /* AppStateTests.swift in Sources */,
 				BD88CA8763EA48B6DF5EA1C0 /* BodyWeightViewModelTests.swift in Sources */,
@@ -1210,11 +1253,12 @@
 				28426E8743F9BFFA58D03268 /* CrashRecoveryTests.swift in Sources */,
 				9D77C0AD9475269F6392DC6F /* CreateExerciseViewModelTests.swift in Sources */,
 				20F178975B299F43207CA68E /* ExerciseLibraryViewModelTests.swift in Sources */,
-				D65BC9F93784AD5672813E74 /* ExercisePhotoViewModelTests.swift in Sources */,
+				0F69BBEFB87750BD31FD5684 /* ExercisePhotoViewModelTests.swift in Sources */,
 				4813B1ECDEF37E3FECE94FD5 /* HistoryViewModelTests.swift in Sources */,
 				22808144F86FCDCD4967FD58 /* HomeViewModelTests.swift in Sources */,
 				6B23B904FEB12E4CC377B8E2 /* LocalPhotoStorageTests.swift in Sources */,
 				BC062055415B9F5F2AA218D4 /* ProgressChartsViewModelTests.swift in Sources */,
+				4B340AF9EDD47AEC71F6BF34 /* ReportSheetViewModelTests.swift in Sources */,
 				6192B90B42FCA84FFD2BDD3F /* RestTimerViewModelTests.swift in Sources */,
 				9EA086F04073CE8260011E36 /* SettingsViewModelTests.swift in Sources */,
 				F32875CBA3923465ACB2286C /* TemplateEditorViewModelTests.swift in Sources */,

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -1371,7 +1371,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1396,7 +1396,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1420,7 +1420,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.3.0;
@@ -1438,7 +1438,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.3.0;
@@ -1455,7 +1455,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.3.0;
@@ -1472,7 +1472,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.3.0;

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -1367,7 +1367,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1377,7 +1377,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1392,7 +1392,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1402,7 +1402,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1416,10 +1416,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1434,10 +1434,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1451,10 +1451,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1468,10 +1468,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		4DF8695AC30B877952FCC26E /* ActiveWorkoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D95DEF01B532D14260C628DA /* ActiveWorkoutView.swift */; };
 		3D8A244B51132990CE039B82 /* BodyWeightCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4923800CA1FD7F8CB4004C68 /* BodyWeightCard.swift */; };
 		A6561E854F4137DCE189325B /* ExerciseCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38AA7F3DEA42BB23873FA3CF /* ExerciseCardView.swift */; };
+		F7EB7FC7D0A3ED33CD42DC4C /* ExerciseNoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDB50C83E38F026FF38A0A7 /* ExerciseNoteEditorView.swift */; };
 		3FFA31DADD610FBC28E081E2 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872C18983FC82204C6673019 /* HomeView.swift */; };
 		0063A185AE0B214715BA9FBA /* RestTimerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 251A036C35AA00E683BDB9BD /* RestTimerOverlayView.swift */; };
 		790A2E66A6B1A9D8A9CDFB78 /* ResumeWorkoutCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E66131E8982224C5E417AE /* ResumeWorkoutCard.swift */; };
@@ -366,6 +367,7 @@
 		D95DEF01B532D14260C628DA /* ActiveWorkoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutView.swift; sourceTree = "<group>"; };
 		4923800CA1FD7F8CB4004C68 /* BodyWeightCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyWeightCard.swift; sourceTree = "<group>"; };
 		38AA7F3DEA42BB23873FA3CF /* ExerciseCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseCardView.swift; sourceTree = "<group>"; };
+		1CDB50C83E38F026FF38A0A7 /* ExerciseNoteEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseNoteEditorView.swift; sourceTree = "<group>"; };
 		872C18983FC82204C6673019 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		251A036C35AA00E683BDB9BD /* RestTimerOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestTimerOverlayView.swift; sourceTree = "<group>"; };
 		47E66131E8982224C5E417AE /* ResumeWorkoutCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeWorkoutCard.swift; sourceTree = "<group>"; };
@@ -769,6 +771,7 @@
 				D95DEF01B532D14260C628DA,
 				4923800CA1FD7F8CB4004C68,
 				38AA7F3DEA42BB23873FA3CF,
+				1CDB50C83E38F026FF38A0A7,
 				872C18983FC82204C6673019,
 				251A036C35AA00E683BDB9BD,
 				47E66131E8982224C5E417AE,
@@ -1173,6 +1176,7 @@
 				4DF8695AC30B877952FCC26E /* ActiveWorkoutView.swift in Sources */,
 				3D8A244B51132990CE039B82 /* BodyWeightCard.swift in Sources */,
 				A6561E854F4137DCE189325B /* ExerciseCardView.swift in Sources */,
+				F7EB7FC7D0A3ED33CD42DC4C /* ExerciseNoteEditorView.swift in Sources */,
 				3FFA31DADD610FBC28E081E2 /* HomeView.swift in Sources */,
 				0063A185AE0B214715BA9FBA /* RestTimerOverlayView.swift in Sources */,
 				790A2E66A6B1A9D8A9CDFB78 /* ResumeWorkoutCard.swift in Sources */,
@@ -1367,7 +1371,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1377,7 +1381,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1392,7 +1396,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1402,7 +1406,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1416,10 +1420,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1434,10 +1438,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1451,10 +1455,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1468,10 +1472,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/ClaudeLifter.xcodeproj/project.pbxproj
+++ b/ClaudeLifter.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1417,7 +1417,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1432,7 +1432,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ClaudeLifter/ClaudeLifter.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Reads body-weight entries from Health so weights logged elsewhere appear here.";
@@ -1442,7 +1442,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1456,10 +1456,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1474,10 +1474,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1491,10 +1491,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1508,10 +1508,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = 738XNTWZ5K;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddelord.ClaudeLifterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/ClaudeLifter/App/AppSchema.swift
+++ b/ClaudeLifter/App/AppSchema.swift
@@ -36,23 +36,48 @@ enum ClaudeLifterSchemaV2: VersionedSchema {
     }
 }
 
+/// V3 (issue #135): adds `ExerciseReport`. V1 and V2 above are IMMUTABLE
+/// history — never edit an existing version's model list.
+enum ClaudeLifterSchemaV3: VersionedSchema {
+    static let versionIdentifier = Schema.Version(3, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Exercise.self, ExerciseTag.self, WorkoutSet.self,
+            WorkoutExercise.self, TemplateExercise.self, Workout.self,
+            WorkoutTemplate.self, AIChatMessage.self, ProactiveInsight.self,
+            TrainingPreference.self, PersonalRecord.self,
+            BodyWeightEntry.self, ExerciseReport.self
+        ]
+    }
+}
+
 /// The schema version the app currently runs.
-typealias CurrentSchema = ClaudeLifterSchemaV2
+typealias CurrentSchema = ClaudeLifterSchemaV3
 
 enum ClaudeLifterMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [ClaudeLifterSchemaV1.self, ClaudeLifterSchemaV2.self]
+        [
+            ClaudeLifterSchemaV1.self, ClaudeLifterSchemaV2.self,
+            ClaudeLifterSchemaV3.self
+        ]
     }
 
     /// V1→V2 is purely additive (one new model), so lightweight migration
     /// suffices. A schema change without a stage here fails container
     /// creation — which quarantines instead of wiping (issue #72).
     static var stages: [MigrationStage] {
-        [migrateV1toV2]
+        [migrateV1toV2, migrateV2toV3]
     }
 
     static let migrateV1toV2 = MigrationStage.lightweight(
         fromVersion: ClaudeLifterSchemaV1.self,
         toVersion: ClaudeLifterSchemaV2.self
+    )
+
+    /// V2→V3 is purely additive (one new model), so lightweight again.
+    static let migrateV2toV3 = MigrationStage.lightweight(
+        fromVersion: ClaudeLifterSchemaV2.self,
+        toVersion: ClaudeLifterSchemaV3.self
     )
 }

--- a/ClaudeLifter/App/AppSchema.swift
+++ b/ClaudeLifter/App/AppSchema.swift
@@ -52,14 +52,51 @@ enum ClaudeLifterSchemaV3: VersionedSchema {
     }
 }
 
+/// V4 (issue #128): adds template provenance as two NEW models rather than as
+/// properties on `Workout` / `WorkoutExercise`.
+///
+/// That shape is forced, and the reason is worth knowing before anyone tries
+/// again. The `models` lists above name **live** Swift types, so they are not
+/// frozen history: adding a property to `Workout` changes what V1, V2 and V3
+/// mean as well as V4. All four then hash identically and SwiftData refuses the
+/// container with `NSInvalidArgumentException: Duplicate version checksums
+/// detected` — a hard crash on the first launch after the update, not a
+/// recoverable migration failure.
+///
+/// So with live types, a new version can only differ by its model LIST. A
+/// property-only change cannot be versioned here at all without freezing
+/// copies of every affected model (and everything they relate to).
+///
+/// Provenance is a frozen snapshot anyway, so a separate model is the better
+/// shape regardless: it cannot be mutated by ordinary workout edits, and it
+/// references the workout by plain UUID rather than a SwiftData relationship —
+/// deliberately, since a relationship would mean a stored property on
+/// `Workout` and reintroduce the exact problem.
+///
+/// V1–V3 above are IMMUTABLE history — never edit an existing version's list.
+enum ClaudeLifterSchemaV4: VersionedSchema {
+    static let versionIdentifier = Schema.Version(4, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Exercise.self, ExerciseTag.self, WorkoutSet.self,
+            WorkoutExercise.self, TemplateExercise.self, Workout.self,
+            WorkoutTemplate.self, AIChatMessage.self, ProactiveInsight.self,
+            TrainingPreference.self, PersonalRecord.self,
+            BodyWeightEntry.self, ExerciseReport.self,
+            WorkoutTemplateBaseline.self, WorkoutExerciseBaseline.self
+        ]
+    }
+}
+
 /// The schema version the app currently runs.
-typealias CurrentSchema = ClaudeLifterSchemaV3
+typealias CurrentSchema = ClaudeLifterSchemaV4
 
 enum ClaudeLifterMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
         [
             ClaudeLifterSchemaV1.self, ClaudeLifterSchemaV2.self,
-            ClaudeLifterSchemaV3.self
+            ClaudeLifterSchemaV3.self, ClaudeLifterSchemaV4.self
         ]
     }
 
@@ -67,7 +104,7 @@ enum ClaudeLifterMigrationPlan: SchemaMigrationPlan {
     /// suffices. A schema change without a stage here fails container
     /// creation — which quarantines instead of wiping (issue #72).
     static var stages: [MigrationStage] {
-        [migrateV1toV2, migrateV2toV3]
+        [migrateV1toV2, migrateV2toV3, migrateV3toV4]
     }
 
     static let migrateV1toV2 = MigrationStage.lightweight(
@@ -79,5 +116,14 @@ enum ClaudeLifterMigrationPlan: SchemaMigrationPlan {
     static let migrateV2toV3 = MigrationStage.lightweight(
         fromVersion: ClaudeLifterSchemaV2.self,
         toVersion: ClaudeLifterSchemaV3.self
+    )
+
+    /// V3→V4 adds two new models and touches no existing one, so lightweight —
+    /// the same shape as V1→V2 and V2→V3. Verified against a real on-disk V3
+    /// store in `TemplateProvenanceMigrationTests`; an in-memory container does
+    /// not exercise migration at all and would have passed either way.
+    static let migrateV3toV4 = MigrationStage.lightweight(
+        fromVersion: ClaudeLifterSchemaV3.self,
+        toVersion: ClaudeLifterSchemaV4.self
     )
 }

--- a/ClaudeLifter/App/ContentView.swift
+++ b/ClaudeLifter/App/ContentView.swift
@@ -48,7 +48,8 @@ struct ContentView: View {
                     settings: dependencies.settings,
                     appState: appState,
                     autoFillService: dependencies.autoFillService,
-                    prDetectionService: dependencies.prDetectionService
+                    prDetectionService: dependencies.prDetectionService,
+                    baselineRepository: dependencies.baselineRepository
                 )
             }
         }

--- a/ClaudeLifter/App/DependencyContainer.swift
+++ b/ClaudeLifter/App/DependencyContainer.swift
@@ -6,6 +6,7 @@ import SwiftUI
 final class DependencyContainer {
     let workoutRepository: any WorkoutRepository
     let templateRepository: any TemplateRepository
+    let baselineRepository: any TemplateBaselineRepository
     let exerciseRepository: any ExerciseRepository
     let chatRepository: any ChatMessageRepository
     let preferenceRepository: any TrainingPreferenceRepository
@@ -42,6 +43,7 @@ final class DependencyContainer {
 
         let workoutRepo = SwiftDataWorkoutRepository(context: modelContext)
         let templateRepo = SwiftDataTemplateRepository(context: modelContext)
+        let baselineRepo = SwiftDataTemplateBaselineRepository(context: modelContext)
         let chatRepo = SwiftDataChatMessageRepository(context: modelContext)
         let prefRepo = SwiftDataTrainingPreferenceRepository(context: modelContext)
         let insightRepo = SwiftDataInsightRepository(context: modelContext)
@@ -55,6 +57,7 @@ final class DependencyContainer {
 
         self.workoutRepository = workoutRepo
         self.templateRepository = templateRepo
+        self.baselineRepository = baselineRepo
         self.exerciseRepository = exerciseRepo
         self.chatRepository = chatRepo
         self.preferenceRepository = prefRepo

--- a/ClaudeLifter/App/DependencyContainer.swift
+++ b/ClaudeLifter/App/DependencyContainer.swift
@@ -45,7 +45,12 @@ final class DependencyContainer {
         let chatRepo = SwiftDataChatMessageRepository(context: modelContext)
         let prefRepo = SwiftDataTrainingPreferenceRepository(context: modelContext)
         let insightRepo = SwiftDataInsightRepository(context: modelContext)
-        let exerciseRepo = SwiftDataExerciseRepository(context: modelContext)
+        // Custom exercises have no per-record syncStatus, so their only
+        // "a push is due" signal is this callback (#104).
+        let exerciseRepo = SwiftDataExerciseRepository(
+            context: modelContext,
+            onCustomExerciseChanged: { settings.markSnapshotDirty() }
+        )
         let network = NetworkService(settings: settings)
 
         self.workoutRepository = workoutRepo

--- a/ClaudeLifter/App/DependencyContainer.swift
+++ b/ClaudeLifter/App/DependencyContainer.swift
@@ -19,6 +19,7 @@ final class DependencyContainer {
     let insightGenerationService: any InsightGenerationServiceProtocol
     let backupService: any BackupServiceProtocol
     let bodyWeightRepository: any BodyWeightRepository
+    let exerciseReportRepository: any ExerciseReportRepository
     let inboxApplier: InboxApplier
     let healthKitService: any HealthKitServiceProtocol
     /// Shared rest-timer tick source — one instance for the app instead of
@@ -68,9 +69,12 @@ final class DependencyContainer {
         self.imageUploadService = ImageUploadService(networkService: network)
         let bodyWeightRepo = SwiftDataBodyWeightRepository(context: modelContext)
         self.bodyWeightRepository = bodyWeightRepo
+        let reportRepo = SwiftDataExerciseReportRepository(context: modelContext)
+        self.exerciseReportRepository = reportRepo
         let inboxApplier = InboxApplier(
             templateRepository: templateRepo,
-            exerciseRepository: exerciseRepo
+            exerciseRepository: exerciseRepo,
+            reportRepository: reportRepo
         )
         self.inboxApplier = inboxApplier
         self.healthKitService = HealthKitService()
@@ -97,6 +101,7 @@ final class DependencyContainer {
             templateRepository: templateRepo,
             exerciseRepository: exerciseRepo,
             bodyWeightRepository: bodyWeightRepo,
+            exerciseReportRepository: reportRepo,
             networkService: network,
             settings: settings,
             inboxApplier: inboxApplier

--- a/ClaudeLifter/Models/ExerciseReport.swift
+++ b/ClaudeLifter/Models/ExerciseReport.swift
@@ -62,6 +62,54 @@ enum ReportStatus: String, Codable, CaseIterable, Sendable {
     case resolved
 }
 
+/// What the reports list is showing (#146).
+///
+/// Separate from `ReportStatus` because one of the useful views is not a single
+/// status: `backlog` is open + acknowledged, which is what "still outstanding"
+/// actually means and what `list_exercise_reports` returns by default over MCP.
+/// Keeping the two vocabularies aligned matters — the phone and the AI should
+/// not disagree about what is left to do.
+enum ReportStatusFilter: String, CaseIterable, Sendable, Identifiable {
+    /// Open + acknowledged. The default, and the honest answer to "what is left".
+    case backlog
+    case open
+    case acknowledged
+    case resolved
+    case all
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .backlog: return "Outstanding"
+        case .open: return "Open"
+        case .acknowledged: return "Acknowledged"
+        case .resolved: return "Resolved"
+        case .all: return "All"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .backlog: return "tray.full"
+        case .open: return "flag"
+        case .acknowledged: return "checkmark.bubble"
+        case .resolved: return "checkmark.circle"
+        case .all: return "list.bullet"
+        }
+    }
+
+    func includes(_ status: ReportStatus) -> Bool {
+        switch self {
+        case .all: return true
+        case .backlog: return status != .resolved
+        case .open: return status == .open
+        case .acknowledged: return status == .acknowledged
+        case .resolved: return status == .resolved
+        }
+    }
+}
+
 /// A complaint filed from the app — usually mid-workout, in one or two taps —
 /// about an exercise, a logged value, or the app itself (issue #135).
 ///

--- a/ClaudeLifter/Models/ExerciseReport.swift
+++ b/ClaudeLifter/Models/ExerciseReport.swift
@@ -1,0 +1,162 @@
+import Foundation
+import SwiftData
+
+/// What kind of complaint this is. The category is the ONLY thing the user
+/// chooses when filing — every context field (exercise, workout, template,
+/// set state) is captured automatically, because context is something the app
+/// already knows and the gym is a bad place to fill in a form.
+///
+/// The category tells the AI reading these over MCP which captured context
+/// actually matters: `.bug` cares about `workoutId` + `appVersion` and ignores
+/// the exercise; `.wrongExercise` cares about `exerciseExternalId` and
+/// `suggestedReplacement`.
+enum ReportCategory: String, Codable, CaseIterable, Sendable {
+    /// The app misbehaved. Read workoutId, appVersion, contextSummary.
+    case bug
+    /// "Swap this exercise for something else." Read exercise + template.
+    case swapRequest
+    /// The logged exercise is a stand-in because the real one isn't in the
+    /// catalog. Read exerciseExternalId + suggestedReplacement; the fix is
+    /// usually create_custom_exercise plus a template update.
+    case wrongExercise
+    /// A logged value is wrong (bad weight, phantom set).
+    case dataError
+    /// A note about form, setup, or machine settings — folds into the
+    /// exercise's own notes rather than becoming an issue.
+    case formOrSetup
+    case other
+
+    var displayName: String {
+        switch self {
+        case .bug: return "Bug"
+        case .swapRequest: return "Swap it out"
+        case .wrongExercise: return "Wrong exercise"
+        case .dataError: return "Bad data"
+        case .formOrSetup: return "Form / setup"
+        case .other: return "Other"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .bug: return "ladybug"
+        case .swapRequest: return "arrow.triangle.2.circlepath"
+        case .wrongExercise: return "tag"
+        case .dataError: return "exclamationmark.triangle"
+        case .formOrSetup: return "figure.strengthtraining.traditional"
+        case .other: return "ellipsis.bubble"
+        }
+    }
+}
+
+/// Report lifecycle. Without this the AI re-surfaces the same complaints every
+/// session and the backlog stops being trusted — the status is not an
+/// afterthought, it is what makes `list_exercise_reports(status: "open")`
+/// mean something.
+enum ReportStatus: String, Codable, CaseIterable, Sendable {
+    /// Filed, nothing has happened yet.
+    case open
+    /// Seen and understood, but the fix is not done (e.g. a GitHub issue exists).
+    case acknowledged
+    /// Dealt with. Out of the open backlog for good.
+    case resolved
+}
+
+/// A complaint filed from the app — usually mid-workout, in one or two taps —
+/// about an exercise, a logged value, or the app itself (issue #135).
+///
+/// Mirrored to Cosmos by snapshot sync so Claude Code can read the backlog
+/// over MCP, and closed back out through the inbox write path
+/// (`resolveExerciseReport`). Schema V3.
+///
+/// Exercises are referenced by `externalId`, never by `Exercise.id` — the UUID
+/// is minted per install at import time and is meaningless off-device
+/// (`infra/MCP_WRITE_PATH.md`). `exerciseName` is a snapshot taken at file
+/// time so the report stays readable even if the exercise is later swapped
+/// out or renamed — which is precisely what a `.swapRequest` asks for.
+@Model
+final class ExerciseReport: SyncableModel {
+    @Attribute(.unique) var id: UUID
+    var createdAt: Date
+
+    var categoryRaw: String
+    /// The complaint, in the user's own words.
+    var detail: String
+
+    var exerciseExternalId: String?
+    var exerciseName: String?
+    /// For `.swapRequest` / `.wrongExercise`: what it should be instead.
+    var suggestedReplacement: String?
+
+    var workoutId: UUID?
+    var workoutExerciseId: UUID?
+    var templateId: UUID?
+    /// Bounded, human-readable snapshot of the set state at file time, so a
+    /// `.bug` arrives with a repro nobody had to type in the gym.
+    var contextSummary: String?
+
+    var statusRaw: String
+    var resolution: String?
+
+    var appVersion: String?
+    var iosVersion: String?
+    var photoURL: String?
+
+    var syncStatusRaw: String = "pending"
+    var lastModified: Date
+
+    var category: ReportCategory {
+        get { ReportCategory(rawValue: categoryRaw) ?? .other }
+        set { categoryRaw = newValue.rawValue }
+    }
+
+    var status: ReportStatus {
+        get { ReportStatus(rawValue: statusRaw) ?? .open }
+        set { statusRaw = newValue.rawValue }
+    }
+
+    var syncStatus: SyncStatus {
+        get { SyncStatus(rawValue: syncStatusRaw) ?? .pending }
+        set { syncStatusRaw = newValue.rawValue }
+    }
+
+    init(
+        id: UUID = UUID(),
+        createdAt: Date = .now,
+        category: ReportCategory,
+        detail: String,
+        exerciseExternalId: String? = nil,
+        exerciseName: String? = nil,
+        suggestedReplacement: String? = nil,
+        workoutId: UUID? = nil,
+        workoutExerciseId: UUID? = nil,
+        templateId: UUID? = nil,
+        contextSummary: String? = nil,
+        status: ReportStatus = .open,
+        resolution: String? = nil,
+        appVersion: String? = nil,
+        iosVersion: String? = nil,
+        photoURL: String? = nil,
+        syncStatus: SyncStatus = .pending,
+        lastModified: Date = .now
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.categoryRaw = category.rawValue
+        self.detail = detail
+        self.exerciseExternalId = exerciseExternalId
+        self.exerciseName = exerciseName
+        self.suggestedReplacement = suggestedReplacement
+        self.workoutId = workoutId
+        self.workoutExerciseId = workoutExerciseId
+        self.templateId = templateId
+        self.contextSummary = contextSummary
+        self.statusRaw = status.rawValue
+        self.resolution = resolution
+        self.appVersion = appVersion
+        self.iosVersion = iosVersion
+        self.photoURL = photoURL
+        self.syncStatusRaw = syncStatus.rawValue
+        self.lastModified = lastModified
+    }
+}

--- a/ClaudeLifter/Models/WorkoutTemplateBaseline.swift
+++ b/ClaudeLifter/Models/WorkoutTemplateBaseline.swift
@@ -102,3 +102,21 @@ final class WorkoutExerciseBaseline {
         self.plannedNotes = plannedNotes
     }
 }
+
+/// The plan for one exercise, as shown on the workout screen (#144).
+///
+/// A plain value projected from `WorkoutExerciseBaseline` so views never touch
+/// a SwiftData model, and so "there is no plan" is expressible as nil rather
+/// than as a row of zeroes.
+struct PlannedTarget: Equatable, Sendable {
+    let sets: Int
+    let reps: Int
+    let restSeconds: Int
+    let notes: String?
+
+    /// e.g. "3 × 12 · 90s rest" — the whole plan in one glanceable line.
+    var summary: String {
+        let rest = restSeconds > 0 ? " · \(restSeconds)s rest" : ""
+        return "\(sets) × \(reps)\(rest)"
+    }
+}

--- a/ClaudeLifter/Models/WorkoutTemplateBaseline.swift
+++ b/ClaudeLifter/Models/WorkoutTemplateBaseline.swift
@@ -1,0 +1,104 @@
+import Foundation
+import SwiftData
+
+/// The template plan a workout was started from, frozen at start (#128).
+///
+/// Post-workout reconciliation needs to know what was *intended*, and the
+/// workout itself cannot answer that: mutations erase the evidence, and the
+/// logged set values say nothing about intent because auto-fill pre-populates
+/// them from history. Hence a snapshot taken before the user touches anything.
+///
+/// Two deliberate shape choices:
+///
+/// 1. **A separate model, not properties on `Workout`.** The `VersionedSchema`
+///    lists in `AppSchema.swift` name live Swift types, so adding a property to
+///    `Workout` also changes what V1–V3 mean; every version then hashes the
+///    same and SwiftData throws `Duplicate version checksums detected` on
+///    launch. A new model changes only V4's list, which is the one migration
+///    shape that works here.
+/// 2. **`workoutId` as a plain UUID, not a `@Relationship`.** A relationship
+///    would require a stored property on `Workout` and reintroduce (1).
+///
+/// It is also the better model: a frozen record cannot be mutated by ordinary
+/// workout edits.
+@Model
+final class WorkoutTemplateBaseline {
+    @Attribute(.unique) var id: UUID
+    /// The workout this baseline describes. Plain reference — see above.
+    var workoutId: UUID
+    var templateId: UUID
+    /// The template's `lastModified` when the workout started. Reconciliation
+    /// compares against this: if the template has moved on since, the change
+    /// set is a conflict rather than something to apply over someone's edit.
+    var templateRevision: Date?
+    var templateName: String
+    var capturedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        workoutId: UUID,
+        templateId: UUID,
+        templateRevision: Date? = nil,
+        templateName: String,
+        capturedAt: Date = .now
+    ) {
+        self.id = id
+        self.workoutId = workoutId
+        self.templateId = templateId
+        self.templateRevision = templateRevision
+        self.templateName = templateName
+        self.capturedAt = capturedAt
+    }
+}
+
+/// One planned exercise inside a `WorkoutTemplateBaseline` (#128).
+///
+/// A workout exercise with no matching baseline row was added mid-workout —
+/// that absence is precisely how a genuine addition is told apart from a
+/// planned one, and it is the signal #129's change detection runs on.
+@Model
+final class WorkoutExerciseBaseline {
+    @Attribute(.unique) var id: UUID
+    var workoutId: UUID
+    /// The `WorkoutExercise` copied from this plan, when one was created.
+    var workoutExerciseId: UUID?
+    var sourceTemplateExerciseId: UUID
+    var exerciseId: UUID
+    /// Stable catalog id, so a baseline still resolves after a reinstall mints
+    /// new exercise UUIDs — the identity rule from `infra/MCP_WRITE_PATH.md`.
+    var exerciseExternalId: String?
+    var exerciseName: String
+    var plannedOrder: Int
+    var plannedSets: Int
+    var plannedReps: Int
+    var plannedRestSeconds: Int
+    var plannedNotes: String?
+
+    init(
+        id: UUID = UUID(),
+        workoutId: UUID,
+        workoutExerciseId: UUID? = nil,
+        sourceTemplateExerciseId: UUID,
+        exerciseId: UUID,
+        exerciseExternalId: String? = nil,
+        exerciseName: String,
+        plannedOrder: Int,
+        plannedSets: Int,
+        plannedReps: Int,
+        plannedRestSeconds: Int,
+        plannedNotes: String? = nil
+    ) {
+        self.id = id
+        self.workoutId = workoutId
+        self.workoutExerciseId = workoutExerciseId
+        self.sourceTemplateExerciseId = sourceTemplateExerciseId
+        self.exerciseId = exerciseId
+        self.exerciseExternalId = exerciseExternalId
+        self.exerciseName = exerciseName
+        self.plannedOrder = plannedOrder
+        self.plannedSets = plannedSets
+        self.plannedReps = plannedReps
+        self.plannedRestSeconds = plannedRestSeconds
+        self.plannedNotes = plannedNotes
+    }
+}

--- a/ClaudeLifter/Repositories/ExerciseReportRepository.swift
+++ b/ClaudeLifter/Repositories/ExerciseReportRepository.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+@MainActor
+protocol ExerciseReportRepository {
+    func fetchAll() async throws -> [ExerciseReport]
+    func fetch(id: UUID) async throws -> ExerciseReport?
+    /// Everything not yet resolved — the backlog the Home badge counts and
+    /// `list_exercise_reports` defaults to.
+    func fetchOpen() async throws -> [ExerciseReport]
+    func fetchPending() async throws -> [ExerciseReport]
+    func save(_ report: ExerciseReport) async throws
+    func delete(_ report: ExerciseReport) async throws
+}
+
+@MainActor
+final class SwiftDataExerciseReportRepository: ExerciseReportRepository {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    func fetchAll() async throws -> [ExerciseReport] {
+        let descriptor = FetchDescriptor<ExerciseReport>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try context.fetch(descriptor)
+    }
+
+    func fetch(id: UUID) async throws -> ExerciseReport? {
+        let descriptor = FetchDescriptor<ExerciseReport>(
+            predicate: #Predicate { $0.id == id }
+        )
+        return try context.fetch(descriptor).first
+    }
+
+    func fetchOpen() async throws -> [ExerciseReport] {
+        // "Open" is everything that is not resolved — acknowledged reports are
+        // still outstanding work, they have only been read.
+        let resolvedRaw = ReportStatus.resolved.rawValue
+        let descriptor = FetchDescriptor<ExerciseReport>(
+            predicate: #Predicate { $0.statusRaw != resolvedRaw },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try context.fetch(descriptor)
+    }
+
+    func fetchPending() async throws -> [ExerciseReport] {
+        let pendingRaw = SyncStatus.pending.rawValue
+        let descriptor = FetchDescriptor<ExerciseReport>(
+            predicate: #Predicate { $0.syncStatusRaw == pendingRaw }
+        )
+        return try context.fetch(descriptor)
+    }
+
+    func save(_ report: ExerciseReport) async throws {
+        context.insert(report)
+        try context.save()
+    }
+
+    func delete(_ report: ExerciseReport) async throws {
+        context.delete(report)
+        try context.save()
+    }
+}

--- a/ClaudeLifter/Repositories/ExerciseRepository.swift
+++ b/ClaudeLifter/Repositories/ExerciseRepository.swift
@@ -152,18 +152,26 @@ final class SwiftDataExerciseRepository: ExerciseRepository {
         return Array(Set(tags.map(\.value))).sorted()
     }
 
+    // Every save marks the snapshot dirty, not only `isCustom` ones (#140).
+    // A bundled exercise now carries synced data too — its note and photo
+    // travel as an overlay — and gating on "does it currently hold data"
+    // would silently drop the case that matters most: CLEARING a note, where
+    // the exercise is clean by the time it is saved and the stale overlay
+    // would then live in the mirror forever.
+    //
+    // The ~800-row first-launch import does not come through here — it inserts
+    // into the context directly (ExerciseImportService) — so this costs one
+    // flag write per genuine user edit.
+
     func save(_ exercise: Exercise) async throws {
-        let isCustom = exercise.isCustom
         context.insert(exercise)
         try context.save()
-        if isCustom { onCustomExerciseChanged() }
+        onCustomExerciseChanged()
     }
 
     func delete(_ exercise: Exercise) async throws {
-        // Read before the delete — touching a deleted model is undefined.
-        let isCustom = exercise.isCustom
         context.delete(exercise)
         try context.save()
-        if isCustom { onCustomExerciseChanged() }
+        onCustomExerciseChanged()
     }
 }

--- a/ClaudeLifter/Repositories/ExerciseRepository.swift
+++ b/ClaudeLifter/Repositories/ExerciseRepository.swift
@@ -23,8 +23,22 @@ protocol ExerciseRepository {
 final class SwiftDataExerciseRepository: ExerciseRepository {
     private let context: ModelContext
 
-    init(context: ModelContext) {
+    /// Invoked when a CUSTOM exercise is created, updated, or deleted.
+    ///
+    /// `Exercise` is the one mirrored type with no per-record `syncStatus`,
+    /// so `hasPendingChanges` cannot see it and a custom exercise created
+    /// through the UI would sit unpushed until some unrelated workout change
+    /// happened to trigger a snapshot (#104). This callback is that missing
+    /// signal. Bundled exercises are excluded — they are never mirrored, and
+    /// marking on import would dirty the phone 800 times on first launch.
+    private let onCustomExerciseChanged: () -> Void
+
+    init(
+        context: ModelContext,
+        onCustomExerciseChanged: @escaping () -> Void = {}
+    ) {
         self.context = context
+        self.onCustomExerciseChanged = onCustomExerciseChanged
     }
 
     func fetchAll() async throws -> [Exercise] {
@@ -139,12 +153,17 @@ final class SwiftDataExerciseRepository: ExerciseRepository {
     }
 
     func save(_ exercise: Exercise) async throws {
+        let isCustom = exercise.isCustom
         context.insert(exercise)
         try context.save()
+        if isCustom { onCustomExerciseChanged() }
     }
 
     func delete(_ exercise: Exercise) async throws {
+        // Read before the delete — touching a deleted model is undefined.
+        let isCustom = exercise.isCustom
         context.delete(exercise)
         try context.save()
+        if isCustom { onCustomExerciseChanged() }
     }
 }

--- a/ClaudeLifter/Repositories/TemplateBaselineRepository.swift
+++ b/ClaudeLifter/Repositories/TemplateBaselineRepository.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftData
+
+/// Storage for the frozen template plan a workout started from (#128).
+///
+/// Baselines are written once, at workout start, and only ever read after —
+/// there is no update path on purpose. A snapshot that can be edited is not a
+/// snapshot, and the whole value of it is that ordinary workout mutations
+/// cannot reach it.
+@MainActor
+protocol TemplateBaselineRepository {
+    func fetchBaseline(workoutId: UUID) async throws -> WorkoutTemplateBaseline?
+    func fetchEntries(workoutId: UUID) async throws -> [WorkoutExerciseBaseline]
+    func save(
+        _ baseline: WorkoutTemplateBaseline,
+        entries: [WorkoutExerciseBaseline]
+    ) async throws
+    func delete(workoutId: UUID) async throws
+}
+
+@MainActor
+final class SwiftDataTemplateBaselineRepository: TemplateBaselineRepository {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    func fetchBaseline(workoutId: UUID) async throws -> WorkoutTemplateBaseline? {
+        let descriptor = FetchDescriptor<WorkoutTemplateBaseline>(
+            predicate: #Predicate { $0.workoutId == workoutId }
+        )
+        return try context.fetch(descriptor).first
+    }
+
+    func fetchEntries(workoutId: UUID) async throws -> [WorkoutExerciseBaseline] {
+        let descriptor = FetchDescriptor<WorkoutExerciseBaseline>(
+            predicate: #Predicate { $0.workoutId == workoutId },
+            sortBy: [SortDescriptor(\.plannedOrder)]
+        )
+        return try context.fetch(descriptor)
+    }
+
+    func save(
+        _ baseline: WorkoutTemplateBaseline,
+        entries: [WorkoutExerciseBaseline]
+    ) async throws {
+        context.insert(baseline)
+        for entry in entries {
+            context.insert(entry)
+        }
+        try context.save()
+    }
+
+    /// Used when a workout is discarded — an empty ghost session, or a cancel.
+    /// A baseline for a workout that no longer exists is orphaned data that
+    /// nothing will ever collect.
+    func delete(workoutId: UUID) async throws {
+        for entry in try await fetchEntries(workoutId: workoutId) {
+            context.delete(entry)
+        }
+        if let baseline = try await fetchBaseline(workoutId: workoutId) {
+            context.delete(baseline)
+        }
+        try context.save()
+    }
+}

--- a/ClaudeLifter/Services/BackupService.swift
+++ b/ClaudeLifter/Services/BackupService.swift
@@ -3,9 +3,25 @@ import SwiftData
 
 // MARK: - Backup wire format
 
+/// User data attached to a **bundled** exercise (#140).
+///
+/// The exercise itself re-imports from the app bundle, so carrying all 800 of
+/// them would be waste — but the notes and photo the user attached to one are
+/// not in the bundle and are lost forever without this.
+///
+/// Keyed by `externalId`, never by `id`: a reinstall re-imports the catalog
+/// with brand-new random UUIDs, so a UUID-keyed overlay would attach to
+/// nothing. Same identity rule as the MCP write path.
+struct ExerciseOverlayDTO: Codable, Sendable, Equatable {
+    let externalId: String?
+    let notes: String?
+    let photoURL: String?
+}
+
 /// A device-local JSON backup: everything the user would lose if the store were
-/// wiped and cloud sync had never run. Bundled (non-custom) exercises are omitted
-/// — they re-import from the app bundle — so only `isCustom` exercises are carried.
+/// wiped and cloud sync had never run. Bundled (non-custom) exercises are not
+/// carried in full — they re-import from the app bundle — but the user data
+/// attached to them travels as `exerciseOverlays` (#140).
 struct BackupDocument: Codable, Sendable {
     let formatVersion: Int
     let exportedAt: Date
@@ -16,6 +32,42 @@ struct BackupDocument: Codable, Sendable {
     /// written before issue #78 still decode.
     let customExercises: [ExerciseDTO]
     let preferences: [PreferenceDTO]
+    /// Present from formatVersion 2. Decodes as empty for older files, which
+    /// import unchanged — the same tolerance the snapshot wire format uses
+    /// for `exerciseReports`.
+    let exerciseOverlays: [ExerciseOverlayDTO]
+
+    init(
+        formatVersion: Int,
+        exportedAt: Date,
+        workouts: [WorkoutDTO],
+        templates: [TemplateDTO],
+        customExercises: [ExerciseDTO],
+        preferences: [PreferenceDTO],
+        exerciseOverlays: [ExerciseOverlayDTO] = []
+    ) {
+        self.formatVersion = formatVersion
+        self.exportedAt = exportedAt
+        self.workouts = workouts
+        self.templates = templates
+        self.customExercises = customExercises
+        self.preferences = preferences
+        self.exerciseOverlays = exerciseOverlays
+    }
+
+    init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        formatVersion = try c.decode(Int.self, forKey: .formatVersion)
+        exportedAt = try c.decode(Date.self, forKey: .exportedAt)
+        workouts = try c.decode([WorkoutDTO].self, forKey: .workouts)
+        templates = try c.decode([TemplateDTO].self, forKey: .templates)
+        customExercises = try c.decode([ExerciseDTO].self, forKey: .customExercises)
+        preferences = try c.decode([PreferenceDTO].self, forKey: .preferences)
+        exerciseOverlays = try c.decodeIfPresent(
+            [ExerciseOverlayDTO].self,
+            forKey: .exerciseOverlays
+        ) ?? []
+    }
 }
 
 // MARK: - Import errors
@@ -50,6 +102,9 @@ struct BackupImportSummary: Sendable, Equatable {
     var templates = CollectionResult()
     var workouts = CollectionResult()
     var preferences = CollectionResult()
+    /// Bundled-exercise user data (#140). `skipped` means the overlay had no
+    /// matching exercise locally — it is never used to invent one.
+    var exerciseOverlays = CollectionResult()
 }
 
 // MARK: - Service
@@ -116,14 +171,27 @@ final class BackupService: BackupServiceProtocol {
             .filter { $0.isCustom }
             .map { SyncMapper.toDTO($0) }
         let preferences = try await preferenceRepository.fetchAll().map { SyncMapper.toDTO($0) }
+        // Only bundled exercises that actually carry user data (#140) — the
+        // other ~800 are reproduced from the app bundle on import.
+        let overlays = try await exerciseRepository.fetchAll()
+            .filter { !$0.isCustom && $0.externalId != nil }
+            .filter { $0.notes?.isEmpty == false || $0.photoURL?.isEmpty == false }
+            .map {
+                ExerciseOverlayDTO(
+                    externalId: $0.externalId,
+                    notes: $0.notes,
+                    photoURL: $0.photoURL
+                )
+            }
 
         let document = BackupDocument(
-            formatVersion: 1,
+            formatVersion: 2,
             exportedAt: .now,
             workouts: workouts,
             templates: templates,
             customExercises: customExercises,
-            preferences: preferences
+            preferences: preferences,
+            exerciseOverlays: overlays
         )
 
         let data = try encoder.encode(document)
@@ -209,6 +277,33 @@ final class BackupService: BackupServiceProtocol {
             modelContext.insert(preference)
             try modelContext.save()
             summary.preferences.imported += 1
+        }
+
+        // 5. Bundled-exercise user data (#140). Applied LAST, and unlike every
+        // other collection this one overwrites rather than skips: restoring a
+        // backup means "make this device look like the backup", and the
+        // overlay is the only copy of a machine setting that exists. Matched
+        // by externalId because a re-imported catalog has different UUIDs.
+        //
+        // An overlay with no matching exercise is skipped, never used to
+        // invent one — a bundled exercise the app bundle does not contain is
+        // not something a backup should conjure.
+        for overlay in document.exerciseOverlays {
+            guard
+                let externalId = overlay.externalId,
+                let exercise = try await exerciseRepository.fetchByExternalId(externalId)
+            else {
+                summary.exerciseOverlays.skipped += 1
+                continue
+            }
+            if let notes = overlay.notes, !notes.isEmpty {
+                exercise.notes = notes
+            }
+            if let photoURL = overlay.photoURL, !photoURL.isEmpty {
+                exercise.photoURL = photoURL
+            }
+            try modelContext.save()
+            summary.exerciseOverlays.imported += 1
         }
 
         return summary

--- a/ClaudeLifter/Services/BackupService.swift
+++ b/ClaudeLifter/Services/BackupService.swift
@@ -12,11 +12,10 @@ import SwiftData
 /// Keyed by `externalId`, never by `id`: a reinstall re-imports the catalog
 /// with brand-new random UUIDs, so a UUID-keyed overlay would attach to
 /// nothing. Same identity rule as the MCP write path.
-struct ExerciseOverlayDTO: Codable, Sendable, Equatable {
-    let externalId: String?
-    let notes: String?
-    let photoURL: String?
-}
+// `ExerciseOverlayDTO` now lives in Services/Sync/SyncDTOs.swift — the backup
+// file and the snapshot wire carry the same shape, and #140's sync half needed
+// a non-optional `id` for the Cosmos document key. Files written by 1.4.0 with
+// only `externalId` still decode.
 
 /// A device-local JSON backup: everything the user would lose if the store were
 /// wiped and cloud sync had never run. Bundled (non-custom) exercises are not
@@ -178,7 +177,7 @@ final class BackupService: BackupServiceProtocol {
             .filter { $0.notes?.isEmpty == false || $0.photoURL?.isEmpty == false }
             .map {
                 ExerciseOverlayDTO(
-                    externalId: $0.externalId,
+                    id: $0.externalId ?? "",
                     notes: $0.notes,
                     photoURL: $0.photoURL
                 )

--- a/ClaudeLifter/Services/InsightGenerationService.swift
+++ b/ClaudeLifter/Services/InsightGenerationService.swift
@@ -47,8 +47,13 @@ final class InsightGenerationService: InsightGenerationServiceProtocol {
     }
 
     func generateInsights() async throws -> [ProactiveInsight] {
-        let twoWeeksAgo = Calendar.current.date(byAdding: .day, value: -14, to: Date())!
-        let workouts = try await workoutRepository.fetchByDateRange(from: twoWeeksAgo, to: Date())
+        // Force-unwrap removed (#93): a nil here would crash insight
+        // generation on app open. Two weeks of seconds is an exact fallback —
+        // no DST or calendar subtlety matters for a lookback window.
+        let now = Date()
+        let twoWeeksAgo = Calendar.current.date(byAdding: .day, value: -14, to: now)
+            ?? now.addingTimeInterval(-14 * 24 * 60 * 60)
+        let workouts = try await workoutRepository.fetchByDateRange(from: twoWeeksAgo, to: now)
 
         let summary = buildWorkoutSummary(workouts)
 

--- a/ClaudeLifter/Services/Sync/InboxApplier.swift
+++ b/ClaudeLifter/Services/Sync/InboxApplier.swift
@@ -259,9 +259,13 @@ final class InboxApplier {
             status = .resolved
         case ReportStatus.acknowledged.rawValue:
             status = .acknowledged
+        case ReportStatus.open.rawValue:
+            // Reopening, allowed since #146. It was refused on the grounds
+            // that the inbox exists to close reports out — but a fix that
+            // turns out to be inert (#136) needs a route back, and reopening
+            // surfaces a complaint rather than hiding one.
+            status = .open
         case let other?:
-            // `.open` is rejected too: an inbox operation exists to close a
-            // report, never to reopen one behind the user's back.
             throw InboxApplyError.invalidReportStatus(other)
         }
 

--- a/ClaudeLifter/Services/Sync/InboxApplier.swift
+++ b/ClaudeLifter/Services/Sync/InboxApplier.swift
@@ -8,6 +8,9 @@ enum InboxApplyError: Error, LocalizedError {
     case templateNotFound(String)
     case unresolvedExerciseIds([String])
     case invalidCustomExternalId(String)
+    case invalidReportId(String)
+    case reportNotFound(String)
+    case invalidReportStatus(String)
 
     var errorDescription: String? {
         switch self {
@@ -25,6 +28,12 @@ enum InboxApplyError: Error, LocalizedError {
             return "Unresolved exercise externalIds: \(ids.joined(separator: ", "))"
         case .invalidCustomExternalId(let id):
             return "Invalid custom exercise externalId: \(id)"
+        case .invalidReportId(let id):
+            return "Invalid report id: \(id)"
+        case .reportNotFound(let id):
+            return "Report not found: \(id)"
+        case .invalidReportStatus(let status):
+            return "Invalid report status: \(status) (expected acknowledged or resolved)"
         }
     }
 }
@@ -38,13 +47,16 @@ enum InboxApplyError: Error, LocalizedError {
 final class InboxApplier {
     private let templateRepository: any TemplateRepository
     private let exerciseRepository: any ExerciseRepository
+    private let reportRepository: any ExerciseReportRepository
 
     init(
         templateRepository: any TemplateRepository,
-        exerciseRepository: any ExerciseRepository
+        exerciseRepository: any ExerciseRepository,
+        reportRepository: any ExerciseReportRepository
     ) {
         self.templateRepository = templateRepository
         self.exerciseRepository = exerciseRepository
+        self.reportRepository = reportRepository
     }
 
     /// Process every operation even when an earlier one is malformed or fails.
@@ -156,6 +168,12 @@ final class InboxApplier {
                 id: try entityID(for: operation)
             )
 
+        case "resolveExerciseReport":
+            let payload = try decode(
+                ResolveExerciseReportPayload.self, from: operation.payload
+            )
+            try await resolveExerciseReport(payload)
+
         case "updateTemplate":
             let payload = try decode(UpdateTemplatePayload.self, from: operation.payload)
             try validateUpdatePayload(payload)
@@ -222,11 +240,44 @@ final class InboxApplier {
         try await exerciseRepository.save(exercise)
     }
 
+    /// Closing out a report is deliberately approval-free: the whole point of
+    /// the status lifecycle is that the AI can clear the backlog without a
+    /// second confirmation step, and the write is trivially reversible.
+    private func resolveExerciseReport(
+        _ payload: ResolveExerciseReportPayload
+    ) async throws {
+        guard let id = UUID(uuidString: payload.id) else {
+            throw InboxApplyError.invalidReportId(payload.id)
+        }
+        guard let report = try await reportRepository.fetch(id: id) else {
+            throw InboxApplyError.reportNotFound(payload.id)
+        }
+
+        let status: ReportStatus
+        switch payload.status {
+        case nil, ReportStatus.resolved.rawValue:
+            status = .resolved
+        case ReportStatus.acknowledged.rawValue:
+            status = .acknowledged
+        case let other?:
+            // `.open` is rejected too: an inbox operation exists to close a
+            // report, never to reopen one behind the user's back.
+            throw InboxApplyError.invalidReportStatus(other)
+        }
+
+        report.status = status
+        if let resolution = payload.resolution {
+            report.resolution = resolution
+        }
+        report.recordChange()
+        try await reportRepository.save(report)
+    }
+
     private func approvalRequirement(for operation: String) throws -> Bool {
         switch operation {
         case "updateTemplate", "deleteTemplate":
             return true
-        case "createTemplate", "createCustomExercise":
+        case "createTemplate", "createCustomExercise", "resolveExerciseReport":
             return false
         default:
             throw InboxApplyError.unknownOperation(operation)

--- a/ClaudeLifter/Services/Sync/InboxDTOs.swift
+++ b/ClaudeLifter/Services/Sync/InboxDTOs.swift
@@ -94,6 +94,15 @@ struct CreateCustomExercisePayload: Codable, Sendable, Equatable {
     let notes: String?
 }
 
+/// Closes out a user-filed report (issue #135). `status` is the terminal
+/// state the AI is asserting — "resolved" for done, "acknowledged" for seen
+/// but still outstanding (a GitHub issue exists, say).
+struct ResolveExerciseReportPayload: Codable, Sendable, Equatable {
+    let id: String
+    let status: String?
+    let resolution: String?
+}
+
 /// GET /api/inbox operation envelope. `op` and `status` remain raw strings so
 /// an unknown value is isolated to this operation by the applier.
 struct InboxOperationDTO: Codable, Sendable, Equatable {

--- a/ClaudeLifter/Services/Sync/SyncDTOs.swift
+++ b/ClaudeLifter/Services/Sync/SyncDTOs.swift
@@ -175,6 +175,55 @@ struct PreferenceDTO: Codable, Sendable {
     let lastModified: Date
 }
 
+/// User data layered onto a *bundled* exercise — the machine note and the
+/// photo. Bundled exercises themselves are never synced (all ~800 reproduce
+/// from the app bundle), so before #140 this data existed only on the device
+/// that typed it.
+///
+/// Keyed by `externalId`, the stable free-exercise-db identifier, and NOT by
+/// `Exercise.id`: a reinstall re-imports the library with fresh UUIDs, so a
+/// UUID key would orphan every overlay exactly when it was needed most.
+///
+/// `id` is the Cosmos document key and carries the same value. Both keys are
+/// written, and either is accepted on decode, because backup files produced
+/// by 1.4.0 wrote only `externalId`.
+struct ExerciseOverlayDTO: Codable, Sendable, Equatable {
+    let id: String
+    let notes: String?
+    let photoURL: String?
+
+    var externalId: String? { id }
+
+    init(id: String, notes: String?, photoURL: String?) {
+        self.id = id
+        self.notes = notes
+        self.photoURL = photoURL
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, externalId, notes, photoURL
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        if let id = try c.decodeIfPresent(String.self, forKey: .id) {
+            self.id = id
+        } else {
+            self.id = try c.decode(String.self, forKey: .externalId)
+        }
+        notes = try c.decodeIfPresent(String.self, forKey: .notes)
+        photoURL = try c.decodeIfPresent(String.self, forKey: .photoURL)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(id, forKey: .externalId)
+        try c.encodeIfPresent(notes, forKey: .notes)
+        try c.encodeIfPresent(photoURL, forKey: .photoURL)
+    }
+}
+
 // MARK: - Snapshot request/response (POST/GET /api/sync/snapshot)
 
 /// The complete mirrored state. ALWAYS carries all five collections — the
@@ -191,19 +240,24 @@ struct SyncSnapshot: Codable, Sendable {
     let customExercises: [ExerciseDTO]
     let bodyWeightEntries: [BodyWeightEntryDTO]
     let exerciseReports: [ExerciseReportDTO]
+    /// Arrived with schemaVersion 4 (issue #140). Decodes as empty when
+    /// absent, for the same reason `exerciseReports` does.
+    let exerciseOverlays: [ExerciseOverlayDTO]
 
     init(
         workouts: [WorkoutDTO],
         templates: [TemplateDTO],
         customExercises: [ExerciseDTO],
         bodyWeightEntries: [BodyWeightEntryDTO],
-        exerciseReports: [ExerciseReportDTO] = []
+        exerciseReports: [ExerciseReportDTO] = [],
+        exerciseOverlays: [ExerciseOverlayDTO] = []
     ) {
         self.workouts = workouts
         self.templates = templates
         self.customExercises = customExercises
         self.bodyWeightEntries = bodyWeightEntries
         self.exerciseReports = exerciseReports
+        self.exerciseOverlays = exerciseOverlays
     }
 
     init(from decoder: Decoder) throws {
@@ -217,14 +271,24 @@ struct SyncSnapshot: Codable, Sendable {
         exerciseReports = try container.decodeIfPresent(
             [ExerciseReportDTO].self, forKey: .exerciseReports
         ) ?? []
+        exerciseOverlays = try container.decodeIfPresent(
+            [ExerciseOverlayDTO].self, forKey: .exerciseOverlays
+        ) ?? []
     }
 }
 
 struct SnapshotPushRequest: Codable, Sendable {
+    /// Wire contract the client speaks. 4 adds `exerciseOverlays` (#140).
+    static let currentSchemaVersion = 4
+    /// What to fall back to when the server has not been updated yet. The
+    /// Functions app deploys independently of the phone, and this time the
+    /// phone can ship first — see SyncManager.pushSnapshot.
+    static let fallbackSchemaVersion = 3
+
     let schemaVersion: Int
     let snapshot: SyncSnapshot
 
-    init(schemaVersion: Int = 3, snapshot: SyncSnapshot) {
+    init(schemaVersion: Int = SnapshotPushRequest.currentSchemaVersion, snapshot: SyncSnapshot) {
         self.schemaVersion = schemaVersion
         self.snapshot = snapshot
     }

--- a/ClaudeLifter/Services/Sync/SyncDTOs.swift
+++ b/ClaudeLifter/Services/Sync/SyncDTOs.swift
@@ -141,6 +141,30 @@ struct BodyWeightEntryDTO: Codable, Sendable {
     let lastModified: Date
 }
 
+/// A user-filed complaint (issue #135). Mirrored so the MCP server can read
+/// the backlog; `category`/`status` stay raw strings on the wire so an
+/// unrecognised value from a newer app build round-trips instead of failing
+/// the whole snapshot.
+struct ExerciseReportDTO: Codable, Sendable {
+    let id: UUID
+    let createdAt: Date
+    let category: String
+    let detail: String
+    let exerciseExternalId: String?
+    let exerciseName: String?
+    let suggestedReplacement: String?
+    let workoutId: UUID?
+    let workoutExerciseId: UUID?
+    let templateId: UUID?
+    let contextSummary: String?
+    let status: String
+    let resolution: String?
+    let appVersion: String?
+    let iosVersion: String?
+    let photoURL: String?
+    let lastModified: Date
+}
+
 /// Still on the wire for local backup files only (BackupService). Preferences
 /// are NOT part of cloud sync — that path caused the pull ping-pong (#78).
 struct PreferenceDTO: Codable, Sendable {
@@ -153,22 +177,54 @@ struct PreferenceDTO: Codable, Sendable {
 
 // MARK: - Snapshot request/response (POST/GET /api/sync/snapshot)
 
-/// The complete mirrored state. ALWAYS carries all four collections — the
+/// The complete mirrored state. ALWAYS carries all five collections — the
 /// server rejects a missing key (400), and an empty array means "wipe that
 /// type on the server". That is how deletions propagate: no tombstones, the
 /// server deletes any doc absent from the snapshot.
+///
+/// `exerciseReports` arrived with schemaVersion 3 (issue #135). It decodes as
+/// empty when absent so a v2 payload — an old backup file, or the GET of a
+/// mirror last written by a v2 client — still restores.
 struct SyncSnapshot: Codable, Sendable {
     let workouts: [WorkoutDTO]
     let templates: [TemplateDTO]
     let customExercises: [ExerciseDTO]
     let bodyWeightEntries: [BodyWeightEntryDTO]
+    let exerciseReports: [ExerciseReportDTO]
+
+    init(
+        workouts: [WorkoutDTO],
+        templates: [TemplateDTO],
+        customExercises: [ExerciseDTO],
+        bodyWeightEntries: [BodyWeightEntryDTO],
+        exerciseReports: [ExerciseReportDTO] = []
+    ) {
+        self.workouts = workouts
+        self.templates = templates
+        self.customExercises = customExercises
+        self.bodyWeightEntries = bodyWeightEntries
+        self.exerciseReports = exerciseReports
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workouts = try container.decode([WorkoutDTO].self, forKey: .workouts)
+        templates = try container.decode([TemplateDTO].self, forKey: .templates)
+        customExercises = try container.decode([ExerciseDTO].self, forKey: .customExercises)
+        bodyWeightEntries = try container.decode(
+            [BodyWeightEntryDTO].self, forKey: .bodyWeightEntries
+        )
+        exerciseReports = try container.decodeIfPresent(
+            [ExerciseReportDTO].self, forKey: .exerciseReports
+        ) ?? []
+    }
 }
 
 struct SnapshotPushRequest: Codable, Sendable {
     let schemaVersion: Int
     let snapshot: SyncSnapshot
 
-    init(schemaVersion: Int = 2, snapshot: SyncSnapshot) {
+    init(schemaVersion: Int = 3, snapshot: SyncSnapshot) {
         self.schemaVersion = schemaVersion
         self.snapshot = snapshot
     }

--- a/ClaudeLifter/Services/Sync/SyncManager.swift
+++ b/ClaudeLifter/Services/Sync/SyncManager.swift
@@ -40,6 +40,8 @@ struct RestoreSummary: Sendable, Equatable {
     var customExercises = 0
     var bodyWeightEntries = 0
     var exerciseReports = 0
+    /// Bundled exercises whose note/photo was reapplied from the mirror (#140).
+    var exerciseOverlays = 0
     /// Placeholder custom exercises created for exerciseIds that resolved
     /// neither by id nor by name (issue #79 fold-in). Zero on a healthy restore.
     var placeholderExercises = 0
@@ -331,6 +333,19 @@ final class SyncManager: InboxApprovalManaging {
         let customExercises = try await exerciseRepository.fetchAll().filter(\.isCustom)
         let bodyWeightEntries = try await bodyWeightRepository.fetchAll()
         let exerciseReports = try await exerciseReportRepository.fetchAll()
+        // Bundled exercises are never mirrored — all ~800 reproduce from the
+        // app bundle — but the user data attached to them is irreplaceable
+        // and, before #140, was never pushed at all. An exercise with no
+        // externalId cannot be keyed and is skipped rather than guessed at.
+        let exerciseOverlays = try await exerciseRepository.fetchAll()
+            .filter { !$0.isCustom }
+            .compactMap { exercise -> ExerciseOverlayDTO? in
+                guard let externalId = exercise.externalId, !externalId.isEmpty else { return nil }
+                let notes = exercise.notes?.isEmpty == false ? exercise.notes : nil
+                let photoURL = exercise.photoURL?.isEmpty == false ? exercise.photoURL : nil
+                guard notes != nil || photoURL != nil else { return nil }
+                return ExerciseOverlayDTO(id: externalId, notes: notes, photoURL: photoURL)
+            }
 
         // Snapshot lastModified at serialization time: a record edited while
         // the POST is in flight must stay .pending — the server received the
@@ -348,11 +363,12 @@ final class SyncManager: InboxApprovalManaging {
                 templates: templates.map { SyncMapper.toDTO($0) },
                 customExercises: customExercises.map { SyncMapper.toDTO($0) },
                 bodyWeightEntries: bodyWeightEntries.map { SyncMapper.toDTO($0) },
-                exerciseReports: exerciseReports.map { SyncMapper.toDTO($0) }
+                exerciseReports: exerciseReports.map { SyncMapper.toDTO($0) },
+                exerciseOverlays: exerciseOverlays
             )
         )
 
-        let response = try await networkService.pushSnapshot(request)
+        let response = try await push(request)
 
         for workout in workouts where workout.lastModified == workoutModified[workout.id] {
             workout.syncStatus = .synced
@@ -369,6 +385,28 @@ final class SyncManager: InboxApprovalManaging {
 
         recordSuccess(revision: response.revision, serverTime: response.serverTime)
         settings.markSnapshotClean(upTo: generation)
+    }
+
+    /// Sends the push, degrading to the previous wire version once if the
+    /// server rejects this one.
+    ///
+    /// The Functions app and the phone deploy independently, and there is no
+    /// ordering guarantee between them. Without this, installing a build whose
+    /// wire version the server has not learned yet breaks sync *entirely* —
+    /// not just the new collection — until someone remembers to deploy. A 400
+    /// is the server saying "I do not know this schemaVersion"; anything else
+    /// is a real failure and is rethrown untouched.
+    private func push(_ request: SnapshotPushRequest) async throws -> SnapshotPushResponse {
+        do {
+            return try await networkService.pushSnapshot(request)
+        } catch SyncError.serverError(400)
+            where request.schemaVersion > SnapshotPushRequest.fallbackSchemaVersion {
+            let downgraded = SnapshotPushRequest(
+                schemaVersion: SnapshotPushRequest.fallbackSchemaVersion,
+                snapshot: request.snapshot
+            )
+            return try await networkService.pushSnapshot(downgraded)
+        }
     }
 
     // MARK: - Restore
@@ -459,6 +497,29 @@ final class SyncManager: InboxApprovalManaging {
                     SyncMapper.createExerciseReport(from: dto)
                 )
                 summary.exerciseReports += 1
+            }
+
+            // 6. Overlays LAST, and by externalId — the bundled library was
+            //    re-imported with fresh UUIDs, so this is the only key that
+            //    still means anything (#140). An overlay for an exercise this
+            //    build does not ship is dropped, not an error: the library can
+            //    change between the backup and the restore.
+            if !snapshot.exerciseOverlays.isEmpty {
+                let installed = try await exerciseRepository.fetchAll()
+                let byExternalId = Dictionary(
+                    installed.compactMap { exercise -> (String, Exercise)? in
+                        guard let externalId = exercise.externalId else { return nil }
+                        return (externalId, exercise)
+                    },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                for dto in snapshot.exerciseOverlays {
+                    guard let exercise = byExternalId[dto.id] else { continue }
+                    if let notes = dto.notes { exercise.notes = notes }
+                    if let photoURL = dto.photoURL { exercise.photoURL = photoURL }
+                    try await exerciseRepository.save(exercise)
+                    summary.exerciseOverlays += 1
+                }
             }
 
             recordSuccess(revision: response.revision, serverTime: response.serverTime)

--- a/ClaudeLifter/Services/Sync/SyncManager.swift
+++ b/ClaudeLifter/Services/Sync/SyncManager.swift
@@ -149,7 +149,7 @@ final class SyncManager: InboxApprovalManaging {
             if !inbox.operations.isEmpty {
                 let results = await inboxApplier.process(inbox.operations)
                 if results.contains(where: { $0.status == .applied }) {
-                    settings.isSnapshotDirty = true
+                    settings.markSnapshotDirty()
                 }
                 let request = InboxAckRequest(results: results)
                 let response = try await networkService.ackInbox(
@@ -283,7 +283,7 @@ final class SyncManager: InboxApprovalManaging {
                 ? await inboxApplier.approve(operation)
                 : inboxApplier.decline(operation)
             if result.status == .applied {
-                settings.isSnapshotDirty = true
+                settings.markSnapshotDirty()
             }
             let request = InboxAckRequest(results: [result])
             let response = try await networkService.ackInbox(
@@ -323,6 +323,9 @@ final class SyncManager: InboxApprovalManaging {
     /// server revision. On any failure, everything stays `.pending` and the
     /// next trigger retries — the operation is idempotent by design.
     func pushSnapshot() async throws {
+        // Read BEFORE serializing: anything marked dirty from here on did not
+        // make it into this payload and must survive the clear below (#104).
+        let generation = settings.currentSnapshotGeneration()
         let workouts = try await workoutRepository.fetchAll()
         let templates = try await templateRepository.fetchAll()
         let customExercises = try await exerciseRepository.fetchAll().filter(\.isCustom)
@@ -365,7 +368,7 @@ final class SyncManager: InboxApprovalManaging {
         }
 
         recordSuccess(revision: response.revision, serverTime: response.serverTime)
-        settings.isSnapshotDirty = false
+        settings.markSnapshotClean(upTo: generation)
     }
 
     // MARK: - Restore

--- a/ClaudeLifter/Services/Sync/SyncManager.swift
+++ b/ClaudeLifter/Services/Sync/SyncManager.swift
@@ -39,6 +39,7 @@ struct RestoreSummary: Sendable, Equatable {
     var templates = 0
     var customExercises = 0
     var bodyWeightEntries = 0
+    var exerciseReports = 0
     /// Placeholder custom exercises created for exerciseIds that resolved
     /// neither by id nor by name (issue #79 fold-in). Zero on a healthy restore.
     var placeholderExercises = 0
@@ -80,6 +81,7 @@ final class SyncManager: InboxApprovalManaging {
     /// restore resolves exercise references (and creates placeholders).
     private let exerciseRepository: any ExerciseRepository
     private let bodyWeightRepository: any BodyWeightRepository
+    private let exerciseReportRepository: any ExerciseReportRepository
     private let networkService: any NetworkServiceProtocol
     private let settings: SettingsManager
     private let inboxApplier: InboxApplier
@@ -92,6 +94,7 @@ final class SyncManager: InboxApprovalManaging {
         templateRepository: any TemplateRepository,
         exerciseRepository: any ExerciseRepository,
         bodyWeightRepository: any BodyWeightRepository,
+        exerciseReportRepository: any ExerciseReportRepository,
         networkService: any NetworkServiceProtocol,
         settings: SettingsManager,
         inboxApplier: InboxApplier
@@ -100,6 +103,7 @@ final class SyncManager: InboxApprovalManaging {
         self.templateRepository = templateRepository
         self.exerciseRepository = exerciseRepository
         self.bodyWeightRepository = bodyWeightRepository
+        self.exerciseReportRepository = exerciseReportRepository
         self.networkService = networkService
         self.settings = settings
         self.inboxApplier = inboxApplier
@@ -179,6 +183,7 @@ final class SyncManager: InboxApprovalManaging {
         if try await !workoutRepository.fetchPending().isEmpty { return true }
         if try await !templateRepository.fetchPending().isEmpty { return true }
         if try await !bodyWeightRepository.fetchPending().isEmpty { return true }
+        if try await !exerciseReportRepository.fetchPending().isEmpty { return true }
         return false
     }
 
@@ -313,7 +318,7 @@ final class SyncManager: InboxApprovalManaging {
 
     // MARK: - Push
 
-    /// Serialize the complete local state of the four mirrored types and POST
+    /// Serialize the complete local state of the five mirrored types and POST
     /// it as one snapshot. On 200, mark records `.synced` and persist the
     /// server revision. On any failure, everything stays `.pending` and the
     /// next trigger retries — the operation is idempotent by design.
@@ -322,6 +327,7 @@ final class SyncManager: InboxApprovalManaging {
         let templates = try await templateRepository.fetchAll()
         let customExercises = try await exerciseRepository.fetchAll().filter(\.isCustom)
         let bodyWeightEntries = try await bodyWeightRepository.fetchAll()
+        let exerciseReports = try await exerciseReportRepository.fetchAll()
 
         // Snapshot lastModified at serialization time: a record edited while
         // the POST is in flight must stay .pending — the server received the
@@ -329,15 +335,17 @@ final class SyncManager: InboxApprovalManaging {
         let workoutModified = Dictionary(uniqueKeysWithValues: workouts.map { ($0.id, $0.lastModified) })
         let templateModified = Dictionary(uniqueKeysWithValues: templates.map { ($0.id, $0.lastModified) })
         let entryModified = Dictionary(uniqueKeysWithValues: bodyWeightEntries.map { ($0.id, $0.lastModified) })
+        let reportModified = Dictionary(uniqueKeysWithValues: exerciseReports.map { ($0.id, $0.lastModified) })
 
-        // ALWAYS all four collections, even when empty — the server rejects a
+        // ALWAYS all five collections, even when empty — the server rejects a
         // missing key, and an empty array legitimately means "wipe that type".
         let request = SnapshotPushRequest(
             snapshot: SyncSnapshot(
                 workouts: workouts.map { SyncMapper.toDTO($0) },
                 templates: templates.map { SyncMapper.toDTO($0) },
                 customExercises: customExercises.map { SyncMapper.toDTO($0) },
-                bodyWeightEntries: bodyWeightEntries.map { SyncMapper.toDTO($0) }
+                bodyWeightEntries: bodyWeightEntries.map { SyncMapper.toDTO($0) },
+                exerciseReports: exerciseReports.map { SyncMapper.toDTO($0) }
             )
         )
 
@@ -352,6 +360,9 @@ final class SyncManager: InboxApprovalManaging {
         for entry in bodyWeightEntries where entry.lastModified == entryModified[entry.id] {
             entry.syncStatus = .synced
         }
+        for report in exerciseReports where report.lastModified == reportModified[report.id] {
+            report.syncStatus = .synced
+        }
 
         recordSuccess(revision: response.revision, serverTime: response.serverTime)
         settings.isSnapshotDirty = false
@@ -360,7 +371,7 @@ final class SyncManager: InboxApprovalManaging {
     // MARK: - Restore
 
     /// Disaster recovery: fetch the cloud mirror and REPLACE local data for the
-    /// four mirrored types. Never touches chat history, insights, preferences,
+    /// five mirrored types. Never touches chat history, insights, preferences,
     /// or the bundled exercise library. Destructive — callers must confirm with
     /// the user first (Settings does).
     func restoreFromSnapshot() async throws -> RestoreSummary {
@@ -372,7 +383,7 @@ final class SyncManager: InboxApprovalManaging {
         do {
             let response = try await networkService.fetchSnapshot()
 
-            // A fresh mirror (never pushed to) reads as revision 0 with four
+            // A fresh mirror (never pushed to) reads as revision 0 with
             // empty arrays. Wiping local data with that would be data loss
             // dressed up as a restore — refuse.
             guard response.revision > 0 else { throw SyncError.emptyMirror }
@@ -381,7 +392,7 @@ final class SyncManager: InboxApprovalManaging {
             var summary = RestoreSummary()
             summary.revision = response.revision
 
-            // 1. Wipe the four mirrored types.
+            // 1. Wipe the five mirrored types.
             for workout in try await workoutRepository.fetchAll() {
                 try await workoutRepository.delete(workout)
             }
@@ -393,6 +404,9 @@ final class SyncManager: InboxApprovalManaging {
             }
             for entry in try await bodyWeightRepository.fetchAll() {
                 try await bodyWeightRepository.delete(entry)
+            }
+            for report in try await exerciseReportRepository.fetchAll() {
+                try await exerciseReportRepository.delete(report)
             }
 
             // 2. Custom exercises FIRST so template/workout references resolve.
@@ -435,6 +449,13 @@ final class SyncManager: InboxApprovalManaging {
             for dto in snapshot.bodyWeightEntries {
                 try await bodyWeightRepository.save(SyncMapper.createBodyWeightEntry(from: dto))
                 summary.bodyWeightEntries += 1
+            }
+
+            for dto in snapshot.exerciseReports {
+                try await exerciseReportRepository.save(
+                    SyncMapper.createExerciseReport(from: dto)
+                )
+                summary.exerciseReports += 1
             }
 
             recordSuccess(revision: response.revision, serverTime: response.serverTime)

--- a/ClaudeLifter/Services/Sync/SyncMapper.swift
+++ b/ClaudeLifter/Services/Sync/SyncMapper.swift
@@ -112,6 +112,28 @@ enum SyncMapper {
         )
     }
 
+    static func toDTO(_ report: ExerciseReport) -> ExerciseReportDTO {
+        ExerciseReportDTO(
+            id: report.id,
+            createdAt: report.createdAt,
+            category: report.categoryRaw,
+            detail: report.detail,
+            exerciseExternalId: report.exerciseExternalId,
+            exerciseName: report.exerciseName,
+            suggestedReplacement: report.suggestedReplacement,
+            workoutId: report.workoutId,
+            workoutExerciseId: report.workoutExerciseId,
+            templateId: report.templateId,
+            contextSummary: report.contextSummary,
+            status: report.statusRaw,
+            resolution: report.resolution,
+            appVersion: report.appVersion,
+            iosVersion: report.iosVersion,
+            photoURL: report.photoURL,
+            lastModified: report.lastModified
+        )
+    }
+
     static func toDTO(_ pref: TrainingPreference) -> PreferenceDTO {
         PreferenceDTO(
             id: pref.id,
@@ -245,6 +267,36 @@ enum SyncMapper {
             syncStatus: .synced,
             lastModified: dto.lastModified
         )
+    }
+
+    static func createExerciseReport(from dto: ExerciseReportDTO) -> ExerciseReport {
+        let report = ExerciseReport(
+            id: dto.id,
+            createdAt: dto.createdAt,
+            category: ReportCategory(rawValue: dto.category) ?? .other,
+            detail: dto.detail,
+            exerciseExternalId: dto.exerciseExternalId,
+            exerciseName: dto.exerciseName,
+            suggestedReplacement: dto.suggestedReplacement,
+            workoutId: dto.workoutId,
+            workoutExerciseId: dto.workoutExerciseId,
+            templateId: dto.templateId,
+            contextSummary: dto.contextSummary,
+            status: ReportStatus(rawValue: dto.status) ?? .open,
+            resolution: dto.resolution,
+            appVersion: dto.appVersion,
+            iosVersion: dto.iosVersion,
+            photoURL: dto.photoURL,
+            syncStatus: .synced,
+            lastModified: dto.lastModified
+        )
+        // Keep the wire values verbatim rather than the coerced enums: a
+        // category written by a newer build must survive a restore instead of
+        // being flattened to `.other`. The computed accessors do the fallback
+        // at read time, so unknown values stay readable without being lost.
+        report.categoryRaw = dto.category
+        report.statusRaw = dto.status
+        return report
     }
 
     static func createPreference(from dto: PreferenceDTO) -> TrainingPreference {

--- a/ClaudeLifter/Services/TemplateChangeApplier.swift
+++ b/ClaudeLifter/Services/TemplateChangeApplier.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+enum TemplateChangeApplyError: Error, LocalizedError, Equatable {
+    case templateNotFound
+    case conflict
+    case unresolvedExercise(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .templateNotFound:
+            return "That template no longer exists, so it wasn't updated. Your workout is saved."
+        case .conflict:
+            return "The template changed somewhere else since this workout started, so nothing was applied. Your workout is saved."
+        case .unresolvedExercise(let name):
+            return "\(name) couldn't be found in your library, so the template wasn't updated. Your workout is saved."
+        }
+    }
+}
+
+/// Applies a reviewed subset of a `TemplateChangeSet` to its template (#130).
+///
+/// Three rules, in order of importance:
+///
+/// 1. **The workout is already saved before this runs.** Nothing here can undo,
+///    hide or delay it. A failure costs a template update and nothing else,
+///    which is why every error message says so.
+/// 2. **All or nothing.** The template is rebuilt in memory and saved once, so
+///    a partial application is not a state the user can end up in.
+/// 3. **Re-fetch and re-check first.** The template is read fresh and its
+///    revision compared again — the review sheet may have sat on screen while
+///    the Coach or the MCP inbox changed the same template.
+@MainActor
+struct TemplateChangeApplier {
+    private let templateRepository: any TemplateRepository
+    private let exerciseRepository: any ExerciseRepository
+
+    init(
+        templateRepository: any TemplateRepository,
+        exerciseRepository: any ExerciseRepository
+    ) {
+        self.templateRepository = templateRepository
+        self.exerciseRepository = exerciseRepository
+    }
+
+    /// - Parameters:
+    ///   - changes: only the changes the user actually selected.
+    ///   - changeSet: the full set, for its template id and captured revision.
+    ///   - capturedRevision: the template's `lastModified` when the workout
+    ///     started, re-checked here rather than trusted from detection time.
+    func apply(
+        _ changes: [TemplateChange],
+        from changeSet: TemplateChangeSet,
+        capturedRevision: Date?
+    ) async throws {
+        guard !changes.isEmpty else { return }
+
+        guard let template = try await templateRepository.fetch(id: changeSet.templateId) else {
+            throw TemplateChangeApplyError.templateNotFound
+        }
+        if let capturedRevision, template.lastModified > capturedRevision {
+            throw TemplateChangeApplyError.conflict
+        }
+
+        // Work on a plain list first: every reference is resolved and every
+        // edit applied in memory before anything is written.
+        var planned = template.exercises.sorted { $0.order < $1.order }
+
+        for change in changes {
+            switch change {
+            case .removedExercise(let removal):
+                planned.removeAll { $0.id == removal.sourceTemplateExerciseId }
+
+            case .setCountChanged(let change):
+                planned.first { $0.id == change.sourceTemplateExerciseId }?
+                    .defaultSets = change.to
+
+            case .cueChanged(let change):
+                planned.first { $0.id == change.sourceTemplateExerciseId }?
+                    .notes = change.to
+
+            case .reordered(let reorder):
+                // Reindex to the order the workout ran, keeping any template
+                // exercise the workout never mentioned at the end rather than
+                // dropping it.
+                var byId = Dictionary(
+                    planned.map { ($0.id, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+                var reordered: [TemplateExercise] = []
+                for id in reorder.sourceTemplateExerciseIds {
+                    if let te = byId.removeValue(forKey: id) {
+                        reordered.append(te)
+                    }
+                }
+                reordered.append(contentsOf: planned.filter { byId[$0.id] != nil })
+                planned = reordered
+
+            case .addedExercise(let addition):
+                let exercise = try await resolve(addition)
+                planned.append(TemplateExercise(
+                    order: planned.count,
+                    exercise: exercise,
+                    defaultSets: addition.sets,
+                    defaultReps: addition.reps ?? 8,
+                    defaultWeight: nil,
+                    defaultRestSeconds: addition.restSeconds,
+                    notes: nil
+                ))
+            }
+        }
+
+        // Normalise ordering so the template never carries gaps or duplicates,
+        // whatever combination of changes was selected.
+        for (index, te) in planned.enumerated() {
+            te.order = index
+        }
+
+        template.exercises = planned
+        template.updatedAt = .now
+        template.recordChange()
+        try await templateRepository.save(template)
+    }
+
+    /// Resolve by `externalId` first — the stable catalog id — and fall back to
+    /// the local UUID for a custom exercise, which has no external id.
+    private func resolve(
+        _ addition: TemplateChange.AddedExercise
+    ) async throws -> Exercise {
+        if let externalId = addition.externalId,
+           let match = try await exerciseRepository.fetchByExternalId(externalId) {
+            return match
+        }
+        if let match = try await exerciseRepository.fetch(id: addition.exerciseId) {
+            return match
+        }
+        throw TemplateChangeApplyError.unresolvedExercise(addition.name)
+    }
+}

--- a/ClaudeLifter/Services/TemplateChangeDetector.swift
+++ b/ClaudeLifter/Services/TemplateChangeDetector.swift
@@ -64,6 +64,10 @@ struct TemplateChangeSet: Equatable, Sendable {
     let templateId: UUID
     let templateName: String
     let changes: [TemplateChange]
+    /// The template's `lastModified` when the workout started. Carried here so
+    /// apply can re-check for a conflict at the moment the user taps Apply,
+    /// which may be minutes after detection ran.
+    let capturedRevision: Date?
     /// The template moved on since this workout started, so applying these
     /// changes would overwrite an edit made elsewhere — from the Coach, the MCP
     /// inbox, or the template editor. Surfaced instead of silently winning.
@@ -200,6 +204,7 @@ struct TemplateChangeDetector {
             templateId: baseline.templateId,
             templateName: template.name,
             changes: changes,
+            capturedRevision: baseline.templateRevision,
             hasConflict: hasConflict(baseline: baseline, template: template)
         )
     }

--- a/ClaudeLifter/Services/TemplateChangeDetector.swift
+++ b/ClaudeLifter/Services/TemplateChangeDetector.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+/// One proposed change to a template, inferred from a finished workout (#129).
+///
+/// Every case represents something the user did *deliberately* — added an
+/// exercise and trained it, removed one, reordered, changed how many sets were
+/// planned, or rewrote a cue. Nothing here is inferred from performance.
+enum TemplateChange: Identifiable, Equatable, Sendable {
+    case addedExercise(AddedExercise)
+    case removedExercise(RemovedExercise)
+    case reordered(Reorder)
+    case setCountChanged(SetCountChange)
+    case cueChanged(CueChange)
+
+    struct AddedExercise: Equatable, Sendable {
+        let exerciseId: UUID
+        let externalId: String?
+        let name: String
+        let order: Int
+        let sets: Int
+        let reps: Int?
+        let restSeconds: Int
+    }
+
+    struct RemovedExercise: Equatable, Sendable {
+        let sourceTemplateExerciseId: UUID
+        let exerciseId: UUID
+        let name: String
+    }
+
+    struct Reorder: Equatable, Sendable {
+        /// Planned exercises in the order the workout actually ran them.
+        let sourceTemplateExerciseIds: [UUID]
+        let names: [String]
+    }
+
+    struct SetCountChange: Equatable, Sendable {
+        let sourceTemplateExerciseId: UUID
+        let name: String
+        let from: Int
+        let to: Int
+    }
+
+    struct CueChange: Equatable, Sendable {
+        let sourceTemplateExerciseId: UUID
+        let name: String
+        let from: String?
+        let to: String?
+    }
+
+    var id: String {
+        switch self {
+        case .addedExercise(let c): return "added-\(c.exerciseId)"
+        case .removedExercise(let c): return "removed-\(c.sourceTemplateExerciseId)"
+        case .reordered: return "reordered"
+        case .setCountChanged(let c): return "sets-\(c.sourceTemplateExerciseId)"
+        case .cueChanged(let c): return "cue-\(c.sourceTemplateExerciseId)"
+        }
+    }
+}
+
+/// The outcome of comparing a finished workout to the template it started from.
+struct TemplateChangeSet: Equatable, Sendable {
+    let templateId: UUID
+    let templateName: String
+    let changes: [TemplateChange]
+    /// The template moved on since this workout started, so applying these
+    /// changes would overwrite an edit made elsewhere — from the Coach, the MCP
+    /// inbox, or the template editor. Surfaced instead of silently winning.
+    let hasConflict: Bool
+
+    var isEmpty: Bool { changes.isEmpty }
+}
+
+/// Compares a finished workout against the plan it started from (#129).
+///
+/// Pure and synchronous: no repositories, no SwiftData fetches, no clock. It
+/// takes the workout, the frozen baseline (#128) and the template as it stands
+/// now, and returns proposals. That makes every rule below directly testable,
+/// which matters because the rules are the whole product.
+///
+/// ## What is deliberately NOT detected
+///
+/// - **Logged weights and reps, ever.** `AutoFillService` pre-populates sets
+///   from history, so a set's values reflect what the user did last time, not
+///   what the template asked for. Diffing them against template defaults is
+///   semantically meaningless — it would propose a "change" on every workout.
+/// - **Skipped or incomplete exercises as removals.** Not finishing an exercise
+///   is the most ordinary thing in a gym. Only an explicit removal counts.
+/// - **Target reps and rest seconds.** There is no UI that changes either
+///   mid-workout — `WorkoutExercise.restSeconds` is written once at
+///   construction and never mutated — so any difference would be noise, not
+///   intent. When such a control exists, this is where it plugs in.
+struct TemplateChangeDetector {
+
+    /// - Parameters:
+    ///   - workout: the finished session.
+    ///   - baseline: the plan frozen at start, and its per-exercise entries.
+    ///   - template: the template **as it stands now**, for conflict detection.
+    func detect(
+        workout: Workout,
+        baseline: WorkoutTemplateBaseline,
+        entries: [WorkoutExerciseBaseline],
+        template: WorkoutTemplate
+    ) -> TemplateChangeSet {
+        var changes: [TemplateChange] = []
+
+        let workoutExercises = workout.exercises.sorted { $0.order < $1.order }
+        let entryByWorkoutExerciseId = Dictionary(
+            entries.compactMap { entry in
+                entry.workoutExerciseId.map { ($0, entry) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        // 1. Additions. An exercise with no baseline entry was added
+        //    mid-workout — but only propose it if it was actually trained.
+        //    Adding an exercise and leaving it untouched is not a plan.
+        for we in workoutExercises where entryByWorkoutExerciseId[we.id] == nil {
+            guard let exercise = we.exercise else { continue }
+            guard we.sets.contains(where: { $0.isCompleted }) else { continue }
+            let completed = we.sets.filter(\.isCompleted)
+            changes.append(.addedExercise(.init(
+                exerciseId: exercise.id,
+                externalId: exercise.externalId,
+                name: exercise.name,
+                order: we.order,
+                sets: completed.count,
+                // Modal logged reps, as a starting suggestion only — the user
+                // confirms it in review. This is not diffing against a target.
+                reps: modalReps(of: completed),
+                restSeconds: we.restSeconds
+            )))
+        }
+
+        // 2. Removals — only explicit ones. A planned exercise whose
+        //    WorkoutExercise is gone from the session was removed by hand; one
+        //    that is still present but unfinished was merely skipped.
+        let survivingWorkoutExerciseIds = Set(workoutExercises.map(\.id))
+        for entry in entries.sorted(by: { $0.plannedOrder < $1.plannedOrder }) {
+            guard let plannedWorkoutExerciseId = entry.workoutExerciseId else { continue }
+            if !survivingWorkoutExerciseIds.contains(plannedWorkoutExerciseId) {
+                changes.append(.removedExercise(.init(
+                    sourceTemplateExerciseId: entry.sourceTemplateExerciseId,
+                    exerciseId: entry.exerciseId,
+                    name: entry.exerciseName
+                )))
+            }
+        }
+
+        // 3. Reorder, judged only across the planned exercises that survived.
+        //    A mid-workout addition landing at the end is an addition, not a
+        //    reordering of the plan.
+        let survivingPlanned = workoutExercises.compactMap {
+            entryByWorkoutExerciseId[$0.id]
+        }
+        let plannedOrderIds = survivingPlanned
+            .sorted { $0.plannedOrder < $1.plannedOrder }
+            .map(\.sourceTemplateExerciseId)
+        let actualOrderIds = survivingPlanned.map(\.sourceTemplateExerciseId)
+        if plannedOrderIds != actualOrderIds, actualOrderIds.count > 1 {
+            changes.append(.reordered(.init(
+                sourceTemplateExerciseIds: actualOrderIds,
+                names: survivingPlanned.map(\.exerciseName)
+            )))
+        }
+
+        // 4. Set count — the number of set rows, not how many were completed.
+        //    Adding or deleting a row is an explicit act; leaving one unticked
+        //    is not.
+        for we in workoutExercises {
+            guard let entry = entryByWorkoutExerciseId[we.id] else { continue }
+            if we.sets.count != entry.plannedSets {
+                changes.append(.setCountChanged(.init(
+                    sourceTemplateExerciseId: entry.sourceTemplateExerciseId,
+                    name: entry.exerciseName,
+                    from: entry.plannedSets,
+                    to: we.sets.count
+                )))
+            }
+        }
+
+        // 5. Cue text. Rewriting a note during a workout is deliberate, and
+        //    it is exactly the machine-setting case from #136.
+        for we in workoutExercises {
+            guard let entry = entryByWorkoutExerciseId[we.id] else { continue }
+            let before = normalized(entry.plannedNotes)
+            let after = normalized(we.notes)
+            if before != after, after != nil {
+                changes.append(.cueChanged(.init(
+                    sourceTemplateExerciseId: entry.sourceTemplateExerciseId,
+                    name: entry.exerciseName,
+                    from: before,
+                    to: after
+                )))
+            }
+        }
+
+        return TemplateChangeSet(
+            templateId: baseline.templateId,
+            templateName: template.name,
+            changes: changes,
+            hasConflict: hasConflict(baseline: baseline, template: template)
+        )
+    }
+
+    /// The template has moved on since the workout started. Compared against
+    /// the revision captured at start rather than "is it different from what I
+    /// expect", so an edit from the Coach or the MCP inbox is caught too.
+    private func hasConflict(
+        baseline: WorkoutTemplateBaseline,
+        template: WorkoutTemplate
+    ) -> Bool {
+        guard let captured = baseline.templateRevision else { return false }
+        return template.lastModified > captured
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        guard
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+
+    /// The rep count performed most often, ties broken by the lower value —
+    /// a conservative suggestion for a brand-new template entry.
+    private func modalReps(of sets: [WorkoutSet]) -> Int? {
+        let reps = sets.compactMap(\.reps)
+        guard !reps.isEmpty else { return nil }
+        let counts = reps.reduce(into: [Int: Int]()) { $0[$1, default: 0] += 1 }
+        return counts.max { lhs, rhs in
+            lhs.value != rhs.value ? lhs.value < rhs.value : lhs.key > rhs.key
+        }?.key
+    }
+}

--- a/ClaudeLifter/Utilities/SettingsManager.swift
+++ b/ClaudeLifter/Utilities/SettingsManager.swift
@@ -45,6 +45,8 @@ final class SettingsManager {
         static let lastSyncTimestamp = "lastSyncTimestamp"
         static let lastSyncRevision = "lastSyncRevision"
         static let isSnapshotDirty = "isSnapshotDirty"
+        static let snapshotDirtyGeneration = "snapshotDirtyGeneration"
+        static let snapshotCleanGeneration = "snapshotCleanGeneration"
         static let proactiveInsightsEnabled = "proactiveInsightsEnabled"
     }
 
@@ -82,10 +84,46 @@ final class SettingsManager {
         }
     }
 
-    /// Durable trigger for inbox-applied changes that have no per-record
-    /// `syncStatus` (notably custom exercises).
+    /// Durable trigger for changes that have no per-record `syncStatus`
+    /// (notably custom exercises, which never got one — see #104).
+    ///
+    /// Two counters rather than a boolean. `pushSnapshot` runs
+    /// serialize → await network → clear, and the main actor is reentrant, so
+    /// a custom exercise created during that await was not in the pushed
+    /// payload yet had its only signal wiped by the clear that followed.
+    /// Clearing now names the generation that was actually pushed, so a
+    /// mutation landing mid-request leaves the phone dirty and the next
+    /// trigger picks it up.
+    private(set) var snapshotDirtyGeneration: Int {
+        didSet { defaults.set(snapshotDirtyGeneration, forKey: Key.snapshotDirtyGeneration) }
+    }
+
+    private(set) var snapshotCleanGeneration: Int {
+        didSet { defaults.set(snapshotCleanGeneration, forKey: Key.snapshotCleanGeneration) }
+    }
+
     var isSnapshotDirty: Bool {
-        didSet { defaults.set(isSnapshotDirty, forKey: Key.isSnapshotDirty) }
+        snapshotDirtyGeneration != snapshotCleanGeneration
+    }
+
+    /// Records that something with no per-record `syncStatus` changed.
+    /// Idempotent in effect (already-dirty stays dirty) but never a no-op —
+    /// the bump is what makes a mid-request mutation survive the clear.
+    func markSnapshotDirty() {
+        snapshotDirtyGeneration &+= 1
+    }
+
+    /// The generation to hand back to `markSnapshotClean` after a successful
+    /// push. Read BEFORE serializing state.
+    func currentSnapshotGeneration() -> Int {
+        snapshotDirtyGeneration
+    }
+
+    /// Clears the trigger only if nothing has been marked dirty since
+    /// `generation` was taken.
+    func markSnapshotClean(upTo generation: Int) {
+        guard snapshotDirtyGeneration == generation else { return }
+        snapshotCleanGeneration = generation
     }
 
     // MARK: - Init (loads from UserDefaults)
@@ -107,7 +145,25 @@ final class SettingsManager {
         self.serverURL = defaults.string(forKey: Key.serverURL) ?? ""
         self.lastSyncTimestamp = defaults.object(forKey: Key.lastSyncTimestamp) as? Date
         self.lastSyncRevision = defaults.object(forKey: Key.lastSyncRevision) as? Int
-        self.isSnapshotDirty = defaults.bool(forKey: Key.isSnapshotDirty)
+        // Migrate the legacy boolean: a pre-#104 install that was dirty at
+        // upgrade time must stay dirty, or its unpushed state is stranded.
+        // Read the two keys INDEPENDENTLY. `didSet` does not fire for
+        // assignments made in init, so a phone that has been marked dirty but
+        // never cleaned has the dirty key stored and the clean key absent.
+        // Requiring both would read that phone as clean and strand its
+        // unpushed state — which is the very failure this counter exists to
+        // prevent.
+        if let storedDirty = defaults.object(forKey: Key.snapshotDirtyGeneration) as? Int {
+            self.snapshotDirtyGeneration = storedDirty
+            self.snapshotCleanGeneration =
+                defaults.object(forKey: Key.snapshotCleanGeneration) as? Int ?? 0
+        } else if defaults.bool(forKey: Key.isSnapshotDirty) {
+            self.snapshotDirtyGeneration = 1
+            self.snapshotCleanGeneration = 0
+        } else {
+            self.snapshotDirtyGeneration = 0
+            self.snapshotCleanGeneration = 0
+        }
         // Missing key → treat as enabled (legacy install default).
         if defaults.object(forKey: Key.proactiveInsightsEnabled) == nil {
             self.proactiveInsightsEnabled = true

--- a/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
+++ b/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
@@ -44,6 +44,12 @@ final class ActiveWorkoutViewModel {
     var detectedPRs: [PersonalRecord] = []
     private(set) var previousValues: [UUID: AutoFillResult] = [:]
 
+    /// The planned target per workout exercise (#144), from the provenance
+    /// baseline captured at start. Keyed by `WorkoutExercise.id`; an exercise
+    /// added mid-workout is simply absent, because it has no plan.
+    private(set) var plannedTargets: [UUID: PlannedTarget] = [:]
+    private(set) var pendingPlannedTargetsLoad: Task<Void, Never>?
+
     /// Set IDs whose reps field the user has decided about — typed a value or
     /// deliberately cleared it (#137). This is the third state that makes
     /// adoption safe: *unset* (adopt the previous session), *decided-empty*
@@ -105,6 +111,10 @@ final class ActiveWorkoutViewModel {
         await pendingSave?.value
     }
 
+    func awaitPlannedTargetsLoad() async {
+        await pendingPlannedTargetsLoad?.value
+    }
+
     func awaitPreviousValuesLoad() async {
         await pendingPreviousValuesLoad?.value
     }
@@ -128,6 +138,56 @@ final class ActiveWorkoutViewModel {
     /// so these are reported rather than thrown — but not silently dropped the
     /// way the previous `try?` calls dropped them (#125).
     private(set) var postCommitWarnings: [String] = []
+
+    /// The plan for this exercise, or nil when there is none — an ad-hoc
+    /// workout, or an exercise added mid-session. Nil means "show nothing";
+    /// inventing a target would be worse than an empty line.
+    func plannedTarget(for workoutExercise: WorkoutExercise) -> PlannedTarget? {
+        plannedTargets[workoutExercise.id]
+    }
+
+    /// Whether **last session's** reps for this set missed the template target
+    /// (#144).
+    ///
+    /// Deliberately about the previous session, not the current one: this sits
+    /// next to the field the user is about to fill in, while there is still
+    /// time to correct course. Flagging what they just typed would be a
+    /// reprimand after the fact — "in the current session it's too late to do
+    /// anything about the drift once you enter the weight."
+    func previousDriftedFromTarget(
+        _ set: WorkoutSet,
+        in workoutExercise: WorkoutExercise
+    ) -> Bool {
+        guard
+            let target = plannedTargets[workoutExercise.id],
+            let previousReps = previous(for: set)?.reps
+        else {
+            // No plan, or no previous session — absence is not disagreement.
+            return false
+        }
+        return previousReps != target.reps
+    }
+
+    private func loadPlannedTargets(for workout: Workout) {
+        guard let baselineRepository else { return }
+        pendingPlannedTargetsLoad = Task { [weak self] in
+            guard let self else { return }
+            guard let entries = try? await baselineRepository.fetchEntries(
+                workoutId: workout.id
+            ) else { return }
+            var targets: [UUID: PlannedTarget] = [:]
+            for entry in entries {
+                guard let workoutExerciseId = entry.workoutExerciseId else { continue }
+                targets[workoutExerciseId] = PlannedTarget(
+                    sets: entry.plannedSets,
+                    reps: entry.plannedReps,
+                    restSeconds: entry.plannedRestSeconds,
+                    notes: entry.plannedNotes
+                )
+            }
+            self.plannedTargets = targets
+        }
+    }
 
     func previous(for set: WorkoutSet) -> AutoFillResult? {
         previousValues[set.id]
@@ -222,6 +282,9 @@ final class ActiveWorkoutViewModel {
                 in: workout,
                 sourceTemplate: sourceTemplate
             )
+            // A resumed session keeps its targets: the baseline is stored, so
+            // crash recovery reads back the same plan it started with (#144).
+            loadPlannedTargets(for: workout)
             didLoadInitialPreviousValues = true
             return
         }
@@ -322,6 +385,7 @@ final class ActiveWorkoutViewModel {
             try await saveWorkout(newWorkout)
             workout = newWorkout
             didLoadInitialPreviousValues = true
+            loadPlannedTargets(for: newWorkout)
             await captureBaseline(
                 for: newWorkout,
                 from: template,

--- a/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
+++ b/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
@@ -50,6 +50,10 @@ final class ActiveWorkoutViewModel {
     private let autoFillService: any AutoFillServiceProtocol
     private let prDetectionService: (any PRDetectionServiceProtocol)?
     private let templateRepository: (any TemplateRepository)?
+    /// Needed to persist per-exercise notes (#136). Optional so existing
+    /// construction sites keep compiling; when nil the note is written to the
+    /// in-memory model but not saved.
+    private let exerciseRepository: (any ExerciseRepository)?
     /// Global user preferences. Optional so existing construction sites keep
     /// compiling; when nil, newly created sets fall back to kg (#83).
     private let settings: SettingsManager?
@@ -127,6 +131,7 @@ final class ActiveWorkoutViewModel {
         template: WorkoutTemplate,
         workoutRepository: any WorkoutRepository,
         autoFillService: any AutoFillServiceProtocol,
+        exerciseRepository: (any ExerciseRepository)? = nil,
         templateRepository: (any TemplateRepository)? = nil,
         prDetectionService: (any PRDetectionServiceProtocol)? = nil,
         settings: SettingsManager? = nil
@@ -135,6 +140,7 @@ final class ActiveWorkoutViewModel {
         self.adHocName = nil
         self.workoutRepository = workoutRepository
         self.autoFillService = autoFillService
+        self.exerciseRepository = exerciseRepository
         self.templateRepository = templateRepository
         self.prDetectionService = prDetectionService
         self.settings = settings
@@ -144,6 +150,7 @@ final class ActiveWorkoutViewModel {
         adHocName: String,
         workoutRepository: any WorkoutRepository,
         autoFillService: any AutoFillServiceProtocol,
+        exerciseRepository: (any ExerciseRepository)? = nil,
         prDetectionService: (any PRDetectionServiceProtocol)? = nil,
         settings: SettingsManager? = nil
     ) {
@@ -151,6 +158,7 @@ final class ActiveWorkoutViewModel {
         self.adHocName = adHocName
         self.workoutRepository = workoutRepository
         self.autoFillService = autoFillService
+        self.exerciseRepository = exerciseRepository
         self.templateRepository = nil
         self.prDetectionService = prDetectionService
         self.settings = settings
@@ -163,6 +171,7 @@ final class ActiveWorkoutViewModel {
         resuming workout: Workout,
         workoutRepository: any WorkoutRepository,
         autoFillService: any AutoFillServiceProtocol,
+        exerciseRepository: (any ExerciseRepository)? = nil,
         templateRepository: (any TemplateRepository)? = nil,
         prDetectionService: (any PRDetectionServiceProtocol)? = nil,
         settings: SettingsManager? = nil
@@ -171,6 +180,7 @@ final class ActiveWorkoutViewModel {
         self.adHocName = nil
         self.workoutRepository = workoutRepository
         self.autoFillService = autoFillService
+        self.exerciseRepository = exerciseRepository
         self.templateRepository = templateRepository
         self.prDetectionService = prDetectionService
         self.settings = settings
@@ -247,6 +257,9 @@ final class ActiveWorkoutViewModel {
             let we = WorkoutExercise(
                 order: templateExercise.order,
                 exercise: exercise,
+                // Machine settings live here — seat/pin/pivot numbers the user
+                // needs standing at the machine. Never copied until #136.
+                notes: templateExercise.notes,
                 restSeconds: templateExercise.defaultRestSeconds
             )
             // Per-set-index auto-fill from the previous session (#82):
@@ -322,6 +335,50 @@ final class ActiveWorkoutViewModel {
         }
         set.weight = weight
         persistMutation()
+    }
+
+    /// Per-exercise notes — machine settings, cues (#136).
+    ///
+    /// The note is written to the **library `Exercise`**, not to the session
+    /// or the template: "Ankle 4; Seat 4; Pivot 1" describes the machine, so
+    /// it must appear in every future workout that uses Seated Leg Curl,
+    /// whichever template that workout came from.
+    ///
+    /// Whitespace-only input clears the note, so an emptied field does not
+    /// leave a blank note rendering as an empty row.
+    ///
+    /// Note this deliberately does not go through `persistMutation()` — the
+    /// workout record is unchanged, so a note edit must not re-stamp its
+    /// `lastModified` or re-open a finished session (#124).
+    func updateExerciseNotes(
+        _ workoutExercise: WorkoutExercise,
+        notes: String?
+    ) async {
+        guard let exercise = workoutExercise.exercise else { return }
+        let trimmed = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = (trimmed?.isEmpty ?? true) ? nil : trimmed
+        guard exercise.notes != normalized
+            || workoutExercise.notes != normalized else { return }
+
+        exercise.notes = normalized
+
+        // Also stamp the session copy. Two reasons, both real: bundled
+        // exercises are excluded from sync *and* from backup (BackupService
+        // carries only `isCustom`), so the library note is device-local and
+        // invisible to the Coach and MCP — the workout is the copy that
+        // travels. And what settings were used on a given day is genuinely
+        // session data. `persistMutation` handles the sync bookkeeping and
+        // already declines to re-open a finished workout (#124).
+        if workoutExercise.notes != normalized {
+            workoutExercise.notes = normalized
+            persistMutation()
+        }
+
+        do {
+            try await exerciseRepository?.save(exercise)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     func updateSetReps(_ set: WorkoutSet, reps: Int?) {

--- a/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
+++ b/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
@@ -67,6 +67,11 @@ final class ActiveWorkoutViewModel {
     /// construction sites keep compiling; when nil the note is written to the
     /// in-memory model but not saved.
     private let exerciseRepository: (any ExerciseRepository)?
+    /// Records the template plan a workout started from (#128). Optional so
+    /// existing construction sites keep compiling; when nil, provenance is
+    /// simply not captured and post-workout reconciliation has nothing to
+    /// offer — the workout itself is unaffected.
+    private let baselineRepository: (any TemplateBaselineRepository)?
     /// Global user preferences. Optional so existing construction sites keep
     /// compiling; when nil, newly created sets fall back to kg (#83).
     private let settings: SettingsManager?
@@ -146,6 +151,7 @@ final class ActiveWorkoutViewModel {
         autoFillService: any AutoFillServiceProtocol,
         exerciseRepository: (any ExerciseRepository)? = nil,
         templateRepository: (any TemplateRepository)? = nil,
+        baselineRepository: (any TemplateBaselineRepository)? = nil,
         prDetectionService: (any PRDetectionServiceProtocol)? = nil,
         settings: SettingsManager? = nil
     ) {
@@ -154,6 +160,7 @@ final class ActiveWorkoutViewModel {
         self.workoutRepository = workoutRepository
         self.autoFillService = autoFillService
         self.exerciseRepository = exerciseRepository
+        self.baselineRepository = baselineRepository
         self.templateRepository = templateRepository
         self.prDetectionService = prDetectionService
         self.settings = settings
@@ -164,6 +171,7 @@ final class ActiveWorkoutViewModel {
         workoutRepository: any WorkoutRepository,
         autoFillService: any AutoFillServiceProtocol,
         exerciseRepository: (any ExerciseRepository)? = nil,
+        baselineRepository: (any TemplateBaselineRepository)? = nil,
         prDetectionService: (any PRDetectionServiceProtocol)? = nil,
         settings: SettingsManager? = nil
     ) {
@@ -172,6 +180,7 @@ final class ActiveWorkoutViewModel {
         self.workoutRepository = workoutRepository
         self.autoFillService = autoFillService
         self.exerciseRepository = exerciseRepository
+        self.baselineRepository = baselineRepository
         self.templateRepository = nil
         self.prDetectionService = prDetectionService
         self.settings = settings
@@ -186,6 +195,7 @@ final class ActiveWorkoutViewModel {
         autoFillService: any AutoFillServiceProtocol,
         exerciseRepository: (any ExerciseRepository)? = nil,
         templateRepository: (any TemplateRepository)? = nil,
+        baselineRepository: (any TemplateBaselineRepository)? = nil,
         prDetectionService: (any PRDetectionServiceProtocol)? = nil,
         settings: SettingsManager? = nil
     ) {
@@ -194,6 +204,7 @@ final class ActiveWorkoutViewModel {
         self.workoutRepository = workoutRepository
         self.autoFillService = autoFillService
         self.exerciseRepository = exerciseRepository
+        self.baselineRepository = baselineRepository
         self.templateRepository = templateRepository
         self.prDetectionService = prDetectionService
         self.settings = settings
@@ -265,6 +276,11 @@ final class ActiveWorkoutViewModel {
             startedAt: .now,
             templateId: template.id
         )
+        // Pairs each planned exercise with the session exercise created from
+        // it, so the baseline can be linked without a stored property on
+        // WorkoutExercise — which would change every VersionedSchema's
+        // checksum. See the note on ClaudeLifterSchemaV4.
+        var workoutExerciseIdByTemplateExerciseId: [UUID: UUID] = [:]
         for templateExercise in template.exercises.sorted(by: { $0.order < $1.order }) {
             guard let exercise = templateExercise.exercise else { continue }
             let we = WorkoutExercise(
@@ -300,13 +316,64 @@ final class ActiveWorkoutViewModel {
                 }
             }
             newWorkout.exercises.append(we)
+            workoutExerciseIdByTemplateExerciseId[templateExercise.id] = we.id
         }
         do {
             try await saveWorkout(newWorkout)
             workout = newWorkout
             didLoadInitialPreviousValues = true
+            await captureBaseline(
+                for: newWorkout,
+                from: template,
+                workoutExerciseIds: workoutExerciseIdByTemplateExerciseId
+            )
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Freezes the template plan this workout started from (#128).
+    ///
+    /// Written once, after the workout is saved, and never updated — an
+    /// exercise added later deliberately has no entry, and that absence is how
+    /// #129 tells a genuine addition from a planned one.
+    ///
+    /// A failure here is swallowed on purpose. Provenance buys a post-workout
+    /// suggestion; being able to train is not worth risking for it.
+    private func captureBaseline(
+        for workout: Workout,
+        from template: WorkoutTemplate,
+        workoutExerciseIds: [UUID: UUID]
+    ) async {
+        guard let baselineRepository else { return }
+        let baseline = WorkoutTemplateBaseline(
+            workoutId: workout.id,
+            templateId: template.id,
+            templateRevision: template.lastModified,
+            templateName: template.name
+        )
+        let entries = template.exercises
+            .sorted(by: { $0.order < $1.order })
+            .compactMap { te -> WorkoutExerciseBaseline? in
+                guard let exercise = te.exercise else { return nil }
+                return WorkoutExerciseBaseline(
+                    workoutId: workout.id,
+                    workoutExerciseId: workoutExerciseIds[te.id],
+                    sourceTemplateExerciseId: te.id,
+                    exerciseId: exercise.id,
+                    exerciseExternalId: exercise.externalId,
+                    exerciseName: exercise.name,
+                    plannedOrder: te.order,
+                    plannedSets: te.defaultSets,
+                    plannedReps: te.defaultReps,
+                    plannedRestSeconds: te.defaultRestSeconds,
+                    plannedNotes: te.notes
+                )
+            }
+        do {
+            try await baselineRepository.save(baseline, entries: entries)
+        } catch {
+            print("⚠️ captureBaseline failed: \(error)")
         }
     }
 

--- a/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
+++ b/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
@@ -855,6 +855,48 @@ final class ActiveWorkoutViewModel {
                 )
             }
         }
+
+        await detectTemplateChanges(for: workout, summary: summary)
+    }
+
+    /// Compares the finished workout to the plan it started from (#129).
+    ///
+    /// Runs here, after the durable save, for the same reason PR detection
+    /// does: the workout is already safe, so nothing this finds — or fails to
+    /// find — can delay or endanger it. The result lands on the summary, which
+    /// is a reference type precisely so it can be filled in after the sheet is
+    /// already on screen.
+    private func detectTemplateChanges(
+        for workout: Workout,
+        summary: WorkoutCompletionSummary
+    ) async {
+        guard let baselineRepository, let templateRepository else { return }
+        do {
+            guard
+                let baseline = try await baselineRepository.fetchBaseline(
+                    workoutId: workout.id
+                ),
+                let currentTemplate = try await templateRepository.fetch(
+                    id: baseline.templateId
+                )
+            else { return }
+            let entries = try await baselineRepository.fetchEntries(
+                workoutId: workout.id
+            )
+            let changeSet = TemplateChangeDetector().detect(
+                workout: workout,
+                baseline: baseline,
+                entries: entries,
+                template: currentTemplate
+            )
+            // Nil rather than an empty set, so the review card has one simple
+            // condition to test and cannot appear with nothing in it.
+            summary.templateChangeSet = changeSet.isEmpty ? nil : changeSet
+        } catch {
+            postCommitWarnings.append(
+                "Couldn't check for template changes: \(error.localizedDescription)"
+            )
+        }
     }
 
     private func saveWorkout(_ w: Workout) async throws {

--- a/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
+++ b/ClaudeLifter/ViewModels/ActiveWorkoutViewModel.swift
@@ -44,6 +44,19 @@ final class ActiveWorkoutViewModel {
     var detectedPRs: [PersonalRecord] = []
     private(set) var previousValues: [UUID: AutoFillResult] = [:]
 
+    /// Set IDs whose reps field the user has decided about — typed a value or
+    /// deliberately cleared it (#137). This is the third state that makes
+    /// adoption safe: *unset* (adopt the previous session), *decided-empty*
+    /// (persist nil), *entered* (leave alone). Without it, "not filled in yet"
+    /// and "I mean blank" are the same nil and adoption overwrites intent.
+    ///
+    /// Transient by design. It is lost across a crash/resume, where the
+    /// conservative outcome is that an untouched empty set gets its previous
+    /// reps back — harmless, because nil reps on an unlogged set carry no
+    /// meaning. The same reasoning does NOT hold for weight, which is why
+    /// weight is never adopted.
+    private var repsDecidedByUser: Set<UUID> = []
+
     private let template: WorkoutTemplate?
     private let adHocName: String?
     private let workoutRepository: any WorkoutRepository
@@ -382,6 +395,9 @@ final class ActiveWorkoutViewModel {
     }
 
     func updateSetReps(_ set: WorkoutSet, reps: Int?) {
+        // Recorded even when the value is unchanged: clearing a field that is
+        // already nil is still the user saying "blank is what I meant" (#137).
+        repsDecidedByUser.insert(set.id)
         guard set.reps != reps else { return }
         set.reps = reps
         persistMutation()
@@ -521,6 +537,7 @@ final class ActiveWorkoutViewModel {
             excludingWorkoutId: workout?.id
         )) ?? []
 
+        var didAdopt = false
         for (index, set) in sortedSets.enumerated() {
             guard let previous = previousValue(
                 at: index,
@@ -530,7 +547,33 @@ final class ActiveWorkoutViewModel {
                 continue
             }
             previousValues[set.id] = previous
+            if adoptPreviousReps(into: set, from: previous) {
+                didAdopt = true
+            }
         }
+        if didAdopt {
+            persistMutation()
+        }
+    }
+
+    /// Writes the previous session's reps into a set the user has not decided
+    /// about yet (#137). Returns whether anything changed.
+    ///
+    /// Reps only. `WorkoutSet.weight == nil` already means bodyweight, so
+    /// adopting a previous weight would log 80kg for a bodyweight set — the
+    /// exact data-corruption bug that got ghost adoption cut the first time.
+    /// A nil rep count has no such second meaning.
+    @discardableResult
+    private func adoptPreviousReps(
+        into set: WorkoutSet,
+        from previous: AutoFillResult
+    ) -> Bool {
+        // A logged set is a record, not a draft.
+        guard !set.isCompleted else { return false }
+        guard !repsDecidedByUser.contains(set.id) else { return false }
+        guard set.reps == nil, let reps = previous.reps else { return false }
+        set.reps = reps
+        return true
     }
 
     private func queuePreviousValuesLoad(for workoutExercise: WorkoutExercise) {

--- a/ClaudeLifter/ViewModels/CalendarViewModel.swift
+++ b/ClaudeLifter/ViewModels/CalendarViewModel.swift
@@ -72,8 +72,21 @@ final class CalendarViewModel {
     // MARK: - Private helpers
 
     private func monthDateRange(for date: Date) -> (start: Date, end: Date) {
-        let start = calendar.date(from: calendar.dateComponents([.year, .month], from: date))!
-        let end = calendar.date(byAdding: DateComponents(month: 1, second: -1), to: start)!
+        // Non-nil under the Gregorian calendar, but `Calendar` makes no such
+        // promise in general and the style rules ban force unwraps in
+        // production code (#93). Falling back to the day containing `date`
+        // renders a degraded month rather than crashing the History tab.
+        guard
+            let start = calendar.date(
+                from: calendar.dateComponents([.year, .month], from: date)
+            ),
+            let end = calendar.date(
+                byAdding: DateComponents(month: 1, second: -1), to: start
+            )
+        else {
+            let dayStart = calendar.startOfDay(for: date)
+            return (dayStart, dayStart.addingTimeInterval(86_400 - 1))
+        }
         return (start, end)
     }
 

--- a/ClaudeLifter/ViewModels/ChatViewModel.swift
+++ b/ClaudeLifter/ViewModels/ChatViewModel.swift
@@ -326,6 +326,7 @@ final class ChatViewModel {
                     template: template,
                     workoutRepository: self.workoutRepository,
                     autoFillService: autoFillService,
+                    exerciseRepository: self.exerciseRepository,
                     templateRepository: self.templateRepository,
                     prDetectionService: self.prDetectionService,
                     settings: self.settings

--- a/ClaudeLifter/ViewModels/ChatViewModel.swift
+++ b/ClaudeLifter/ViewModels/ChatViewModel.swift
@@ -35,6 +35,7 @@ final class ChatViewModel {
 
     private let anthropicService: any AnthropicServiceProtocol
     private let exerciseRepository: any ExerciseRepository
+    private let baselineRepository: (any TemplateBaselineRepository)?
     private let workoutRepository: any WorkoutRepository
     private let templateRepository: any TemplateRepository
     private let preferenceRepository: any TrainingPreferenceRepository
@@ -74,7 +75,9 @@ final class ChatViewModel {
         settings: SettingsManager? = nil,
         appState: AppState? = nil,
         autoFillService: (any AutoFillServiceProtocol)? = nil,
-        prDetectionService: (any PRDetectionServiceProtocol)? = nil
+        prDetectionService: (any PRDetectionServiceProtocol)? = nil,
+        /// So a Coach-started workout captures template provenance too (#128).
+        baselineRepository: (any TemplateBaselineRepository)? = nil
     ) {
         self.anthropicService = anthropicService
         self.exerciseRepository = exerciseRepository
@@ -86,6 +89,7 @@ final class ChatViewModel {
         self.appState = appState
         self.autoFillService = autoFillService
         self.prDetectionService = prDetectionService
+        self.baselineRepository = baselineRepository
         self.tools = tools ?? [
             SearchExercisesTool(),
             GetExerciseHistoryTool(),
@@ -328,6 +332,7 @@ final class ChatViewModel {
                     autoFillService: autoFillService,
                     exerciseRepository: self.exerciseRepository,
                     templateRepository: self.templateRepository,
+                    baselineRepository: self.baselineRepository,
                     prDetectionService: self.prDetectionService,
                     settings: self.settings
                 )

--- a/ClaudeLifter/ViewModels/HistoryViewModel.swift
+++ b/ClaudeLifter/ViewModels/HistoryViewModel.swift
@@ -57,6 +57,43 @@ final class HistoryViewModel {
         }
     }
 
+    /// Edits a set on a **past** workout (#117).
+    ///
+    /// History edits used to be written straight to the model by the detail
+    /// view, so they persisted locally and were never re-queued for sync — the
+    /// local record silently diverged from the mirror. Every edit goes through
+    /// here instead, mirroring the rule `ActiveWorkoutViewModel` states for the
+    /// live session: views never write to WorkoutSet directly.
+    ///
+    /// `nil` is a legitimate value, not a failed parse: a nil weight is how a
+    /// bodyweight set is recorded, and the old `if let value = Double(text)`
+    /// made it unreachable.
+    ///
+    /// Deliberately *not* routed through `ActiveWorkoutViewModel.persistMutation`
+    /// — that early-returns on a finished workout and its `saveDraft()` deletes
+    /// records it judges empty, which is the wrong semantics for a completed
+    /// session.
+    func updateSet(_ set: WorkoutSet, weight: Double?, in workout: Workout) async {
+        guard set.weight != weight else { return }
+        set.weight = weight
+        await persist(workout)
+    }
+
+    func updateSet(_ set: WorkoutSet, reps: Int?, in workout: Workout) async {
+        guard set.reps != reps else { return }
+        set.reps = reps
+        await persist(workout)
+    }
+
+    private func persist(_ workout: Workout) async {
+        workout.recordChange()
+        do {
+            try await workoutRepository.save(workout)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
     func updateWorkout(_ workout: Workout) async {
         // History edits mutate nested sets/exercises directly in the detail
         // view; without recordChange() here the edit never bumped the parent

--- a/ClaudeLifter/ViewModels/ReportListViewModel.swift
+++ b/ClaudeLifter/ViewModels/ReportListViewModel.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The local view of the report backlog (issue #135).
+///
+/// Reports are normally closed out by the AI over MCP, but they must be
+/// closeable here too — a backlog you can only clear from another device is a
+/// backlog you stop trusting.
+@MainActor
+@Observable
+final class ReportListViewModel {
+    private(set) var reports: [ExerciseReport] = []
+    var errorMessage: String?
+    var showsResolved = false
+
+    private let repository: any ExerciseReportRepository
+
+    init(repository: any ExerciseReportRepository) {
+        self.repository = repository
+    }
+
+    var openCount: Int {
+        reports.filter { $0.status != .resolved }.count
+    }
+
+    var visibleReports: [ExerciseReport] {
+        showsResolved ? reports : reports.filter { $0.status != .resolved }
+    }
+
+    func load() async {
+        do {
+            reports = try await repository.fetchAll()
+        } catch {
+            errorMessage = "Couldn't load reports: \(error.localizedDescription)"
+        }
+    }
+
+    func setStatus(_ status: ReportStatus, for report: ExerciseReport) async {
+        report.status = status
+        report.recordChange()
+        do {
+            try await repository.save(report)
+            await load()
+        } catch {
+            errorMessage = "Couldn't update the report: \(error.localizedDescription)"
+        }
+    }
+
+    func delete(_ report: ExerciseReport) async {
+        do {
+            try await repository.delete(report)
+            await load()
+        } catch {
+            errorMessage = "Couldn't delete the report: \(error.localizedDescription)"
+        }
+    }
+}

--- a/ClaudeLifter/ViewModels/ReportListViewModel.swift
+++ b/ClaudeLifter/ViewModels/ReportListViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class ReportListViewModel {
     private(set) var reports: [ExerciseReport] = []
     var errorMessage: String?
-    var showsResolved = false
+    var statusFilter: ReportStatusFilter = .backlog
 
     private let repository: any ExerciseReportRepository
 
@@ -18,12 +18,22 @@ final class ReportListViewModel {
         self.repository = repository
     }
 
+    /// Reports nobody has answered yet. Deliberately **not** everything that
+    /// is un-resolved: `acknowledged` means a fix is written and waiting on an
+    /// install, and counting those as open made the home card read "6 open
+    /// reports" while three of the six showed a written resolution (#146).
     var openCount: Int {
-        reports.filter { $0.status != .resolved }.count
+        reports.filter { $0.status == .open }.count
+    }
+
+    /// Answered, not yet finished. Surfaced separately so the two halves of
+    /// the backlog stop being conflated.
+    var acknowledgedCount: Int {
+        reports.filter { $0.status == .acknowledged }.count
     }
 
     var visibleReports: [ExerciseReport] {
-        showsResolved ? reports : reports.filter { $0.status != .resolved }
+        reports.filter { statusFilter.includes($0.status) }
     }
 
     func load() async {

--- a/ClaudeLifter/ViewModels/ReportSheetViewModel.swift
+++ b/ClaudeLifter/ViewModels/ReportSheetViewModel.swift
@@ -1,0 +1,169 @@
+import Foundation
+import UIKit
+
+/// Everything the app already knows about what is being reported (issue #135).
+///
+/// Assembled at the tap site, never chosen by the user — the whole design
+/// rests on context being captured rather than filled in. `Identifiable` so a
+/// non-nil context doubles as the `sheet(item:)` trigger.
+struct ReportContext: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    var exerciseExternalId: String?
+    var exerciseName: String?
+    var workoutId: UUID?
+    var workoutExerciseId: UUID?
+    var templateId: UUID?
+    var contextSummary: String?
+
+    /// The subtitle shown at the top of the sheet, so it is obvious what the
+    /// report will be attached to before anything is typed.
+    var subject: String {
+        exerciseName ?? "This workout"
+    }
+}
+
+extension ReportContext {
+    /// Report filed from an exercise card mid-workout — the main entry point.
+    @MainActor
+    static func forExercise(
+        _ workoutExercise: WorkoutExercise,
+        in workout: Workout?
+    ) -> ReportContext {
+        ReportContext(
+            exerciseExternalId: workoutExercise.exercise?.externalId,
+            exerciseName: workoutExercise.exercise?.name,
+            workoutId: workout?.id,
+            workoutExerciseId: workoutExercise.id,
+            templateId: workout?.templateId,
+            contextSummary: summarize(workoutExercise, in: workout)
+        )
+    }
+
+    /// Report filed from the workout toolbar — not about any one exercise.
+    @MainActor
+    static func forWorkout(_ workout: Workout?) -> ReportContext {
+        ReportContext(
+            workoutId: workout?.id,
+            templateId: workout?.templateId,
+            contextSummary: workout.map { summarizeWorkout($0) }
+        )
+    }
+
+    /// Report filed from the exercise library, away from the gym.
+    @MainActor
+    static func forLibraryExercise(_ exercise: Exercise) -> ReportContext {
+        ReportContext(
+            exerciseExternalId: exercise.externalId,
+            exerciseName: exercise.name
+        )
+    }
+
+    /// A bounded, human-readable line describing the sets as they stood when
+    /// the report was filed. This is what turns "the timer did something
+    /// weird" into something reproducible three days later, without asking
+    /// anyone to type a repro mid-set.
+    @MainActor
+    private static func summarize(
+        _ workoutExercise: WorkoutExercise,
+        in workout: Workout?
+    ) -> String {
+        let sets = workoutExercise.sets
+            .sorted { $0.order < $1.order }
+            .map { set -> String in
+                let weight = set.weight.map { formatted($0) + set.weightUnit.rawValue }
+                    ?? "bodyweight"
+                let reps = set.reps.map(String.init) ?? "–"
+                return "\(weight)×\(reps)\(set.isCompleted ? " ✓" : "")"
+            }
+        var parts: [String] = []
+        if let name = workout?.name { parts.append(name) }
+        parts.append(workoutExercise.exercise?.name ?? "Unknown exercise")
+        parts.append(sets.isEmpty ? "no sets" : sets.joined(separator: ", "))
+        return parts.joined(separator: " · ")
+    }
+
+    @MainActor
+    private static func summarizeWorkout(_ workout: Workout) -> String {
+        let completed = workout.exercises
+            .flatMap(\.sets)
+            .filter(\.isCompleted)
+            .count
+        let exercises = workout.exercises
+            .sorted { $0.order < $1.order }
+            .compactMap { $0.exercise?.name }
+            .joined(separator: ", ")
+        return "\(workout.name) · \(completed) sets completed · \(exercises)"
+    }
+
+    private static func formatted(_ weight: Double) -> String {
+        weight == weight.rounded()
+            ? String(Int(weight))
+            : String(format: "%.1f", weight)
+    }
+}
+
+/// Drives the report sheet. Deliberately thin: pick a category, type a
+/// sentence, save. Everything else is filled in from `context` and the build.
+@MainActor
+@Observable
+final class ReportSheetViewModel {
+    let context: ReportContext
+    var category: ReportCategory = .bug
+    var detail: String = ""
+    var suggestedReplacement: String = ""
+    private(set) var isSaving = false
+    var errorMessage: String?
+
+    private let repository: any ExerciseReportRepository
+
+    init(context: ReportContext, repository: any ExerciseReportRepository) {
+        self.context = context
+        self.repository = repository
+        // A report filed against a specific exercise is far more often about
+        // that exercise than about the app; one without an exercise almost
+        // always is a bug. Start on the likelier chip.
+        self.category = context.exerciseName == nil ? .bug : .swapRequest
+    }
+
+    /// Only the two categories that name a substitute show the field — asking
+    /// for a replacement on a bug report is noise.
+    var showsReplacementField: Bool {
+        category == .swapRequest || category == .wrongExercise
+    }
+
+    var canSubmit: Bool {
+        !detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSaving
+    }
+
+    /// Returns true when the report was saved and the sheet should close.
+    func submit() async -> Bool {
+        guard canSubmit else { return false }
+        isSaving = true
+        defer { isSaving = false }
+
+        let replacement = suggestedReplacement
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let report = ExerciseReport(
+            category: category,
+            detail: detail.trimmingCharacters(in: .whitespacesAndNewlines),
+            exerciseExternalId: context.exerciseExternalId,
+            exerciseName: context.exerciseName,
+            suggestedReplacement:
+                showsReplacementField && !replacement.isEmpty ? replacement : nil,
+            workoutId: context.workoutId,
+            workoutExerciseId: context.workoutExerciseId,
+            templateId: context.templateId,
+            contextSummary: context.contextSummary,
+            appVersion: "\(BuildInfo.appVersion) (\(BuildInfo.buildNumber))",
+            iosVersion: UIDevice.current.systemVersion
+        )
+
+        do {
+            try await repository.save(report)
+            return true
+        } catch {
+            errorMessage = "Couldn't save the report: \(error.localizedDescription)"
+            return false
+        }
+    }
+}

--- a/ClaudeLifter/ViewModels/WorkoutCompletionSummary.swift
+++ b/ClaudeLifter/ViewModels/WorkoutCompletionSummary.swift
@@ -30,6 +30,12 @@ final class WorkoutCompletionSummary: Identifiable {
     /// so a slow or failing detector never delays the return to Home.
     var personalRecords: [PersonalRecord] = []
 
+    /// Proposed template changes detected after the workout was saved (#129),
+    /// for the review card in #130. Nil until detection finishes, and nil
+    /// forever for an ad-hoc workout or one whose plan produced nothing —
+    /// the card must appear only when there is genuinely something to decide.
+    var templateChangeSet: TemplateChangeSet?
+
     init(workout: Workout) {
         self.id = workout.id
         self.workout = workout

--- a/ClaudeLifter/Views/Exercises/ExerciseDetailView.swift
+++ b/ClaudeLifter/Views/Exercises/ExerciseDetailView.swift
@@ -16,6 +16,7 @@ struct ExerciseDetailView: View {
             List {
                 imageSection
                 photoSection
+                notesSection
                 musclesSection
                 if !exercise.instructions.isEmpty {
                     instructionsSection
@@ -157,6 +158,21 @@ struct ExerciseDetailView: View {
     }
 
     // MARK: - Muscles / instructions / metadata
+
+    /// The note attached to the exercise (#136) — machine settings written at
+    /// the machine during a workout. Read-only here; it is edited where it is
+    /// used, on the workout screen.
+    @ViewBuilder
+    private var notesSection: some View {
+        if let notes = exercise.notes?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !notes.isEmpty {
+            Section("Notes") {
+                Text(notes)
+                    .accessibilityIdentifier("exerciseDetailNotes")
+            }
+        }
+    }
 
     private var musclesSection: some View {
         Section("Muscles") {

--- a/ClaudeLifter/Views/Exercises/ExerciseDetailView.swift
+++ b/ClaudeLifter/Views/Exercises/ExerciseDetailView.swift
@@ -6,6 +6,9 @@ struct ExerciseDetailView: View {
 
     @State private var photoVM = ExercisePhotoViewModel()
     @State private var selectedItem: PhotosPickerItem? = nil
+    /// Considered reports, filed away from the gym (issue #135).
+    @State private var reportContext: ReportContext?
+    @Environment(\.dependencies) private var dependencies
 
     var body: some View {
         VStack(spacing: 0) {
@@ -22,6 +25,26 @@ struct ExerciseDetailView: View {
         }
         .navigationTitle(exercise.name)
         .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    reportContext = .forLibraryExercise(exercise)
+                } label: {
+                    Label("Report a problem…", systemImage: "flag")
+                }
+                .accessibilityIdentifier("reportExerciseFromLibrary")
+            }
+        }
+        .sheet(item: $reportContext) { context in
+            if let dependencies {
+                ReportSheetView(
+                    vm: ReportSheetViewModel(
+                        context: context,
+                        repository: dependencies.exerciseReportRepository
+                    )
+                )
+            }
+        }
         // Use .task instead of .onAppear — .onAppear re-fires on every view
         // redraw (e.g. navigation push/pop, orientation change), which would
         // overwrite any local photo state the user has just chosen.

--- a/ClaudeLifter/Views/History/HistoryListView.swift
+++ b/ClaudeLifter/Views/History/HistoryListView.swift
@@ -114,9 +114,18 @@ struct HistoryListView: View {
                     } else {
                         ForEach(calendarVM.selectedDayWorkouts, id: \.id) { workout in
                             NavigationLink {
-                                WorkoutDetailView(workout: workout, onSave: { updated in
-                                    await historyVM.updateWorkout(updated)
-                                })
+                                WorkoutDetailView(
+                                    workout: workout,
+                                    onSave: { updated in
+                                        await historyVM.updateWorkout(updated)
+                                    },
+                                    onEditWeight: { set, weight in
+                                        Task { await historyVM.updateSet(set, weight: weight, in: workout) }
+                                    },
+                                    onEditReps: { set, reps in
+                                        Task { await historyVM.updateSet(set, reps: reps, in: workout) }
+                                    }
+                                )
                             } label: {
                                 WorkoutHistoryRowView(workout: workout)
                             }
@@ -145,9 +154,18 @@ struct HistoryListView: View {
                 LazyVStack(spacing: 0) {
                     ForEach(vm.completedWorkouts, id: \.id) { workout in
                         NavigationLink {
-                            WorkoutDetailView(workout: workout, onSave: { updated in
-                                await vm.updateWorkout(updated)
-                            })
+                            WorkoutDetailView(
+                                workout: workout,
+                                onSave: { updated in
+                                    await vm.updateWorkout(updated)
+                                },
+                                onEditWeight: { set, weight in
+                                    Task { await vm.updateSet(set, weight: weight, in: workout) }
+                                },
+                                onEditReps: { set, reps in
+                                    Task { await vm.updateSet(set, reps: reps, in: workout) }
+                                }
+                            )
                         } label: {
                             WorkoutHistoryRowView(workout: workout)
                         }
@@ -173,9 +191,18 @@ struct HistoryListView: View {
             } else {
                 List(vm.completedWorkouts, id: \.id) { workout in
                     NavigationLink {
-                        WorkoutDetailView(workout: workout, onSave: { updated in
-                            await vm.updateWorkout(updated)
-                        })
+                        WorkoutDetailView(
+                            workout: workout,
+                            onSave: { updated in
+                                await vm.updateWorkout(updated)
+                            },
+                            onEditWeight: { set, weight in
+                                Task { await vm.updateSet(set, weight: weight, in: workout) }
+                            },
+                            onEditReps: { set, reps in
+                                Task { await vm.updateSet(set, reps: reps, in: workout) }
+                            }
+                        )
                     } label: {
                         WorkoutHistoryRowView(workout: workout)
                     }

--- a/ClaudeLifter/Views/History/WorkoutDetailView.swift
+++ b/ClaudeLifter/Views/History/WorkoutDetailView.swift
@@ -3,6 +3,11 @@ import SwiftUI
 struct WorkoutDetailView: View {
     let workout: Workout
     var onSave: ((@MainActor (Workout) async -> Void))? = nil
+    /// Per-set edits go through the ViewModel so they re-queue the workout for
+    /// sync (#117). Optional so existing previews keep compiling; when nil the
+    /// rows are read-only.
+    var onEditWeight: ((WorkoutSet, Double?) -> Void)? = nil
+    var onEditReps: ((WorkoutSet, Int?) -> Void)? = nil
 
     @State private var isEditing = false
     @State private var editedName: String = ""
@@ -15,8 +20,12 @@ struct WorkoutDetailView: View {
             ForEach(workout.exercises.sorted(by: { $0.order < $1.order }), id: \.id) { we in
                 Section(we.exercise?.name ?? "Unknown") {
                     ForEach(we.sets.sorted(by: { $0.order < $1.order }), id: \.id) { set in
-                        if isEditing {
-                            WorkoutSetEditRow(set: set)
+                        if isEditing, let onEditWeight, let onEditReps {
+                            WorkoutSetEditRow(
+                                set: set,
+                                onEditWeight: onEditWeight,
+                                onEditReps: onEditReps
+                            )
                         } else {
                             WorkoutSetDetailRow(set: set)
                         }
@@ -43,7 +52,7 @@ struct WorkoutDetailView: View {
     @ToolbarContentBuilder
     private var editToolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            if onSave != nil {
+            if onSave != nil, onEditWeight != nil {
                 Button(isEditing ? "Done" : "Edit") {
                     if isEditing {
                         commitEdits()
@@ -86,7 +95,9 @@ private struct WorkoutSetDetailRow: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 48, alignment: .leading)
             if let weight = set.weight {
-                Text(String(format: "%.1f %@", weight, set.weightUnit.rawValue))
+                // Locale-aware, matching the edit row — String(format:) always
+                // renders a dot and disagreed with what the keypad accepted.
+                Text("\(weight.formatted(.number.grouping(.never).precision(.fractionLength(0...3)))) \(set.weightUnit.rawValue)")
                     .frame(width: 80)
             }
             if let reps = set.reps {
@@ -104,43 +115,56 @@ private struct WorkoutSetDetailRow: View {
 
 private struct WorkoutSetEditRow: View {
     let set: WorkoutSet
+    let onEditWeight: (WorkoutSet, Double?) -> Void
+    let onEditReps: (WorkoutSet, Int?) -> Void
 
-    @State private var weightText: String = ""
-    @State private var repsText: String = ""
+    @Environment(\.locale) private var locale
+
+    // No local @State buffer, and no onAppear seeding. That pattern was
+    // removed from SetRowView in #76 for clobbering newer model values, and
+    // it was the last copy of it (#117). The binding reads the model, so an
+    // emptied field is nil rather than a failed parse the write silently
+    // skipped — and nil weight is how a bodyweight set is recorded.
+    private var weightBinding: Binding<Double?> {
+        Binding(get: { set.weight }, set: { onEditWeight(set, $0) })
+    }
+
+    private var repsBinding: Binding<Int?> {
+        Binding(get: { set.reps }, set: { onEditReps(set, $0) })
+    }
+
+    private var weightFormat: FloatingPointFormatStyle<Double> {
+        .number
+            .locale(locale)
+            .grouping(.never)
+            .precision(.fractionLength(0...3))
+    }
+
+    private var repsFormat: IntegerFormatStyle<Int> {
+        .number.locale(locale).grouping(.never)
+    }
 
     var body: some View {
         HStack(spacing: 12) {
             Text("Set \(set.order + 1)")
                 .foregroundStyle(.secondary)
                 .frame(width: 48, alignment: .leading)
-            TextField("Weight", text: $weightText)
+            TextField("Weight", value: weightBinding, format: weightFormat)
                 .keyboardType(.decimalPad)
                 .frame(width: 70)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Weight in \(set.weightUnit.rawValue)")
             Text(set.weightUnit.rawValue)
                 .foregroundStyle(.secondary)
-            TextField("Reps", text: $repsText)
+            TextField("Reps", value: repsBinding, format: repsFormat)
                 .keyboardType(.numberPad)
                 .frame(width: 50)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Reps")
             Text("reps")
                 .foregroundStyle(.secondary)
             Spacer()
         }
         .font(.body)
-        .onAppear {
-            weightText = set.weight.map { String(format: "%.1f", $0) } ?? ""
-            repsText = set.reps.map { String($0) } ?? ""
-        }
-        .onChange(of: weightText) {
-            if let value = Double(weightText) {
-                set.weight = value
-            }
-        }
-        .onChange(of: repsText) {
-            if let value = Int(repsText) {
-                set.reps = value
-            }
-        }
     }
 }

--- a/ClaudeLifter/Views/Reports/OpenReportsCard.swift
+++ b/ClaudeLifter/Views/Reports/OpenReportsCard.swift
@@ -5,15 +5,33 @@ import SwiftUI
 /// clears. Renders nothing when there is nothing outstanding.
 struct OpenReportsCard: View {
     let count: Int
+    /// Reports that have an answer written but are waiting on an install.
+    /// Shown apart from `count` because folding them together made the card
+    /// say "6 open reports" while three of the six displayed a resolution
+    /// (#146) — the number disagreed with what was on screen right below it.
+    var acknowledgedCount: Int = 0
     let onOpen: () -> Void
 
+    private var total: Int { count + acknowledgedCount }
+
+    private var title: String {
+        switch (count, acknowledgedCount) {
+        case (0, let waiting):
+            return waiting == 1 ? "1 report awaiting install" : "\(waiting) reports awaiting install"
+        case (let open, 0):
+            return open == 1 ? "1 open report" : "\(open) open reports"
+        case (let open, let waiting):
+            return "\(open) open · \(waiting) awaiting install"
+        }
+    }
+
     var body: some View {
-        if count > 0 {
+        if total > 0 {
             Button(action: onOpen) {
                 HStack(spacing: 10) {
                     Image(systemName: "flag.fill")
                         .foregroundStyle(BrandTheme.terracotta)
-                    Text(count == 1 ? "1 open report" : "\(count) open reports")
+                    Text(title)
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(.primary)
                     Spacer()

--- a/ClaudeLifter/Views/Reports/OpenReportsCard.swift
+++ b/ClaudeLifter/Views/Reports/OpenReportsCard.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Home card showing how many reports are still outstanding. Exists so filed
+/// reports don't quietly rot — a backlog nobody sees is a backlog nobody
+/// clears. Renders nothing when there is nothing outstanding.
+struct OpenReportsCard: View {
+    let count: Int
+    let onOpen: () -> Void
+
+    var body: some View {
+        if count > 0 {
+            Button(action: onOpen) {
+                HStack(spacing: 10) {
+                    Image(systemName: "flag.fill")
+                        .foregroundStyle(BrandTheme.terracotta)
+                    Text(count == 1 ? "1 open report" : "\(count) open reports")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(Color(uiColor: .secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .accessibilityIdentifier("openReportsCard")
+        }
+    }
+}

--- a/ClaudeLifter/Views/Reports/ReportListView.swift
+++ b/ClaudeLifter/Views/Reports/ReportListView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// The report backlog. Reachable from the Home card so filed reports are
+/// visible without a round trip through the cloud.
+struct ReportListView: View {
+    @State var vm: ReportListViewModel
+
+    var body: some View {
+        @Bindable var vm = vm
+        return List {
+            if vm.visibleReports.isEmpty {
+                ContentUnavailableView(
+                    vm.showsResolved ? "No reports" : "Nothing outstanding",
+                    systemImage: "flag",
+                    description: Text(
+                        "Reports you file from a workout show up here, and "
+                        + "Claude can read them over MCP."
+                    )
+                )
+            } else {
+                ForEach(vm.visibleReports, id: \.id) { report in
+                    ReportRow(report: report)
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                Task { await vm.delete(report) }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                            if report.status != .resolved {
+                                Button {
+                                    Task { await vm.setStatus(.resolved, for: report) }
+                                } label: {
+                                    Label("Resolve", systemImage: "checkmark")
+                                }
+                                .tint(.green)
+                            }
+                        }
+                }
+            }
+        }
+        .navigationTitle("Reports")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Toggle("Show resolved", isOn: $vm.showsResolved)
+                    .toggleStyle(.button)
+                    .accessibilityIdentifier("toggleResolvedReports")
+            }
+        }
+        .task { await vm.load() }
+    }
+}
+
+private struct ReportRow: View {
+    let report: ExerciseReport
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Label(report.category.displayName, systemImage: report.category.systemImage)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(BrandTheme.terracotta)
+                Spacer()
+                if report.status != .open {
+                    Text(report.status.rawValue.capitalized)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Text(report.detail)
+                .font(.body)
+            if let name = report.exerciseName {
+                Text(name)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let replacement = report.suggestedReplacement {
+                Text("→ \(replacement)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let resolution = report.resolution {
+                Text(resolution)
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+            Text(report.createdAt, format: .dateTime.month().day().hour().minute())
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ClaudeLifter/Views/Reports/ReportListView.swift
+++ b/ClaudeLifter/Views/Reports/ReportListView.swift
@@ -10,11 +10,16 @@ struct ReportListView: View {
         return List {
             if vm.visibleReports.isEmpty {
                 ContentUnavailableView(
-                    vm.showsResolved ? "No reports" : "Nothing outstanding",
-                    systemImage: "flag",
+                    vm.statusFilter == .all
+                        ? "No reports"
+                        : "Nothing \(vm.statusFilter.displayName.lowercased())",
+                    systemImage: vm.statusFilter.systemImage,
                     description: Text(
-                        "Reports you file from a workout show up here, and "
-                        + "Claude can read them over MCP."
+                        vm.reports.isEmpty
+                            ? "Reports you file from a workout show up here, and "
+                                + "Claude can read them over MCP."
+                            : "\(vm.reports.count) report\(vm.reports.count == 1 ? "" : "s") "
+                                + "under a different filter."
                     )
                 )
             } else {
@@ -34,6 +39,25 @@ struct ReportListView: View {
                                 }
                                 .tint(.green)
                             }
+                            if report.status == .open {
+                                Button {
+                                    Task { await vm.setStatus(.acknowledged, for: report) }
+                                } label: {
+                                    Label("Acknowledge", systemImage: "checkmark.bubble")
+                                }
+                                .tint(BrandTheme.terracotta)
+                            }
+                            // The escape hatch #136 needed: a fix that turns
+                            // out to be inert has to be reopenable, or the
+                            // backlog quietly loses a real complaint.
+                            if report.status != .open {
+                                Button {
+                                    Task { await vm.setStatus(.open, for: report) }
+                                } label: {
+                                    Label("Reopen", systemImage: "arrow.uturn.backward")
+                                }
+                                .tint(.orange)
+                            }
                         }
                 }
             }
@@ -42,9 +66,20 @@ struct ReportListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Toggle("Show resolved", isOn: $vm.showsResolved)
-                    .toggleStyle(.button)
-                    .accessibilityIdentifier("toggleResolvedReports")
+                // A picker rather than the old "Show resolved" toggle. That
+                // toggle keyed on a state nothing in the app or the write path
+                // ever produced, so it could not visibly do anything (#146).
+                Menu {
+                    Picker("Filter", selection: $vm.statusFilter) {
+                        ForEach(ReportStatusFilter.allCases) { filter in
+                            Label(filter.displayName, systemImage: filter.systemImage)
+                                .tag(filter)
+                        }
+                    }
+                } label: {
+                    Label(vm.statusFilter.displayName, systemImage: "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityIdentifier("reportStatusFilter")
             }
         }
         .task { await vm.load() }

--- a/ClaudeLifter/Views/Reports/ReportSheetView.swift
+++ b/ClaudeLifter/Views/Reports/ReportSheetView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// File a complaint (issue #135). The gym version of this screen has to be
+/// survivable one-handed between sets: pick a chip, type a sentence, Send.
+/// Nothing else is required, and no context is asked for — it is all captured.
+struct ReportSheetView: View {
+    @State var vm: ReportSheetViewModel
+    var onSaved: () -> Void = {}
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var detailFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    categoryPicker
+                } header: {
+                    Text("What's wrong?")
+                }
+
+                Section {
+                    TextField(
+                        "Describe it in your own words",
+                        text: $vm.detail,
+                        axis: .vertical
+                    )
+                    .lineLimit(3...8)
+                    .focused($detailFocused)
+                    .accessibilityIdentifier("reportDetailField")
+
+                    if vm.showsReplacementField {
+                        TextField(
+                            "What should it be instead? (optional)",
+                            text: $vm.suggestedReplacement
+                        )
+                        .accessibilityIdentifier("reportReplacementField")
+                    }
+                }
+
+                if let contextSummary = vm.context.contextSummary {
+                    Section {
+                        Text(contextSummary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } header: {
+                        Text("Attached automatically")
+                    } footer: {
+                        Text(
+                            "Sent with the report so it can be looked into later. "
+                            + "You don't need to write any of this down."
+                        )
+                    }
+                }
+
+                if let errorMessage = vm.errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.callout)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Report a problem")
+            .navigationBarTitleDisplayMode(.inline)
+            .safeAreaInset(edge: .top, spacing: 0) {
+                subjectBanner
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Send") {
+                        Task {
+                            if await vm.submit() {
+                                onSaved()
+                                dismiss()
+                            }
+                        }
+                    }
+                    .disabled(!vm.canSubmit)
+                    .accessibilityIdentifier("submitReport")
+                }
+            }
+            .task { detailFocused = true }
+        }
+    }
+
+    private var subjectBanner: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "flag")
+                .foregroundStyle(.secondary)
+            Text(vm.context.subject)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    private var categoryPicker: some View {
+        // A wrapping row of chips rather than a Picker: every option stays
+        // visible and one-tap, which matters far more than saving a row.
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 150), spacing: 8)],
+            alignment: .leading,
+            spacing: 8
+        ) {
+            ForEach(ReportCategory.allCases, id: \.self) { category in
+                categoryChip(category)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func categoryChip(_ category: ReportCategory) -> some View {
+        let isSelected = vm.category == category
+        return Button {
+            vm.category = category
+        } label: {
+            Label(category.displayName, systemImage: category.systemImage)
+                .font(.subheadline)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, minHeight: 34)
+                .padding(.horizontal, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isSelected
+                              ? BrandTheme.terracotta.opacity(0.2)
+                              : Color(uiColor: .tertiarySystemFill))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(
+                            isSelected ? BrandTheme.terracotta : .clear,
+                            lineWidth: 1.5
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isSelected ? BrandTheme.terracotta : .primary)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier("reportCategory_\(category.rawValue)")
+    }
+}

--- a/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
+++ b/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
@@ -239,6 +239,10 @@ struct ActiveWorkoutView: View {
             onEditNotes: {
                 focusedField = nil
                 noteTarget = ExerciseNoteTarget(workoutExercise: workoutExercise)
+            },
+            plannedTarget: vm.plannedTarget(for: workoutExercise),
+            previousDrifted: { set in
+                vm.previousDriftedFromTarget(set, in: workoutExercise)
             }
         )
     }

--- a/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
+++ b/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
@@ -61,6 +61,8 @@ struct ActiveWorkoutView: View {
     @State private var restSession: RestTimerSession?
     @State private var showExercisePicker = false
     @State private var showCancelDialog = false
+    /// Non-nil while the report sheet is up; carries the captured context.
+    @State private var reportContext: ReportContext?
     @FocusState private var focusedField: SetEntryFieldID?
     @Environment(AppState.self) private var appState
     @Environment(\.dependencies) private var dependencies
@@ -79,6 +81,9 @@ struct ActiveWorkoutView: View {
                 .toolbar { toolbarContent(scrollProxy: scrollProxy) }
                 .task { await vm.startWorkout() }
                 .sheet(isPresented: $showExercisePicker) { exercisePicker }
+                .sheet(item: $reportContext) { context in
+                    reportSheet(for: context)
+                }
                 .confirmationDialog(
                     "Exit workout?",
                     isPresented: $showCancelDialog
@@ -201,8 +206,24 @@ struct ActiveWorkoutView: View {
             onRemoveSet: { set in
                 focusedField = nil
                 vm.removeSet(set, from: workoutExercise)
+            },
+            onReport: {
+                focusedField = nil
+                reportContext = .forExercise(workoutExercise, in: vm.workout)
             }
         )
+    }
+
+    @ViewBuilder
+    private func reportSheet(for context: ReportContext) -> some View {
+        if let dependencies {
+            ReportSheetView(
+                vm: ReportSheetViewModel(
+                    context: context,
+                    repository: dependencies.exerciseReportRepository
+                )
+            )
+        }
     }
 
     @ViewBuilder
@@ -251,6 +272,15 @@ struct ActiveWorkoutView: View {
                 }
             }
             .accessibilityIdentifier("cancelWorkout")
+        }
+        ToolbarItem(placement: .secondaryAction) {
+            Button {
+                focusedField = nil
+                reportContext = .forWorkout(vm.workout)
+            } label: {
+                Label("Report a problem…", systemImage: "flag")
+            }
+            .accessibilityIdentifier("reportWorkout")
         }
         ToolbarItem(placement: .primaryAction) {
             Button {

--- a/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
+++ b/ClaudeLifter/Views/Workout/ActiveWorkoutView.swift
@@ -54,6 +54,16 @@ func isSetEntryFieldAccessibilityIdentifier(_ identifier: String?) -> Bool {
         && UUID(uuidString: String(components[2])) != nil
 }
 
+/// Identifies the exercise whose note is being edited (#136). A wrapper rather
+/// than the model itself so `.sheet(item:)` keys on the stable UUID.
+struct ExerciseNoteTarget: Identifiable {
+    let workoutExercise: WorkoutExercise
+    var id: UUID { workoutExercise.id }
+    var exerciseName: String {
+        workoutExercise.exercise?.name ?? "Exercise"
+    }
+}
+
 struct ActiveWorkoutView: View {
     @State var vm: ActiveWorkoutViewModel
     var onDismiss: (() -> Void)? = nil
@@ -63,6 +73,8 @@ struct ActiveWorkoutView: View {
     @State private var showCancelDialog = false
     /// Non-nil while the report sheet is up; carries the captured context.
     @State private var reportContext: ReportContext?
+    /// Non-nil while the per-exercise note editor is up (#136).
+    @State private var noteTarget: ExerciseNoteTarget?
     @FocusState private var focusedField: SetEntryFieldID?
     @Environment(AppState.self) private var appState
     @Environment(\.dependencies) private var dependencies
@@ -83,6 +95,19 @@ struct ActiveWorkoutView: View {
                 .sheet(isPresented: $showExercisePicker) { exercisePicker }
                 .sheet(item: $reportContext) { context in
                     reportSheet(for: context)
+                }
+                .sheet(item: $noteTarget) { target in
+                    ExerciseNoteEditorView(
+                        exerciseName: target.exerciseName,
+                        initialNotes: target.workoutExercise.exercise?.notes
+                    ) { notes in
+                        Task {
+                            await vm.updateExerciseNotes(
+                                target.workoutExercise,
+                                notes: notes
+                            )
+                        }
+                    }
                 }
                 .confirmationDialog(
                     "Exit workout?",
@@ -210,6 +235,10 @@ struct ActiveWorkoutView: View {
             onReport: {
                 focusedField = nil
                 reportContext = .forExercise(workoutExercise, in: vm.workout)
+            },
+            onEditNotes: {
+                focusedField = nil
+                noteTarget = ExerciseNoteTarget(workoutExercise: workoutExercise)
             }
         )
     }

--- a/ClaudeLifter/Views/Workout/ExerciseCardView.swift
+++ b/ClaudeLifter/Views/Workout/ExerciseCardView.swift
@@ -9,6 +9,9 @@ struct ExerciseCardView: View {
     let onEditReps: (WorkoutSet, Int?) -> Void
     let onAddSet: () -> Void
     var onRemoveSet: ((WorkoutSet) -> Void)? = nil
+    /// Files a report against this exercise (issue #135). The gym is where
+    /// the problem is noticed, so this is the entry point that matters.
+    var onReport: (() -> Void)? = nil
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -109,18 +112,28 @@ struct ExerciseCardView: View {
                 }
             }
             Spacer()
-            removeSetMenu
+            actionsMenu
         }
     }
 
     @ViewBuilder
-    private var removeSetMenu: some View {
-        if sortedSets.count > 1, let onRemoveSet {
+    private var actionsMenu: some View {
+        if onRemoveSet != nil || onReport != nil {
             Menu {
-                Section("Remove Set…") {
-                    ForEach(sortedSets, id: \.id) { set in
-                        Button("Set \(set.order + 1)", role: .destructive) {
-                            onRemoveSet(set)
+                if let onReport {
+                    Button {
+                        onReport()
+                    } label: {
+                        Label("Report a problem…", systemImage: "flag")
+                    }
+                    .accessibilityIdentifier("reportExercise")
+                }
+                if sortedSets.count > 1, let onRemoveSet {
+                    Section("Remove Set…") {
+                        ForEach(sortedSets, id: \.id) { set in
+                            Button("Set \(set.order + 1)", role: .destructive) {
+                                onRemoveSet(set)
+                            }
                         }
                     }
                 }

--- a/ClaudeLifter/Views/Workout/ExerciseCardView.swift
+++ b/ClaudeLifter/Views/Workout/ExerciseCardView.swift
@@ -16,6 +16,12 @@ struct ExerciseCardView: View {
     /// are needed standing at the machine, so the note is shown inline and the
     /// editor is one tap from it.
     var onEditNotes: (() -> Void)? = nil
+    /// The template plan for this exercise (#144). Nil for ad-hoc workouts and
+    /// exercises added mid-session — both genuinely have no target, and an
+    /// invented one would be worse than none.
+    var plannedTarget: PlannedTarget? = nil
+    /// Whether last session's reps for a given set missed that target.
+    var previousDrifted: (WorkoutSet) -> Bool = { _ in false }
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -26,6 +32,7 @@ struct ExerciseCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             exerciseHeader
+            targetRow
             notesRow
             Divider()
             setEntryRows
@@ -34,6 +41,21 @@ struct ExerciseCardView: View {
         .padding()
         .background(Color(uiColor: .secondarySystemBackground))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// The plan, so drift is visible while training rather than only in
+    /// hindsight (#144). Without it the screen showed what you did last time
+    /// and nothing about what was intended, so 8 → 12 → 12 → 12 each looked
+    /// locally reasonable.
+    @ViewBuilder
+    private var targetRow: some View {
+        if let plannedTarget {
+            Text("Target \(plannedTarget.summary)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Target \(plannedTarget.sets) sets of \(plannedTarget.reps) reps")
+                .accessibilityIdentifier("exerciseTarget")
+        }
     }
 
     /// The durable note lives on the library `Exercise` — it describes the
@@ -140,6 +162,7 @@ struct ExerciseCardView: View {
             workoutExerciseID: workoutExercise.id,
             set: set,
             previous: previousValue(set),
+            previousDrifted: previousDrifted(set),
             layout: layout,
             focusedField: focusedField,
             onComplete: onCompleteSet,

--- a/ClaudeLifter/Views/Workout/ExerciseCardView.swift
+++ b/ClaudeLifter/Views/Workout/ExerciseCardView.swift
@@ -12,6 +12,10 @@ struct ExerciseCardView: View {
     /// Files a report against this exercise (issue #135). The gym is where
     /// the problem is noticed, so this is the entry point that matters.
     var onReport: (() -> Void)? = nil
+    /// Opens the per-exercise note editor (issue #136). The machine settings
+    /// are needed standing at the machine, so the note is shown inline and the
+    /// editor is one tap from it.
+    var onEditNotes: (() -> Void)? = nil
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -22,6 +26,7 @@ struct ExerciseCardView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             exerciseHeader
+            notesRow
             Divider()
             setEntryRows
             addSetButton
@@ -29,6 +34,82 @@ struct ExerciseCardView: View {
         .padding()
         .background(Color(uiColor: .secondarySystemBackground))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// The durable note lives on the library `Exercise` — it describes the
+    /// machine, so it follows the exercise into every workout (#136). The
+    /// session note is a separate, rarer thing (template cues, synced data)
+    /// and is shown beneath it rather than hidden.
+    private var exerciseNotes: String? {
+        Self.cleaned(workoutExercise.exercise?.notes)
+    }
+
+    private var sessionNotes: String? {
+        let session = Self.cleaned(workoutExercise.notes)
+        return session == exerciseNotes ? nil : session
+    }
+
+    private static func cleaned(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !value.isEmpty else { return nil }
+        return value
+    }
+
+    /// Shown inline, unconditionally when present — a note behind a tap is a
+    /// note you do not read mid-set, which is the whole of #136.
+    @ViewBuilder
+    private var notesRow: some View {
+        if exerciseNotes != nil || sessionNotes != nil {
+            VStack(alignment: .leading, spacing: 4) {
+                if let exerciseNotes {
+                    noteLine(
+                        exerciseNotes,
+                        systemImage: "note.text",
+                        identifier: "exerciseNotes",
+                        label: "Note"
+                    )
+                }
+                if let sessionNotes {
+                    noteLine(
+                        sessionNotes,
+                        systemImage: "text.bubble",
+                        identifier: "sessionNotes",
+                        label: "Session note"
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func noteLine(
+        _ text: String,
+        systemImage: String,
+        identifier: String,
+        label: String
+    ) -> some View {
+        let content = Label {
+            Text(text)
+                .font(.callout)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } icon: {
+            Image(systemName: systemImage)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(text)")
+        .accessibilityIdentifier(identifier)
+
+        if let onEditNotes, identifier == "exerciseNotes" {
+            Button(action: onEditNotes) { content }
+                .buttonStyle(.plain)
+                .accessibilityHint("Edit this note")
+        } else {
+            content
+        }
     }
 
     @ViewBuilder
@@ -118,8 +199,19 @@ struct ExerciseCardView: View {
 
     @ViewBuilder
     private var actionsMenu: some View {
-        if onRemoveSet != nil || onReport != nil {
+        if onRemoveSet != nil || onReport != nil || onEditNotes != nil {
             Menu {
+                if let onEditNotes {
+                    Button {
+                        onEditNotes()
+                    } label: {
+                        Label(
+                            exerciseNotes == nil ? "Add a note…" : "Edit note…",
+                            systemImage: "note.text"
+                        )
+                    }
+                    .accessibilityIdentifier("editExerciseNotes")
+                }
                 if let onReport {
                     Button {
                         onReport()

--- a/ClaudeLifter/Views/Workout/ExerciseNoteEditorView.swift
+++ b/ClaudeLifter/Views/Workout/ExerciseNoteEditorView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Edits the note attached to a library `Exercise` (#136).
+///
+/// The note describes the machine — "Ankle 4; Seat 4; Pivot 1" — so it belongs
+/// to the exercise, not to this session or this template. Every future workout
+/// containing the exercise shows it, whichever template it came from.
+///
+/// A sheet rather than an inline field: the workout screen owns a single
+/// `@FocusState` keyed on `SetEntryFieldID` with a keyboard accessory bar for
+/// weight/reps navigation, and a free-text field in that hierarchy would have
+/// to join or fight it.
+struct ExerciseNoteEditorView: View {
+    let exerciseName: String
+    let initialNotes: String?
+    let onSave: (String?) -> Void
+
+    @State private var text: String
+    @FocusState private var isFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        exerciseName: String,
+        initialNotes: String?,
+        onSave: @escaping (String?) -> Void
+    ) {
+        self.exerciseName = exerciseName
+        self.initialNotes = initialNotes
+        self.onSave = onSave
+        _text = State(initialValue: initialNotes ?? "")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(
+                        "Seat 4; pin 7; pivot 1",
+                        text: $text,
+                        axis: .vertical
+                    )
+                    .lineLimit(3...8)
+                    .focused($isFocused)
+                    .accessibilityIdentifier("exerciseNoteField")
+                    .accessibilityLabel("Exercise note")
+                } header: {
+                    Text(exerciseName)
+                } footer: {
+                    Text("Machine settings and cues. Shown every time this exercise comes up, in any workout.")
+                }
+            }
+            .navigationTitle("Note")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        onSave(text)
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("saveExerciseNote")
+                }
+            }
+            .task { isFocused = true }
+        }
+    }
+}

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -7,6 +7,8 @@ struct HomeView: View {
     @State private var bodyWeightVM: BodyWeightViewModel?
     @State private var approvalVM: InboxApprovalViewModel?
     @State private var showTemplateEditor = false
+    @State private var reportListVM: ReportListViewModel?
+    @State private var showReports = false
     @State private var unreadInsights: [ProactiveInsight] = []
     @State private var path = NavigationPath()
 
@@ -59,6 +61,12 @@ struct HomeView: View {
                     settings: deps.settings
                 )
             }
+            if reportListVM == nil {
+                reportListVM = ReportListViewModel(
+                    repository: deps.exerciseReportRepository
+                )
+            }
+            await reportListVM?.load()
             if approvalVM == nil {
                 approvalVM = InboxApprovalViewModel(
                     manager: deps.syncManager
@@ -103,6 +111,16 @@ struct HomeView: View {
         } message: {
             Text(approvalVM?.errorMessage ?? "")
         }
+        .sheet(isPresented: $showReports) {
+            if let reportListVM {
+                NavigationStack {
+                    ReportListView(vm: reportListVM)
+                }
+                // Reports are also closed out by the AI over MCP, so the
+                // count can be stale by the time this closes.
+                .onDisappear { Task { await reportListVM.load() } }
+            }
+        }
         .sheet(isPresented: $showTemplateEditor) {
             if let deps {
                 TemplateEditorView(
@@ -143,6 +161,11 @@ struct HomeView: View {
                             Task { await approvalVM.decline(operation) }
                         }
                     )
+                }
+            }
+            if let reportListVM {
+                OpenReportsCard(count: reportListVM.openCount) {
+                    showReports = true
                 }
             }
             if let bodyWeightVM {

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -33,12 +33,7 @@ struct HomeView: View {
         // Presenting it over Home means the workout is already safely closed by
         // the time this appears, so any way of dismissing it is harmless (#123).
         .sheet(item: $appState.completedWorkoutSummary) { summary in
-            WorkoutSummaryView(
-                workout: summary.workout,
-                personalRecords: summary.personalRecords
-            ) {
-                appState.completedWorkoutSummary = nil
-            }
+            summarySheet(for: summary)
         }
         .task {
             guard let deps else { return }
@@ -261,6 +256,48 @@ struct HomeView: View {
         }
         .listStyle(.plain)
         .refreshable { await vm.loadTemplates() }
+    }
+
+    /// `summary` is @Observable, so both personalRecords and templateChangeSet
+    /// appear when their post-commit work lands, even though the sheet is
+    /// already on screen (#125, #130). Extracted from `body` because inlining
+    /// it pushed the expression past the type-checker's budget.
+    private func summarySheet(for summary: WorkoutCompletionSummary) -> some View {
+        WorkoutSummaryView(
+            workout: summary.workout,
+            personalRecords: summary.personalRecords,
+            onDismiss: { appState.completedWorkoutSummary = nil },
+            templateChangeSet: summary.templateChangeSet,
+            onApplyTemplateChanges: { changes in
+                await applyTemplateChanges(changes, from: summary)
+            }
+        )
+    }
+
+    /// Applies the reviewed template changes (#130). Returns an error message
+    /// to display, or nil on success — the workout is already saved, so a
+    /// failure here costs a template update and nothing more.
+    private func applyTemplateChanges(
+        _ changes: [TemplateChange],
+        from summary: WorkoutCompletionSummary
+    ) async -> String? {
+        guard let deps, let changeSet = summary.templateChangeSet else {
+            return "Couldn't update the template. Your workout is saved."
+        }
+        do {
+            try await TemplateChangeApplier(
+                templateRepository: deps.templateRepository,
+                exerciseRepository: deps.exerciseRepository
+            ).apply(
+                changes,
+                from: changeSet,
+                capturedRevision: changeSet.capturedRevision
+            )
+            await vm?.loadTemplates()
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
     }
 
     private func startWorkout(from template: WorkoutTemplate) {

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -269,6 +269,7 @@ struct HomeView: View {
             template: template,
             workoutRepository: deps.workoutRepository,
             autoFillService: deps.autoFillService,
+            exerciseRepository: deps.exerciseRepository,
             templateRepository: deps.templateRepository,
             prDetectionService: deps.prDetectionService,
             settings: deps.settings
@@ -289,6 +290,7 @@ struct HomeView: View {
             resuming: workout,
             workoutRepository: deps.workoutRepository,
             autoFillService: deps.autoFillService,
+            exerciseRepository: deps.exerciseRepository,
             templateRepository: deps.templateRepository,
             prDetectionService: deps.prDetectionService,
             settings: deps.settings
@@ -304,6 +306,7 @@ struct HomeView: View {
             adHocName: "Quick Workout",
             workoutRepository: deps.workoutRepository,
             autoFillService: deps.autoFillService,
+            exerciseRepository: deps.exerciseRepository,
             prDetectionService: deps.prDetectionService,
             settings: deps.settings
         )

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -271,6 +271,7 @@ struct HomeView: View {
             autoFillService: deps.autoFillService,
             exerciseRepository: deps.exerciseRepository,
             templateRepository: deps.templateRepository,
+            baselineRepository: deps.baselineRepository,
             prDetectionService: deps.prDetectionService,
             settings: deps.settings
         )
@@ -292,6 +293,7 @@ struct HomeView: View {
             autoFillService: deps.autoFillService,
             exerciseRepository: deps.exerciseRepository,
             templateRepository: deps.templateRepository,
+            baselineRepository: deps.baselineRepository,
             prDetectionService: deps.prDetectionService,
             settings: deps.settings
         )

--- a/ClaudeLifter/Views/Workout/HomeView.swift
+++ b/ClaudeLifter/Views/Workout/HomeView.swift
@@ -159,7 +159,10 @@ struct HomeView: View {
                 }
             }
             if let reportListVM {
-                OpenReportsCard(count: reportListVM.openCount) {
+                OpenReportsCard(
+                    count: reportListVM.openCount,
+                    acknowledgedCount: reportListVM.acknowledgedCount
+                ) {
                     showReports = true
                 }
             }

--- a/ClaudeLifter/Views/Workout/SetRowView.swift
+++ b/ClaudeLifter/Views/Workout/SetRowView.swift
@@ -17,6 +17,11 @@ struct SetRowView: View {
     let workoutExerciseID: UUID
     let set: WorkoutSet
     let previous: AutoFillResult?
+    /// True when last session's reps missed the template target (#144). Marked
+    /// here, on PREVIOUS, and never on what the user is typing now — this is
+    /// next to the field they are about to fill in, while the choice is still
+    /// theirs to make.
+    var previousDrifted: Bool = false
     let layout: SetRowLayout
     let focusedField: FocusState<SetEntryFieldID?>.Binding
     let onComplete: (WorkoutSet) -> Void
@@ -129,9 +134,22 @@ struct SetRowView: View {
             let reps = previous.reps.map {
                 Text($0, format: repsFormat)
             } ?? Text("—")
-            Text("\(weight) × \(reps)")
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
+            HStack(spacing: 2) {
+                Text("\(weight) × \(reps)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(previousDrifted ? .orange : .secondary)
+                if previousDrifted {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                previousDrifted
+                    ? "Previous session, off target"
+                    : "Previous session"
+            )
         } else {
             Text("—")
                 .foregroundStyle(.tertiary)

--- a/ClaudeLifter/Views/Workout/TemplateReviewSection.swift
+++ b/ClaudeLifter/Views/Workout/TemplateReviewSection.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+/// Post-workout template reconciliation, shown on the completion summary (#130).
+///
+/// Deliberately inline in the summary rather than a second sheet: presenting a
+/// sheet from a sheet is where SwiftUI dismissal races live, and this screen is
+/// already the one place where a stranded presentation cost the user a whole
+/// workout once (#123). Expanding in place cannot strand anything.
+///
+/// It appears **only** when there is something to decide, and its default is to
+/// do nothing — the workout is already saved, and the template is the user's.
+struct TemplateReviewSection: View {
+    let changeSet: TemplateChangeSet
+    let onApply: ([TemplateChange]) async -> String?
+
+    /// Where the user has got to. Explicit rather than a pile of booleans,
+    /// because "declined" and "applied" must not be able to render as each
+    /// other — telling someone their template was updated when it was not is
+    /// worse than any of this being on screen at all.
+    private enum Outcome {
+        case undecided
+        case reviewing
+        case declined
+        case applied
+    }
+
+    @State private var outcome: Outcome = .undecided
+    @State private var selected: Set<String> = []
+    @State private var isApplying = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            switch outcome {
+            case .undecided: promptState
+            case .reviewing: reviewState
+            case .declined: closedState(text: "Template left unchanged")
+            case .applied: closedState(text: "Template updated")
+            }
+        }
+        .padding()
+        .background(BrandTheme.accent.opacity(0.1))
+        .cornerRadius(12)
+        .onAppear {
+            // Everything selected by default: the user came here because the
+            // changes describe what they actually did.
+            if selected.isEmpty {
+                selected = Set(changeSet.changes.map(\.id))
+            }
+        }
+    }
+
+    private var promptState: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Update \(changeSet.templateName)?", systemImage: "square.and.pencil")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(summaryLine)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Button("Review changes") { outcome = .reviewing }
+                    .buttonStyle(.bordered)
+                    .accessibilityIdentifier("reviewTemplateChanges")
+                Spacer()
+                Button("Keep unchanged") { outcome = .declined }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var reviewState: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Update \(changeSet.templateName)")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if changeSet.hasConflict {
+                Label(
+                    "This template changed somewhere else since you started. Applying may overwrite that.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+
+            ForEach(changeSet.changes) { change in
+                Toggle(isOn: binding(for: change)) {
+                    Text(description(of: change))
+                        .font(.subheadline)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .toggleStyle(.switch)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Button("Not now") { outcome = .declined }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Apply") { Task { await apply() } }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(selected.isEmpty || isApplying)
+                    .accessibilityIdentifier("applyTemplateChanges")
+            }
+        }
+    }
+
+    private func closedState(text: String) -> some View {
+        Label(text, systemImage: "checkmark.circle")
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var summaryLine: String {
+        let count = changeSet.changes.count
+        let noun = count == 1 ? "change" : "changes"
+        return "This workout differed from the template in \(count) \(noun)."
+    }
+
+    private func binding(for change: TemplateChange) -> Binding<Bool> {
+        Binding(
+            get: { selected.contains(change.id) },
+            set: { isOn in
+                if isOn { selected.insert(change.id) } else { selected.remove(change.id) }
+            }
+        )
+    }
+
+    private func apply() async {
+        isApplying = true
+        errorMessage = nil
+        let chosen = changeSet.changes.filter { selected.contains($0.id) }
+        let failure = await onApply(chosen)
+        isApplying = false
+        if let failure {
+            // Stay in the review state so the user can retry or decline. The
+            // workout is saved either way, which is what the message says.
+            errorMessage = failure
+        } else {
+            outcome = .applied
+        }
+    }
+
+    private func description(of change: TemplateChange) -> String {
+        switch change {
+        case .addedExercise(let c):
+            let reps = c.reps.map { " × \($0)" } ?? ""
+            return "Add \(c.name) (\(c.sets) sets\(reps))"
+        case .removedExercise(let c):
+            return "Remove \(c.name)"
+        case .reordered(let c):
+            return "Reorder to: \(c.names.joined(separator: ", "))"
+        case .setCountChanged(let c):
+            return "\(c.name): \(c.from) → \(c.to) sets"
+        case .cueChanged(let c):
+            return "\(c.name) note: “\(c.to ?? "")”"
+        }
+    }
+}

--- a/ClaudeLifter/Views/Workout/WorkoutSummaryView.swift
+++ b/ClaudeLifter/Views/Workout/WorkoutSummaryView.swift
@@ -4,6 +4,12 @@ struct WorkoutSummaryView: View {
     let workout: Workout
     let personalRecords: [PersonalRecord]
     let onDismiss: () -> Void
+    /// Proposed template changes (#130). Nil when the workout was ad-hoc, or
+    /// matched its plan, or detection has not finished yet — the card must
+    /// never appear with nothing in it.
+    var templateChangeSet: TemplateChangeSet? = nil
+    /// Returns an error message to show, or nil on success.
+    var onApplyTemplateChanges: (([TemplateChange]) async -> String?)? = nil
 
     var totalSets: Int {
         workout.exercises.flatMap(\.sets).filter(\.isCompleted).count
@@ -48,6 +54,13 @@ struct WorkoutSummaryView: View {
 
                 if !personalRecords.isEmpty {
                     prSection
+                }
+
+                if let templateChangeSet, let onApplyTemplateChanges {
+                    TemplateReviewSection(
+                        changeSet: templateChangeSet,
+                        onApply: onApplyTemplateChanges
+                    )
                 }
 
                 Button("Done") { onDismiss() }

--- a/ClaudeLifterTests/Helpers/MockNetworkService.swift
+++ b/ClaudeLifterTests/Helpers/MockNetworkService.swift
@@ -74,11 +74,22 @@ final class MockNetworkService: NetworkServiceProtocol, @unchecked Sendable {
     /// is returned — lets tests simulate edits made while the POST is in flight.
     var onPushSnapshot: (@MainActor () -> Void)?
 
+    /// Every request in call order — the downgrade-and-retry path (#140) sends
+    /// two, and only checking `lastSnapshotRequest` would hide the first.
+    var snapshotRequests: [SnapshotPushRequest] = []
+    /// Consumed one per call, before `pushSnapshotError`. A nil entry means
+    /// "this call succeeds"; an exhausted queue falls through to the flat
+    /// error, so existing tests are unaffected.
+    var pushSnapshotErrorQueue: [Error?] = []
+
     func pushSnapshot(_ request: SnapshotPushRequest) async throws -> SnapshotPushResponse {
         pushSnapshotCallCount += 1
         lastSnapshotRequest = request
+        snapshotRequests.append(request)
         if let onPushSnapshot { await onPushSnapshot() }
-        if let pushSnapshotError { throw pushSnapshotError }
+        if !pushSnapshotErrorQueue.isEmpty {
+            if let queued = pushSnapshotErrorQueue.removeFirst() { throw queued }
+        } else if let pushSnapshotError { throw pushSnapshotError }
         if let error = errorToThrow { throw error }
         guard let result = pushSnapshotResult else {
             throw SyncError.serverError(500)

--- a/ClaudeLifterTests/Helpers/MockTemplateBaselineRepository.swift
+++ b/ClaudeLifterTests/Helpers/MockTemplateBaselineRepository.swift
@@ -1,0 +1,40 @@
+import Foundation
+@testable import ClaudeLifter
+
+@MainActor
+final class MockTemplateBaselineRepository: TemplateBaselineRepository {
+    var baselines: [WorkoutTemplateBaseline] = []
+    var entries: [WorkoutExerciseBaseline] = []
+    var saveCallCount = 0
+    var deletedWorkoutIds: [UUID] = []
+    var errorToThrow: Error?
+
+    func fetchBaseline(workoutId: UUID) async throws -> WorkoutTemplateBaseline? {
+        if let errorToThrow { throw errorToThrow }
+        return baselines.first { $0.workoutId == workoutId }
+    }
+
+    func fetchEntries(workoutId: UUID) async throws -> [WorkoutExerciseBaseline] {
+        if let errorToThrow { throw errorToThrow }
+        return entries
+            .filter { $0.workoutId == workoutId }
+            .sorted { $0.plannedOrder < $1.plannedOrder }
+    }
+
+    func save(
+        _ baseline: WorkoutTemplateBaseline,
+        entries newEntries: [WorkoutExerciseBaseline]
+    ) async throws {
+        saveCallCount += 1
+        if let errorToThrow { throw errorToThrow }
+        baselines.append(baseline)
+        entries.append(contentsOf: newEntries)
+    }
+
+    func delete(workoutId: UUID) async throws {
+        if let errorToThrow { throw errorToThrow }
+        deletedWorkoutIds.append(workoutId)
+        baselines.removeAll { $0.workoutId == workoutId }
+        entries.removeAll { $0.workoutId == workoutId }
+    }
+}

--- a/ClaudeLifterTests/ModelTests/TemplateProvenanceMigrationTests.swift
+++ b/ClaudeLifterTests/ModelTests/TemplateProvenanceMigrationTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import ClaudeLifter
+
+/// V3 → V4 (issue #128): template provenance as two new models.
+///
+/// Worth testing on a **real on-disk store** rather than in memory, because an
+/// in-memory container does not exercise migration at all — it would pass while
+/// the phone crashed on first launch.
+///
+/// It caught exactly that. The first attempt put the provenance fields on
+/// `Workout` and `WorkoutExercise` and died with `NSInvalidArgumentException:
+/// Duplicate version checksums detected`: the `VersionedSchema` model lists
+/// name live Swift types, so adding a property changes V1–V3 as well as V4 and
+/// all four hash identically. See the note on `ClaudeLifterSchemaV4`.
+@Suite("Template Provenance Migration Tests")
+@MainActor
+struct TemplateProvenanceMigrationTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appending(path: "provenance-migration-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    @Test("A populated V3 store migrates to V4 with every record intact")
+    func v3StoreMigratesToV4() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storeURL = dir.appending(path: "default.store")
+
+        let workoutId = UUID()
+
+        // A genuine V3 store — no migration plan, V3 schema only — populated
+        // the way the device actually is: a workout with exercises and sets,
+        // a template, and a report.
+        do {
+            let v3Schema = Schema(versionedSchema: ClaudeLifterSchemaV3.self)
+            let container = try ModelContainer(
+                for: v3Schema,
+                configurations: [ModelConfiguration(schema: v3Schema, url: storeURL)]
+            )
+            let context = container.mainContext
+            let exercise = Exercise(name: "Seated Leg Curl", isCustom: false, externalId: "Seated_Leg_Curl")
+            context.insert(exercise)
+
+            let workout = Workout(id: workoutId, name: "Lower B", startedAt: .now)
+            context.insert(workout)
+            let we = WorkoutExercise(order: 0, exercise: exercise, restSeconds: 90)
+            context.insert(we)
+            workout.exercises.append(we)
+            let set = WorkoutSet(order: 0, weight: 47.5, weightUnit: .kg, reps: 12, isCompleted: true, completedAt: .now)
+            context.insert(set)
+            we.sets.append(set)
+
+            let template = WorkoutTemplate(name: "Lower B")
+            context.insert(template)
+            let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 3, defaultReps: 12)
+            context.insert(te)
+            template.exercises.append(te)
+
+            context.insert(ExerciseReport(category: .bug, detail: "notes missing"))
+            try context.save()
+        }
+
+        // Reopen through the factory. CurrentSchema is V4, so this runs the
+        // V3→V4 stage. `.opened` — a quarantine here is the on-device crash.
+        let result = try ModelContainerFactory.make(
+            storeURL: storeURL,
+            quarantineDirectory: dir.appending(path: "StoreQuarantine")
+        )
+        #expect(result.outcome == .opened, "a quarantine here means the phone loses its store on first launch")
+
+        let context = result.container.mainContext
+
+        let workouts = try context.fetch(FetchDescriptor<Workout>())
+        #expect(workouts.count == 1)
+        let migrated = try #require(workouts.first)
+        #expect(migrated.name == "Lower B")
+        #expect(migrated.exercises.count == 1)
+        #expect(migrated.exercises.first?.sets.count == 1)
+        #expect(migrated.exercises.first?.sets.first?.weight == 47.5)
+        #expect(try context.fetch(FetchDescriptor<WorkoutTemplate>()).count == 1)
+        #expect(try context.fetch(FetchDescriptor<ExerciseReport>()).count == 1)
+
+        // Pre-existing workouts simply have no baseline. Old history is never
+        // retro-reconciled, and its absence must not be an error.
+        let baselines = try context.fetch(FetchDescriptor<WorkoutTemplateBaseline>())
+        #expect(baselines.isEmpty)
+        #expect(try context.fetch(FetchDescriptor<WorkoutExerciseBaseline>()).isEmpty)
+        _ = workoutId
+    }
+
+    @Test("Provenance is writable and persists in the migrated store")
+    func provenanceWritableAfterMigration() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storeURL = dir.appending(path: "default.store")
+
+        do {
+            let v3Schema = Schema(versionedSchema: ClaudeLifterSchemaV3.self)
+            let container = try ModelContainer(
+                for: v3Schema,
+                configurations: [ModelConfiguration(schema: v3Schema, url: storeURL)]
+            )
+            try container.mainContext.save()
+        }
+
+        let result = try ModelContainerFactory.make(
+            storeURL: storeURL,
+            quarantineDirectory: dir.appending(path: "StoreQuarantine")
+        )
+        #expect(result.outcome == .opened)
+        let context = result.container.mainContext
+
+        let workoutId = UUID()
+        let revision = Date(timeIntervalSince1970: 1_787_000_000)
+        let baseline = WorkoutTemplateBaseline(
+            workoutId: workoutId,
+            templateId: UUID(),
+            templateRevision: revision,
+            templateName: "Lower B"
+        )
+        context.insert(baseline)
+        let entry = WorkoutExerciseBaseline(
+            workoutId: workoutId,
+            workoutExerciseId: UUID(),
+            sourceTemplateExerciseId: UUID(),
+            exerciseId: UUID(),
+            exerciseExternalId: "Split_Squat_with_Dumbbells",
+            exerciseName: "Split Squat with Dumbbells",
+            plannedOrder: 1,
+            plannedSets: 2,
+            plannedReps: 8,
+            plannedRestSeconds: 90,
+            plannedNotes: "Rear foot on the bench"
+        )
+        context.insert(entry)
+        try context.save()
+
+        let reread = try #require(try context.fetch(FetchDescriptor<WorkoutTemplateBaseline>()).first)
+        #expect(reread.templateRevision == revision)
+        #expect(reread.templateName == "Lower B")
+        let rereadEntry = try #require(try context.fetch(FetchDescriptor<WorkoutExerciseBaseline>()).first)
+        #expect(rereadEntry.plannedReps == 8)
+        #expect(rereadEntry.plannedSets == 2)
+        #expect(rereadEntry.plannedNotes == "Rear foot on the bench")
+        #expect(rereadEntry.exerciseExternalId == "Split_Squat_with_Dumbbells")
+    }
+}

--- a/ClaudeLifterTests/RepositoryTests/ExerciseReportRepositoryTests.swift
+++ b/ClaudeLifterTests/RepositoryTests/ExerciseReportRepositoryTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import ClaudeLifter
+
+@Suite("ExerciseReportRepository Tests")
+@MainActor
+struct ExerciseReportRepositoryTests {
+
+    private struct Setup {
+        let container: ModelContainer
+        let repository: SwiftDataExerciseReportRepository
+    }
+
+    private func makeSetup() throws -> Setup {
+        let container = try makeTestContainer()
+        return Setup(
+            container: container,
+            repository: SwiftDataExerciseReportRepository(context: container.mainContext)
+        )
+    }
+
+    @Test("Saved reports fetch newest-first")
+    func fetchAllNewestFirst() async throws {
+        let setup = try makeSetup()
+        try await setup.repository.save(ExerciseReport(
+            createdAt: Date(timeIntervalSinceNow: -3600),
+            category: .bug,
+            detail: "Rest timer fired twice"
+        ))
+        try await setup.repository.save(ExerciseReport(
+            createdAt: .now,
+            category: .swapRequest,
+            detail: "Swap this for a machine row"
+        ))
+
+        let all = try await setup.repository.fetchAll()
+        #expect(all.count == 2)
+        #expect(all.first?.detail == "Swap this for a machine row")
+    }
+
+    @Test("fetch by id returns the matching report")
+    func fetchByID() async throws {
+        let setup = try makeSetup()
+        let id = UUID()
+        try await setup.repository.save(ExerciseReport(
+            id: id, category: .other, detail: "Something"
+        ))
+
+        let found = try await setup.repository.fetch(id: id)
+        #expect(found?.id == id)
+        #expect(try await setup.repository.fetch(id: UUID()) == nil)
+    }
+
+    @Test("fetchOpen excludes resolved but keeps acknowledged")
+    func fetchOpenExcludesResolvedOnly() async throws {
+        let setup = try makeSetup()
+        try await setup.repository.save(ExerciseReport(
+            category: .bug, detail: "open one", status: .open
+        ))
+        try await setup.repository.save(ExerciseReport(
+            category: .bug, detail: "seen but not fixed", status: .acknowledged
+        ))
+        try await setup.repository.save(ExerciseReport(
+            category: .bug, detail: "done", status: .resolved
+        ))
+
+        let open = try await setup.repository.fetchOpen()
+        #expect(open.count == 2)
+        #expect(!open.contains { $0.detail == "done" })
+    }
+
+    @Test("fetchPending returns only unsynced reports")
+    func fetchPendingReturnsUnsynced() async throws {
+        let setup = try makeSetup()
+        try await setup.repository.save(ExerciseReport(
+            category: .bug, detail: "not yet pushed", syncStatus: .pending
+        ))
+        try await setup.repository.save(ExerciseReport(
+            category: .bug, detail: "already mirrored", syncStatus: .synced
+        ))
+
+        let pending = try await setup.repository.fetchPending()
+        #expect(pending.count == 1)
+        #expect(pending.first?.detail == "not yet pushed")
+    }
+
+    @Test("Deleting removes the report")
+    func deleteRemovesReport() async throws {
+        let setup = try makeSetup()
+        let report = ExerciseReport(category: .other, detail: "temp")
+        try await setup.repository.save(report)
+        try await setup.repository.delete(report)
+
+        #expect(try await setup.repository.fetchAll().isEmpty)
+    }
+}
+
+@Suite("ExerciseReport Model Tests")
+@MainActor
+struct ExerciseReportModelTests {
+
+    @Test("Unknown raw category and status fall back rather than crashing")
+    func unknownRawValuesFallBack() {
+        let report = ExerciseReport(category: .bug, detail: "x")
+        report.categoryRaw = "somethingFromANewerBuild"
+        report.statusRaw = "quarantined"
+
+        #expect(report.category == .other)
+        #expect(report.status == .open)
+        // The raw value itself is untouched — the fallback is a read-time
+        // convenience, not a rewrite.
+        #expect(report.categoryRaw == "somethingFromANewerBuild")
+    }
+
+    @Test("recordChange re-queues the report for the next snapshot push")
+    func recordChangeMarksPending() {
+        let report = ExerciseReport(
+            category: .bug, detail: "x", syncStatus: .synced
+        )
+        report.status = .resolved
+        report.recordChange()
+
+        #expect(report.syncStatus == .pending)
+    }
+
+    @Test("Every category has a distinct display name and icon")
+    func categoriesAreDistinct() {
+        let names = Set(ReportCategory.allCases.map(\.displayName))
+        let icons = Set(ReportCategory.allCases.map(\.systemImage))
+        #expect(names.count == ReportCategory.allCases.count)
+        #expect(icons.count == ReportCategory.allCases.count)
+    }
+}

--- a/ClaudeLifterTests/RepositoryTests/ExerciseRepositoryTests.swift
+++ b/ClaudeLifterTests/RepositoryTests/ExerciseRepositoryTests.swift
@@ -424,16 +424,27 @@ struct ExerciseRepositoryCustomSyncTriggerTests {
         _ = container
     }
 
-    @Test("Saving a bundled exercise does not")
-    func savingBundledExerciseDoesNotSignal() async throws {
-        // Bundled exercises are never mirrored, and signalling here would
-        // dirty the phone 800 times during the first-launch import.
+    @Test("Saving a bundled exercise signals as well, since #140")
+    func savingBundledExerciseSignals() async throws {
+        // Inverted by #140. This test used to assert the opposite, on the
+        // grounds that bundled exercises are never mirrored and signalling
+        // would dirty the phone 800 times during the first-launch import.
+        //
+        // The first half stopped being true: a bundled exercise's note and
+        // photo ARE mirrored now, as overlays. The second half was never true
+        // — the import inserts into the ModelContext directly and does not go
+        // through this repository at all.
+        //
+        // It signals unconditionally rather than "only when the exercise
+        // carries data", because the case that matters most is CLEARING a
+        // note: by save time the exercise is clean, and a gate would leave the
+        // deleted note alive in the mirror forever.
         let counter = CallCounter()
         let (container, repository) = try makeRepository(counter)
 
         try await repository.save(Exercise(name: "Bench Press", isCustom: false))
 
-        #expect(counter.count == 0)
+        #expect(counter.count == 1)
         _ = container
     }
 

--- a/ClaudeLifterTests/RepositoryTests/ExerciseRepositoryTests.swift
+++ b/ClaudeLifterTests/RepositoryTests/ExerciseRepositoryTests.swift
@@ -389,3 +389,64 @@ struct ExerciseRepositoryTests {
         }
     }
 }
+
+@Suite("ExerciseRepository — custom-exercise sync trigger (#104)")
+@MainActor
+struct ExerciseRepositoryCustomSyncTriggerTests {
+
+    /// Box because the callback is `@escaping` and the assertion needs to see
+    /// mutations made from inside it.
+    private final class CallCounter {
+        var count = 0
+    }
+
+    private func makeRepository(
+        _ counter: CallCounter
+    ) throws -> (ModelContainer, SwiftDataExerciseRepository) {
+        let container = try makeTestContainer()
+        let repository = SwiftDataExerciseRepository(
+            context: container.mainContext,
+            onCustomExerciseChanged: { counter.count += 1 }
+        )
+        return (container, repository)
+    }
+
+    @Test("Saving a custom exercise signals that a snapshot push is due")
+    func savingCustomExerciseSignals() async throws {
+        let counter = CallCounter()
+        let (container, repository) = try makeRepository(counter)
+
+        try await repository.save(
+            Exercise(name: "Cable Katana Extension", isCustom: true)
+        )
+
+        #expect(counter.count == 1)
+        _ = container
+    }
+
+    @Test("Saving a bundled exercise does not")
+    func savingBundledExerciseDoesNotSignal() async throws {
+        // Bundled exercises are never mirrored, and signalling here would
+        // dirty the phone 800 times during the first-launch import.
+        let counter = CallCounter()
+        let (container, repository) = try makeRepository(counter)
+
+        try await repository.save(Exercise(name: "Bench Press", isCustom: false))
+
+        #expect(counter.count == 0)
+        _ = container
+    }
+
+    @Test("Deleting a custom exercise signals too")
+    func deletingCustomExerciseSignals() async throws {
+        let counter = CallCounter()
+        let (container, repository) = try makeRepository(counter)
+        let exercise = Exercise(name: "Doomed Custom", isCustom: true)
+        try await repository.save(exercise)
+
+        try await repository.delete(exercise)
+
+        #expect(counter.count == 2)
+        _ = container
+    }
+}

--- a/ClaudeLifterTests/ServiceTests/BackupServiceTests.swift
+++ b/ClaudeLifterTests/ServiceTests/BackupServiceTests.swift
@@ -119,7 +119,8 @@ struct BackupServiceTests {
         let doc = try JSONDecoder().decode(BackupDocument.self, from: data)
 
         // Assert
-        #expect(doc.formatVersion == 1)
+        // 2 since #140 — the file now also carries bundled-exercise user data.
+        #expect(doc.formatVersion == 2)
         #expect(doc.workouts.count == 1)
         #expect(doc.templates.count == 1)
         #expect(doc.preferences.count == 1)
@@ -317,5 +318,143 @@ struct BackupServiceTests {
         let all = try await SwiftDataTrainingPreferenceRepository(context: contextB).fetchAll()
         #expect(all.filter { $0.key == ids.preferenceKey }.count == 1)
         #expect(all.first { $0.key == ids.preferenceKey }?.value == "strength")
+    }
+
+    // MARK: - Bundled-exercise user data (#140)
+    //
+    // Notes written on a bundled exercise — machine settings, per #136 — are
+    // the one thing a bundled exercise carries that the app bundle cannot
+    // restore. Excluding them from backup meant a reinstall silently lost
+    // "Ankle 4; Seat 4; Pivot 1" with no way to get it back.
+    //
+    // Carried as an overlay keyed by `externalId`, never by `id`: a fresh
+    // store re-imports the catalog with brand-new random UUIDs, so a
+    // UUID-keyed overlay would attach to nothing.
+
+    @Test("Export carries notes on bundled exercises as an externalId-keyed overlay")
+    func exportCarriesBundledExerciseOverlay() async throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        try seed(into: context)
+        let bundled = Exercise(
+            name: "Seated Leg Curl",
+            isCustom: false,
+            externalId: "Seated_Leg_Curl",
+            notes: "Ankle 4; Seat 4; Pivot 1"
+        )
+        context.insert(bundled)
+        // A bundled exercise with no user data must not bloat the file.
+        context.insert(Exercise(name: "Plain", isCustom: false, externalId: "Plain"))
+        try context.save()
+
+        let dir = try tempDirectory()
+        let service = makeService(context: context, documentsDirectory: dir)
+        let url = try await service.exportBackup()
+
+        let document = try JSONDecoder().decode(
+            BackupDocument.self,
+            from: try Data(contentsOf: url)
+        )
+        #expect(document.formatVersion == 2)
+        #expect(document.exerciseOverlays.count == 1)
+        let overlay = try #require(document.exerciseOverlays.first)
+        #expect(overlay.externalId == "Seated_Leg_Curl")
+        #expect(overlay.notes == "Ankle 4; Seat 4; Pivot 1")
+        // Custom exercises travel in full and must not be duplicated here.
+        #expect(document.exerciseOverlays.allSatisfy { $0.externalId != nil })
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("Import re-attaches an overlay by externalId even though the UUID differs")
+    func importReattachesOverlayByExternalId() async throws {
+        // Export from one store…
+        let source = try makeTestContainer()
+        let sourceContext = source.mainContext
+        try seed(into: sourceContext)
+        let bundled = Exercise(
+            name: "Seated Leg Curl",
+            isCustom: false,
+            externalId: "Seated_Leg_Curl",
+            notes: "Ankle 4; Seat 4; Pivot 1"
+        )
+        sourceContext.insert(bundled)
+        try sourceContext.save()
+        let dir = try tempDirectory()
+        let url = try await makeService(context: sourceContext, documentsDirectory: dir)
+            .exportBackup()
+
+        // …into a fresh store where the catalog has been re-imported with a
+        // different UUID for the same exercise. This is the reinstall case.
+        let destination = try makeTestContainer()
+        let destContext = destination.mainContext
+        let reimported = Exercise(
+            name: "Seated Leg Curl",
+            isCustom: false,
+            externalId: "Seated_Leg_Curl"
+        )
+        destContext.insert(reimported)
+        try destContext.save()
+        #expect(reimported.id != bundled.id, "a re-import mints a new UUID")
+
+        let summary = try await makeService(context: destContext, documentsDirectory: dir)
+            .importBackup(from: url)
+
+        #expect(reimported.notes == "Ankle 4; Seat 4; Pivot 1")
+        #expect(summary.exerciseOverlays.imported == 1)
+        withExtendedLifetime(source) {}
+        withExtendedLifetime(destination) {}
+    }
+
+    @Test("An overlay for an exercise that is not present is skipped, not invented")
+    func importSkipsOverlayWithNoMatchingExercise() async throws {
+        let source = try makeTestContainer()
+        let sourceContext = source.mainContext
+        try seed(into: sourceContext)
+        sourceContext.insert(Exercise(
+            name: "Obscure Machine",
+            isCustom: false,
+            externalId: "Obscure_Machine",
+            notes: "Seat 2"
+        ))
+        try sourceContext.save()
+        let dir = try tempDirectory()
+        let url = try await makeService(context: sourceContext, documentsDirectory: dir)
+            .exportBackup()
+
+        let destination = try makeTestContainer()
+        let destContext = destination.mainContext
+        let summary = try await makeService(context: destContext, documentsDirectory: dir)
+            .importBackup(from: url)
+
+        #expect(summary.exerciseOverlays.imported == 0)
+        #expect(summary.exerciseOverlays.skipped == 1)
+        withExtendedLifetime(source) {}
+        withExtendedLifetime(destination) {}
+    }
+
+    @Test("A v1 backup written before overlays existed still imports")
+    func importAcceptsV1BackupWithoutOverlays() async throws {
+        let dir = try tempDirectory()
+        let legacy = """
+        {
+          "formatVersion": 1,
+          "exportedAt": 776000000,
+          "workouts": [],
+          "templates": [],
+          "customExercises": [],
+          "preferences": []
+        }
+        """
+        let url = dir.appending(path: "legacy.json")
+        try Data(legacy.utf8).write(to: url)
+
+        let container = try makeTestContainer()
+        let summary = try await makeService(
+            context: container.mainContext,
+            documentsDirectory: dir
+        ).importBackup(from: url)
+
+        #expect(summary.exerciseOverlays == BackupImportSummary.CollectionResult())
+        withExtendedLifetime(container) {}
     }
 }

--- a/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
+++ b/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
@@ -14,6 +14,7 @@ private struct InboxTestEnv {
     let templateRepository: SwiftDataTemplateRepository
     let exerciseRepository: SwiftDataExerciseRepository
     let bodyWeightRepository: SwiftDataBodyWeightRepository
+    let reportRepository: SwiftDataExerciseReportRepository
     let applier: InboxApplier
     let network: MockNetworkService
     let settings: SettingsManager
@@ -26,9 +27,11 @@ private struct InboxTestEnv {
         templateRepository = SwiftDataTemplateRepository(context: context)
         exerciseRepository = SwiftDataExerciseRepository(context: context)
         bodyWeightRepository = SwiftDataBodyWeightRepository(context: context)
+        reportRepository = SwiftDataExerciseReportRepository(context: context)
         applier = InboxApplier(
             templateRepository: templateRepository,
-            exerciseRepository: exerciseRepository
+            exerciseRepository: exerciseRepository,
+            reportRepository: reportRepository
         )
         network = MockNetworkService()
         settings = SettingsManager(
@@ -40,6 +43,7 @@ private struct InboxTestEnv {
             templateRepository: templateRepository,
             exerciseRepository: exerciseRepository,
             bodyWeightRepository: bodyWeightRepository,
+            exerciseReportRepository: reportRepository,
             networkService: network,
             settings: settings,
             inboxApplier: applier
@@ -1049,4 +1053,127 @@ struct InboxApplierTests {
         )
     }
 
+}
+
+@Suite("InboxApplier — resolveExerciseReport (#135)")
+@MainActor
+struct InboxApplierReportTests {
+
+    @Test("Resolving a report closes it out and re-queues it for the mirror")
+    func resolvesReport() async throws {
+        // Arrange
+        let env = try InboxTestEnv()
+        let report = ExerciseReport(
+            category: .bug,
+            detail: "Rest timer fired twice",
+            syncStatus: .synced
+        )
+        try await env.reportRepository.save(report)
+        let operation = try makeOperation(
+            op: "resolveExerciseReport",
+            payload: ResolveExerciseReportPayload(
+                id: report.id.uuidString,
+                status: nil,
+                resolution: "Filed as #140, fixed in 1.4.2"
+            )
+        )
+
+        // Act
+        let results = await env.applier.process([operation])
+
+        // Assert
+        #expect(results.map(\.status) == [.applied])
+        let stored = try #require(try await env.reportRepository.fetch(id: report.id))
+        #expect(stored.status == .resolved)
+        #expect(stored.resolution == "Filed as #140, fixed in 1.4.2")
+        // The mirror is a projection of the phone: an applied write is only
+        // real once the next snapshot push carries it.
+        #expect(stored.syncStatus == .pending)
+    }
+
+    @Test("acknowledged keeps the report in the backlog")
+    func acknowledgeKeepsItOpen() async throws {
+        let env = try InboxTestEnv()
+        let report = ExerciseReport(category: .swapRequest, detail: "swap this")
+        try await env.reportRepository.save(report)
+        let operation = try makeOperation(
+            op: "resolveExerciseReport",
+            payload: ResolveExerciseReportPayload(
+                id: report.id.uuidString,
+                status: "acknowledged",
+                resolution: "Looking for a replacement"
+            )
+        )
+
+        _ = await env.applier.process([operation])
+
+        let stored = try #require(try await env.reportRepository.fetch(id: report.id))
+        #expect(stored.status == .acknowledged)
+        #expect(try await env.reportRepository.fetchOpen().count == 1)
+    }
+
+    @Test("A report cannot be reopened from the inbox")
+    func cannotReopenAReport() async throws {
+        let env = try InboxTestEnv()
+        let report = ExerciseReport(category: .bug, detail: "x", status: .resolved)
+        try await env.reportRepository.save(report)
+        let operation = try makeOperation(
+            op: "resolveExerciseReport",
+            payload: ResolveExerciseReportPayload(
+                id: report.id.uuidString, status: "open", resolution: nil
+            )
+        )
+
+        let results = await env.applier.process([operation])
+
+        #expect(results.map(\.status) == [.failed])
+        let stored = try #require(try await env.reportRepository.fetch(id: report.id))
+        #expect(stored.status == .resolved)
+    }
+
+    @Test("An unknown report id fails that operation alone")
+    func unknownReportFailsInIsolation() async throws {
+        let env = try InboxTestEnv()
+        let report = ExerciseReport(category: .bug, detail: "real one")
+        try await env.reportRepository.save(report)
+        let operations = [
+            try makeOperation(
+                op: "resolveExerciseReport",
+                payload: ResolveExerciseReportPayload(
+                    id: UUID().uuidString, status: nil, resolution: nil
+                )
+            ),
+            try makeOperation(
+                op: "resolveExerciseReport",
+                payload: ResolveExerciseReportPayload(
+                    id: report.id.uuidString, status: nil, resolution: "done"
+                )
+            )
+        ]
+
+        let results = await env.applier.process(operations)
+
+        #expect(results.map(\.status) == [.failed, .applied])
+        #expect(results[0].error?.contains("Report not found") == true)
+    }
+
+    @Test("Resolving needs no user approval")
+    func resolveDoesNotRequireApproval() async throws {
+        let env = try InboxTestEnv()
+        let report = ExerciseReport(category: .bug, detail: "x")
+        try await env.reportRepository.save(report)
+        let operation = try makeOperation(
+            op: "resolveExerciseReport",
+            payload: ResolveExerciseReportPayload(
+                id: report.id.uuidString, status: nil, resolution: nil
+            ),
+            requiresApproval: true
+        )
+
+        let results = await env.applier.process([operation])
+
+        // The applier must reject the mismatched envelope rather than trust it.
+        #expect(results.map(\.status) == [.failed])
+        #expect(results[0].error?.contains("approval flag mismatch") == true)
+    }
 }

--- a/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
+++ b/ClaudeLifterTests/ServiceTests/InboxApplierTests.swift
@@ -1112,15 +1112,43 @@ struct InboxApplierReportTests {
         #expect(try await env.reportRepository.fetchOpen().count == 1)
     }
 
-    @Test("A report cannot be reopened from the inbox")
-    func cannotReopenAReport() async throws {
+    /// Inverted by #146. This asserted the opposite — the inbox existed to
+    /// close reports, never to reopen one behind the user. What changed it:
+    /// #136 was acknowledged, its fix shipped, and the fix turned out to be
+    /// inert. A real complaint had left the backlog with no route back, and
+    /// the guardrail was protecting the wrong thing — reopening SURFACES a
+    /// complaint, which is the safe direction.
+    @Test("A report closed too early can be reopened from the inbox")
+    func canReopenAReport() async throws {
         let env = try InboxTestEnv()
         let report = ExerciseReport(category: .bug, detail: "x", status: .resolved)
         try await env.reportRepository.save(report)
         let operation = try makeOperation(
             op: "resolveExerciseReport",
             payload: ResolveExerciseReportPayload(
-                id: report.id.uuidString, status: "open", resolution: nil
+                id: report.id.uuidString,
+                status: "open",
+                resolution: "The fix did not touch this case"
+            )
+        )
+
+        let results = await env.applier.process([operation])
+
+        #expect(results.map(\.status) == [.applied])
+        let stored = try #require(try await env.reportRepository.fetch(id: report.id))
+        #expect(stored.status == .open)
+        #expect(stored.resolution == "The fix did not touch this case")
+    }
+
+    @Test("A status outside the lifecycle still fails that operation")
+    func unknownReportStatusStillFails() async throws {
+        let env = try InboxTestEnv()
+        let report = ExerciseReport(category: .bug, detail: "x", status: .resolved)
+        try await env.reportRepository.save(report)
+        let operation = try makeOperation(
+            op: "resolveExerciseReport",
+            payload: ResolveExerciseReportPayload(
+                id: report.id.uuidString, status: "wontfix", resolution: nil
             )
         )
 

--- a/ClaudeLifterTests/ServiceTests/SettingsManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SettingsManagerTests.swift
@@ -77,10 +77,41 @@ struct SettingsManagerTests {
         let defaults = UserDefaults(suiteName: suite)!
         let settings = SettingsManager(defaults: defaults)
 
-        settings.isSnapshotDirty = true
+        settings.markSnapshotDirty()
         let reloaded = SettingsManager(defaults: UserDefaults(suiteName: suite)!)
 
         #expect(reloaded.isSnapshotDirty == true)
+    }
+
+    @Test("a legacy stored isSnapshotDirty flag survives the upgrade to generations")
+    func legacyDirtyFlagMigrates() {
+        // A pre-#104 install that was dirty at upgrade time has unpushed state.
+        // Reading the new keys and finding nothing must not be read as clean.
+        let suite = "settings-legacy-dirty-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: "isSnapshotDirty")
+
+        let settings = SettingsManager(defaults: defaults)
+
+        #expect(settings.isSnapshotDirty == true)
+    }
+
+    @Test("clearing names the generation it pushed, so a mid-request change stays dirty")
+    func cleanUpToStaleGenerationLeavesItDirty() {
+        let defaults = UserDefaults(suiteName: "settings-generation-\(UUID())")!
+        let settings = SettingsManager(defaults: defaults)
+
+        settings.markSnapshotDirty()
+        let inFlight = settings.currentSnapshotGeneration()
+        // A custom exercise created while the POST was in flight.
+        settings.markSnapshotDirty()
+        settings.markSnapshotClean(upTo: inFlight)
+
+        #expect(settings.isSnapshotDirty == true)
+
+        // The next push covers both and does clear it.
+        settings.markSnapshotClean(upTo: settings.currentSnapshotGeneration())
+        #expect(settings.isSnapshotDirty == false)
     }
 
     @Test("clearing lastSyncRevision removes the stored value")
@@ -97,5 +128,44 @@ struct SettingsManagerTests {
         // Assert
         let reloaded = SettingsManager(defaults: UserDefaults(suiteName: suite)!)
         #expect(reloaded.lastSyncRevision == nil)
+    }
+}
+
+@Suite("SettingsManager — snapshot dirty generations (#104)")
+struct SettingsManagerSnapshotGenerationTests {
+
+    @Test("A phone marked dirty but never cleaned reloads as dirty")
+    func dirtyWithoutCleanKeyReloadsDirty() {
+        // `didSet` does not fire for init assignments, so the clean key is
+        // absent on a phone that has only ever been marked dirty. Reading
+        // that as clean would strand unpushed state.
+        let suite = "settings-dirty-no-clean-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        SettingsManager(defaults: defaults).markSnapshotDirty()
+
+        let reloaded = SettingsManager(defaults: UserDefaults(suiteName: suite)!)
+
+        #expect(reloaded.isSnapshotDirty == true)
+    }
+
+    @Test("A cleared phone reloads clean")
+    func cleanedReloadsClean() {
+        let suite = "settings-cleaned-\(UUID())"
+        let defaults = UserDefaults(suiteName: suite)!
+        let settings = SettingsManager(defaults: defaults)
+        settings.markSnapshotDirty()
+        settings.markSnapshotClean(upTo: settings.currentSnapshotGeneration())
+
+        let reloaded = SettingsManager(defaults: UserDefaults(suiteName: suite)!)
+
+        #expect(reloaded.isSnapshotDirty == false)
+    }
+
+    @Test("A fresh install starts clean")
+    func freshInstallIsClean() {
+        let settings = SettingsManager(
+            defaults: UserDefaults(suiteName: "settings-fresh-\(UUID())")!
+        )
+        #expect(settings.isSnapshotDirty == false)
     }
 }

--- a/ClaudeLifterTests/ServiceTests/SyncDTOTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncDTOTests.swift
@@ -180,7 +180,7 @@ struct SyncDTOTests {
 
     // MARK: - Snapshot wire contract (v3)
 
-    @Test("SnapshotPushRequest always encodes all five collection keys, even when empty")
+    @Test("SnapshotPushRequest always encodes every collection key, even when empty")
     func snapshotRequestAlwaysHasFiveKeys() throws {
         // The server rejects a body with a missing collection key (400). An empty
         // array means "wipe that type" — so empty must still be on the wire.
@@ -193,13 +193,14 @@ struct SyncDTOTests {
         let json = try #require(
             try JSONSerialization.jsonObject(with: data) as? [String: Any]
         )
-        #expect(json["schemaVersion"] as? Int == 3)
+        #expect(json["schemaVersion"] as? Int == 4)
         let snapshot = try #require(json["snapshot"] as? [String: Any])
         #expect(snapshot["workouts"] as? [Any] != nil)
         #expect(snapshot["templates"] as? [Any] != nil)
         #expect(snapshot["customExercises"] as? [Any] != nil)
         #expect(snapshot["bodyWeightEntries"] as? [Any] != nil)
         #expect(snapshot["exerciseReports"] as? [Any] != nil)
+        #expect(snapshot["exerciseOverlays"] as? [Any] != nil)
     }
 
     @Test("A v2 snapshot without exerciseReports still decodes")

--- a/ClaudeLifterTests/ServiceTests/SyncDTOTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncDTOTests.swift
@@ -178,10 +178,10 @@ struct SyncDTOTests {
         #expect(decoded.source == dto.source)
     }
 
-    // MARK: - Snapshot wire contract (v2)
+    // MARK: - Snapshot wire contract (v3)
 
-    @Test("SnapshotPushRequest always encodes all four collection keys, even when empty")
-    func snapshotRequestAlwaysHasFourKeys() throws {
+    @Test("SnapshotPushRequest always encodes all five collection keys, even when empty")
+    func snapshotRequestAlwaysHasFiveKeys() throws {
         // The server rejects a body with a missing collection key (400). An empty
         // array means "wipe that type" — so empty must still be on the wire.
         let request = SnapshotPushRequest(
@@ -193,12 +193,61 @@ struct SyncDTOTests {
         let json = try #require(
             try JSONSerialization.jsonObject(with: data) as? [String: Any]
         )
-        #expect(json["schemaVersion"] as? Int == 2)
+        #expect(json["schemaVersion"] as? Int == 3)
         let snapshot = try #require(json["snapshot"] as? [String: Any])
         #expect(snapshot["workouts"] as? [Any] != nil)
         #expect(snapshot["templates"] as? [Any] != nil)
         #expect(snapshot["customExercises"] as? [Any] != nil)
         #expect(snapshot["bodyWeightEntries"] as? [Any] != nil)
+        #expect(snapshot["exerciseReports"] as? [Any] != nil)
+    }
+
+    @Test("A v2 snapshot without exerciseReports still decodes")
+    func snapshotDecodesWithoutReports() throws {
+        // Old local backup files and a mirror last written by a v2 client both
+        // lack the key. Failing the whole restore over it would be absurd.
+        let json = """
+        {
+          "workouts": [], "templates": [],
+          "customExercises": [], "bodyWeightEntries": []
+        }
+        """
+        let snapshot = try decoder.decode(
+            SyncSnapshot.self, from: Data(json.utf8)
+        )
+        #expect(snapshot.exerciseReports.isEmpty)
+    }
+
+    @Test("ExerciseReportDTO round-trips its captured context")
+    func reportDTORoundTrips() throws {
+        let dto = ExerciseReportDTO(
+            id: UUID(),
+            createdAt: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            category: "wrongExercise",
+            detail: "mislabeled machine",
+            exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip",
+            exerciseName: "Barbell Bench Press",
+            suggestedReplacement: "Hammer Strength Iso-Lateral Press",
+            workoutId: UUID(),
+            workoutExerciseId: UUID(),
+            templateId: UUID(),
+            contextSummary: "Push Day · 60kg×8 ✓",
+            status: "open",
+            resolution: nil,
+            appVersion: "1.4.0 (42)",
+            iosVersion: "26.5",
+            photoURL: nil,
+            lastModified: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+
+        let decoded = try decoder.decode(
+            ExerciseReportDTO.self, from: try encoder.encode(dto)
+        )
+
+        #expect(decoded.id == dto.id)
+        #expect(decoded.category == "wrongExercise")
+        #expect(decoded.exerciseExternalId == dto.exerciseExternalId)
+        #expect(decoded.contextSummary == dto.contextSummary)
     }
 
     @Test("SnapshotPushResponse decodes the contract-literal JSON")

--- a/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
@@ -1022,3 +1022,65 @@ struct SyncManagerReportTests {
         #expect(restored.first?.syncStatus == .synced)
     }
 }
+
+@Suite("SyncManager — custom exercises trigger a push (#104)")
+@MainActor
+struct SyncManagerCustomExerciseTriggerTests {
+
+    @Test("A custom exercise created through the UI is enough to trigger a push")
+    func customExerciseTriggersPush() async throws {
+        // Arrange — nothing else is pending, which is exactly the case that
+        // used to leave a custom exercise stranded indefinitely.
+        let env = try SyncTestEnv()
+        let repository = SwiftDataExerciseRepository(
+            context: env.context,
+            onCustomExerciseChanged: { env.settings.markSnapshotDirty() }
+        )
+        try await repository.save(
+            Exercise(name: "Cable Katana Extension", isCustom: true)
+        )
+        env.network.fetchInboxResult = InboxListResponse(operations: [])
+        env.network.pushSnapshotResult = SnapshotPushResponse(
+            revision: 1,
+            serverTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            counts: [:]
+        )
+
+        // Act
+        await env.manager.syncIfNeeded()
+
+        // Assert
+        #expect(env.network.pushSnapshotCallCount == 1)
+        let sent = try #require(env.network.lastSnapshotRequest)
+        #expect(sent.snapshot.customExercises.count == 1)
+        #expect(env.settings.isSnapshotDirty == false)
+    }
+
+    @Test("A custom exercise created mid-push is not silently marked clean")
+    func customExerciseCreatedDuringPushSurvives() async throws {
+        // The main actor is reentrant: pushSnapshot serializes, awaits, then
+        // clears. A create landing inside that await was never in the payload
+        // and used to have its only signal wiped by the clear.
+        let env = try SyncTestEnv()
+        let repository = SwiftDataExerciseRepository(
+            context: env.context,
+            onCustomExerciseChanged: { env.settings.markSnapshotDirty() }
+        )
+        env.settings.markSnapshotDirty()
+        env.network.pushSnapshotResult = SnapshotPushResponse(
+            revision: 1,
+            serverTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            counts: [:]
+        )
+        env.network.onPushSnapshot = {
+            env.settings.markSnapshotDirty()
+        }
+
+        // Act
+        try await env.manager.pushSnapshot()
+
+        // Assert — still dirty, so the next trigger picks the new exercise up.
+        #expect(env.settings.isSnapshotDirty == true)
+        _ = repository
+    }
+}

--- a/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
@@ -111,7 +111,7 @@ private func runAckValidationScenario(
 @Suite("SyncManager Snapshot Push")
 @MainActor
 struct SyncManagerSnapshotPushTests {
-    @Test("snapshot push serializes full state: all five types, nothing else")
+    @Test("snapshot push serializes full state: every mirrored type, nothing else")
     func snapshotContainsAllFiveTypesAndNothingElse() async throws {
         // Arrange — one of everything, including types that must NOT sync
         let env = try SyncTestEnv()
@@ -132,9 +132,9 @@ struct SyncManagerSnapshotPushTests {
         // Act
         try await env.manager.pushSnapshot()
 
-        // Assert — request carries exactly the five mirrored collections
+        // Assert — request carries exactly the mirrored collections
         let request = try #require(env.network.lastSnapshotRequest)
-        #expect(request.schemaVersion == 3)
+        #expect(request.schemaVersion == 4)
         #expect(request.snapshot.workouts.count == 1)
         #expect(request.snapshot.templates.count == 1)
         #expect(request.snapshot.customExercises.count == 1)
@@ -1082,5 +1082,176 @@ struct SyncManagerCustomExerciseTriggerTests {
         // Assert — still dirty, so the next trigger picks the new exercise up.
         #expect(env.settings.isSnapshotDirty == true)
         _ = repository
+    }
+}
+
+// MARK: - Bundled-exercise overlays (issue #140)
+
+/// Notes and photos the user attaches to *bundled* exercises never reached the
+/// mirror: only `isCustom` exercises were pushed. A machine setting typed at
+/// the gym survived exactly as long as the install did.
+@Suite("Snapshot sync — exercise overlays")
+@MainActor
+struct SyncManagerOverlayTests {
+
+    private func makeOverlayPushResponse() -> SnapshotPushResponse {
+        makePushResponse()
+    }
+
+    private func makeOverlayFetchResponse(
+        overlays: [ExerciseOverlayDTO]
+    ) -> SnapshotFetchResponse {
+        SnapshotFetchResponse(
+            revision: 3,
+            serverTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            snapshot: SyncSnapshot(
+                workouts: [],
+                templates: [],
+                customExercises: [],
+                bodyWeightEntries: [],
+                exerciseReports: [],
+                exerciseOverlays: overlays
+            )
+        )
+    }
+
+    private func seedBundled(
+        _ env: SyncTestEnv,
+        externalId: String,
+        notes: String? = nil,
+        photoURL: String? = nil
+    ) throws -> Exercise {
+        let exercise = Exercise(
+            name: "Leg Curl",
+            isCustom: false,
+            externalId: externalId,
+            notes: notes,
+            photoURL: photoURL
+        )
+        env.context.insert(exercise)
+        try env.context.save()
+        return exercise
+    }
+
+    @Test("A bundled exercise carrying a note is pushed as an overlay")
+    func bundledNoteIsPushed() async throws {
+        let env = try SyncTestEnv()
+        _ = try seedBundled(env, externalId: "Leg_Curl", notes: "pin 7, seat 4")
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        try await env.manager.pushSnapshot()
+
+        let overlays = try #require(env.network.lastSnapshotRequest?.snapshot.exerciseOverlays)
+        #expect(overlays.count == 1)
+        #expect(overlays.first?.id == "Leg_Curl")
+        #expect(overlays.first?.notes == "pin 7, seat 4")
+    }
+
+    @Test("A bundled exercise with no user data is not pushed")
+    func cleanBundledExerciseIsOmitted() async throws {
+        let env = try SyncTestEnv()
+        _ = try seedBundled(env, externalId: "Barbell_Squat")
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        try await env.manager.pushSnapshot()
+
+        #expect(env.network.lastSnapshotRequest?.snapshot.exerciseOverlays.isEmpty == true)
+    }
+
+    @Test("An overlay is keyed by externalId, never the local UUID")
+    func overlayKeyedByExternalId() async throws {
+        let env = try SyncTestEnv()
+        let exercise = try seedBundled(env, externalId: "Leg_Curl", notes: "pin 7")
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        try await env.manager.pushSnapshot()
+
+        let id = env.network.lastSnapshotRequest?.snapshot.exerciseOverlays.first?.id
+        #expect(id == "Leg_Curl")
+        #expect(id != exercise.id.uuidString)
+    }
+
+    @Test("A bundled exercise with no externalId cannot be keyed, so it is skipped")
+    func missingExternalIdIsSkipped() async throws {
+        let env = try SyncTestEnv()
+        let exercise = Exercise(name: "Mystery Machine")
+        exercise.isCustom = false
+        exercise.externalId = nil
+        exercise.notes = "seat 3"
+        env.context.insert(exercise)
+        try env.context.save()
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        try await env.manager.pushSnapshot()
+
+        #expect(env.network.lastSnapshotRequest?.snapshot.exerciseOverlays.isEmpty == true)
+    }
+
+    @Test("The push declares schemaVersion 4")
+    func pushDeclaresV4() async throws {
+        let env = try SyncTestEnv()
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        try await env.manager.pushSnapshot()
+
+        #expect(env.network.lastSnapshotRequest?.schemaVersion == 4)
+    }
+
+    /// The Functions app deploys separately from the phone, and this time the
+    /// phone shipped first. A v4 push to a server that only knows v3 must not
+    /// break sync outright — it degrades, so install order stops mattering.
+    @Test("A server that rejects v4 gets a v3 push instead of a failed sync")
+    func downgradesToV3WhenServerRejectsV4() async throws {
+        let env = try SyncTestEnv()
+        _ = try seedBundled(env, externalId: "Leg_Curl", notes: "pin 7")
+        env.network.pushSnapshotErrorQueue = [SyncError.serverError(400), nil]
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        try await env.manager.pushSnapshot()
+
+        #expect(env.network.snapshotRequests.count == 2)
+        #expect(env.network.snapshotRequests.first?.schemaVersion == 4)
+        #expect(env.network.snapshotRequests.last?.schemaVersion == 3)
+    }
+
+    @Test("A non-400 failure is not retried at a lower version")
+    func serverErrorIsNotDowngraded() async throws {
+        let env = try SyncTestEnv()
+        env.network.pushSnapshotErrorQueue = [SyncError.serverError(500), nil]
+        env.network.pushSnapshotResult = makeOverlayPushResponse()
+
+        await #expect(throws: SyncError.self) {
+            try await env.manager.pushSnapshot()
+        }
+        #expect(env.network.snapshotRequests.count == 1)
+    }
+
+    @Test("Restoring applies an overlay onto the matching bundled exercise")
+    func restoreAppliesOverlay() async throws {
+        let env = try SyncTestEnv()
+        let exercise = try seedBundled(env, externalId: "Leg_Curl")
+        env.network.fetchSnapshotResult = makeOverlayFetchResponse(
+            overlays: [
+                ExerciseOverlayDTO(id: "Leg_Curl", notes: "pin 7", photoURL: nil)
+            ]
+        )
+
+        _ = try await env.manager.restoreFromSnapshot()
+
+        #expect(exercise.notes == "pin 7")
+    }
+
+    @Test("An overlay for an exercise that is not installed is ignored, not an error")
+    func unknownOverlayIsIgnored() async throws {
+        let env = try SyncTestEnv()
+        env.network.fetchSnapshotResult = makeOverlayFetchResponse(
+            overlays: [
+                ExerciseOverlayDTO(id: "Not_Installed", notes: "x", photoURL: nil)
+            ]
+        )
+
+        let summary = try await env.manager.restoreFromSnapshot()
+
+        #expect(summary.exerciseOverlays == 0)
     }
 }

--- a/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
+++ b/ClaudeLifterTests/ServiceTests/SyncManagerTests.swift
@@ -14,6 +14,7 @@ private struct SyncTestEnv {
     let templateRepo: SwiftDataTemplateRepository
     let exerciseRepo: SwiftDataExerciseRepository
     let bodyWeightRepo: SwiftDataBodyWeightRepository
+    let reportRepo: SwiftDataExerciseReportRepository
     let inboxApplier: InboxApplier
     let network: MockNetworkService
     let settings: SettingsManager
@@ -29,9 +30,11 @@ private struct SyncTestEnv {
         templateRepo = SwiftDataTemplateRepository(context: context)
         exerciseRepo = SwiftDataExerciseRepository(context: context)
         bodyWeightRepo = SwiftDataBodyWeightRepository(context: context)
+        reportRepo = SwiftDataExerciseReportRepository(context: context)
         inboxApplier = InboxApplier(
             templateRepository: templateRepo,
-            exerciseRepository: exerciseRepo
+            exerciseRepository: exerciseRepo,
+            reportRepository: reportRepo
         )
         network = MockNetworkService()
         settings = SettingsManager(
@@ -44,6 +47,7 @@ private struct SyncTestEnv {
             templateRepository: templateRepo,
             exerciseRepository: exerciseRepo,
             bodyWeightRepository: bodyWeightRepo,
+            exerciseReportRepository: reportRepo,
             networkService: network,
             settings: settings,
             inboxApplier: inboxApplier
@@ -107,8 +111,8 @@ private func runAckValidationScenario(
 @Suite("SyncManager Snapshot Push")
 @MainActor
 struct SyncManagerSnapshotPushTests {
-    @Test("snapshot push serializes full state: all four types, nothing else")
-    func snapshotContainsAllFourTypesAndNothingElse() async throws {
+    @Test("snapshot push serializes full state: all five types, nothing else")
+    func snapshotContainsAllFiveTypesAndNothingElse() async throws {
         // Arrange — one of everything, including types that must NOT sync
         let env = try SyncTestEnv()
         let custom = TestFixtures.makeExercise(name: "My Cable Fly", isCustom: true)
@@ -118,6 +122,7 @@ struct SyncManagerSnapshotPushTests {
         env.context.insert(Workout(name: "Push Day", startedAt: .now, syncStatus: .pending))
         env.context.insert(WorkoutTemplate(name: "Push Template"))
         env.context.insert(BodyWeightEntry(weightKg: 82.5))
+        env.context.insert(ExerciseReport(category: .bug, detail: "timer double-fired"))
         env.context.insert(TestFixtures.makeChatMessage(content: "not synced"))
         env.context.insert(TestFixtures.makeInsight(content: "not synced"))
         env.context.insert(TestFixtures.makeTrainingPreference(key: "style", value: "not synced"))
@@ -127,14 +132,15 @@ struct SyncManagerSnapshotPushTests {
         // Act
         try await env.manager.pushSnapshot()
 
-        // Assert — request carries exactly the four mirrored collections
+        // Assert — request carries exactly the five mirrored collections
         let request = try #require(env.network.lastSnapshotRequest)
-        #expect(request.schemaVersion == 2)
+        #expect(request.schemaVersion == 3)
         #expect(request.snapshot.workouts.count == 1)
         #expect(request.snapshot.templates.count == 1)
         #expect(request.snapshot.customExercises.count == 1)
         #expect(request.snapshot.customExercises.first?.name == "My Cable Fly")
         #expect(request.snapshot.bodyWeightEntries.count == 1)
+        #expect(request.snapshot.exerciseReports.count == 1)
     }
 
     @Test("snapshot is full state even when only some records are pending")
@@ -521,6 +527,7 @@ struct SyncIfNeededTests {
             templateRepository: env.templateRepo,
             exerciseRepository: env.exerciseRepo,
             bodyWeightRepository: env.bodyWeightRepo,
+            exerciseReportRepository: env.reportRepo,
             networkService: env.network,
             settings: reloadedSettings,
             inboxApplier: env.inboxApplier
@@ -863,11 +870,13 @@ struct SyncStateTests {
             templateRepository: SwiftDataTemplateRepository(context: context),
             exerciseRepository: SwiftDataExerciseRepository(context: context),
             bodyWeightRepository: SwiftDataBodyWeightRepository(context: context),
+            exerciseReportRepository: SwiftDataExerciseReportRepository(context: context),
             networkService: MockNetworkService(),
             settings: settings,
             inboxApplier: InboxApplier(
                 templateRepository: SwiftDataTemplateRepository(context: context),
-                exerciseRepository: SwiftDataExerciseRepository(context: context)
+                exerciseRepository: SwiftDataExerciseRepository(context: context),
+                reportRepository: SwiftDataExerciseReportRepository(context: context)
             )
         )
         #expect(manager.lastRevision == 17)
@@ -914,5 +923,102 @@ struct SyncStateTests {
         if case .error = env.manager.state {} else {
             Issue.record("expected .error, got \(env.manager.state)")
         }
+    }
+}
+
+@Suite("SyncManager — exercise reports in the snapshot (#135)")
+@MainActor
+struct SyncManagerReportTests {
+
+    @Test("Push carries reports and marks them synced")
+    func pushIncludesReports() async throws {
+        // Arrange
+        let env = try SyncTestEnv()
+        let report = ExerciseReport(
+            category: .wrongExercise,
+            detail: "Mislabeled machine",
+            exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip"
+        )
+        try await env.reportRepo.save(report)
+        env.network.pushSnapshotResult = SnapshotPushResponse(
+            revision: 3,
+            serverTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            counts: [:]
+        )
+
+        // Act
+        try await env.manager.pushSnapshot()
+
+        // Assert
+        let sent = try #require(env.network.lastSnapshotRequest)
+        #expect(sent.snapshot.exerciseReports.count == 1)
+        #expect(sent.snapshot.exerciseReports.first?.category == "wrongExercise")
+        #expect(sent.snapshot.exerciseReports.first?.detail == "Mislabeled machine")
+        #expect(report.syncStatus == .synced)
+    }
+
+    @Test("A pending report alone is enough to trigger a push")
+    func pendingReportTriggersPush() async throws {
+        let env = try SyncTestEnv()
+        try await env.reportRepo.save(
+            ExerciseReport(category: .bug, detail: "timer double-fired")
+        )
+        env.network.fetchInboxResult = InboxListResponse(operations: [])
+        env.network.pushSnapshotResult = SnapshotPushResponse(
+            revision: 1,
+            serverTime: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            counts: [:]
+        )
+
+        await env.manager.syncIfNeeded()
+
+        #expect(env.network.pushSnapshotCallCount == 1)
+    }
+
+    @Test("Restore replaces local reports with the mirror's")
+    func restoreReplacesReports() async throws {
+        // Arrange
+        let env = try SyncTestEnv()
+        try await env.reportRepo.save(
+            ExerciseReport(category: .bug, detail: "doomed local report")
+        )
+        let mirrored = ExerciseReportDTO(
+            id: UUID(),
+            createdAt: Date(timeIntervalSinceReferenceDate: 795_000_000),
+            category: "swapRequest",
+            detail: "from the mirror",
+            exerciseExternalId: "squat",
+            exerciseName: "Squat",
+            suggestedReplacement: "Leg Press",
+            workoutId: nil,
+            workoutExerciseId: nil,
+            templateId: nil,
+            contextSummary: nil,
+            status: "acknowledged",
+            resolution: "looking into it",
+            appVersion: "1.4.0 (42)",
+            iosVersion: "26.5",
+            photoURL: nil,
+            lastModified: Date(timeIntervalSinceReferenceDate: 795_000_000)
+        )
+        env.network.fetchSnapshotResult = SnapshotFetchResponse(
+            revision: 9,
+            serverTime: Date(timeIntervalSinceReferenceDate: 795_000_000),
+            snapshot: SyncSnapshot(
+                workouts: [], templates: [], customExercises: [],
+                bodyWeightEntries: [], exerciseReports: [mirrored]
+            )
+        )
+
+        // Act
+        let summary = try await env.manager.restoreFromSnapshot()
+
+        // Assert
+        #expect(summary.exerciseReports == 1)
+        let restored = try await env.reportRepo.fetchAll()
+        #expect(restored.count == 1)
+        #expect(restored.first?.detail == "from the mirror")
+        #expect(restored.first?.status == .acknowledged)
+        #expect(restored.first?.syncStatus == .synced)
     }
 }

--- a/ClaudeLifterTests/ServiceTests/TemplateChangeApplierTests.swift
+++ b/ClaudeLifterTests/ServiceTests/TemplateChangeApplierTests.swift
@@ -1,0 +1,257 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import ClaudeLifter
+
+/// #130's apply step. The acceptance criteria that matter are the negative
+/// ones: declining changes nothing, and a failure cannot touch the workout.
+@Suite("TemplateChangeApplier Tests")
+@MainActor
+struct TemplateChangeApplierTests {
+
+    private struct Env {
+        let container: ModelContainer
+        let template: WorkoutTemplate
+        let templateRepo: MockTemplateRepository
+        let exerciseRepo: MockExerciseRepository
+        let applier: TemplateChangeApplier
+        let changeSet: TemplateChangeSet
+        var exercises: [Exercise]
+    }
+
+    private func makeEnv() throws -> Env {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let template = WorkoutTemplate(name: "Lower B")
+        context.insert(template)
+
+        var exercises: [Exercise] = []
+        for (index, name) in ["Trap Bar Deadlift", "Split Squat with Dumbbells", "Seated Leg Curl"].enumerated() {
+            let exercise = TestFixtures.makeExercise(name: name)
+            exercise.externalId = name.replacingOccurrences(of: " ", with: "_")
+            context.insert(exercise)
+            exercises.append(exercise)
+            let te = TemplateExercise(order: index, exercise: exercise, defaultSets: 3, defaultReps: 10)
+            context.insert(te)
+            template.exercises.append(te)
+        }
+        try context.save()
+
+        let templateRepo = MockTemplateRepository()
+        templateRepo.templates = [template]
+        let exerciseRepo = MockExerciseRepository()
+        exerciseRepo.exercises = exercises
+
+        return Env(
+            container: container,
+            template: template,
+            templateRepo: templateRepo,
+            exerciseRepo: exerciseRepo,
+            applier: TemplateChangeApplier(
+                templateRepository: templateRepo,
+                exerciseRepository: exerciseRepo
+            ),
+            changeSet: TemplateChangeSet(
+                templateId: template.id,
+                templateName: template.name,
+                changes: [],
+                capturedRevision: template.lastModified,
+                hasConflict: false
+            ),
+            exercises: exercises
+        )
+    }
+
+    @Test("Applying nothing writes nothing — declining leaves the template untouched")
+    func applyingNothingWritesNothing() async throws {
+        let env = try makeEnv()
+        let before = env.template.lastModified
+
+        try await env.applier.apply([], from: env.changeSet, capturedRevision: before)
+
+        #expect(env.templateRepo.savedTemplates.isEmpty)
+        #expect(env.template.lastModified == before)
+        #expect(env.template.exercises.count == 3)
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("An addition is appended and resolved by externalId")
+    func additionIsAppended() async throws {
+        var env = try makeEnv()
+        let context = env.container.mainContext
+        let crunch = TestFixtures.makeExercise(name: "Ab Crunch Machine")
+        crunch.externalId = "Ab_Crunch_Machine"
+        context.insert(crunch)
+        try context.save()
+        env.exerciseRepo.exercises.append(crunch)
+
+        let change = TemplateChange.addedExercise(.init(
+            exerciseId: crunch.id,
+            externalId: "Ab_Crunch_Machine",
+            name: "Ab Crunch Machine",
+            order: 4,
+            sets: 3,
+            reps: 10,
+            restSeconds: 90
+        ))
+
+        try await env.applier.apply([change], from: env.changeSet, capturedRevision: env.template.lastModified)
+
+        #expect(env.template.exercises.count == 4)
+        let added = try #require(env.template.exercises.sorted { $0.order < $1.order }.last)
+        #expect(added.exercise?.name == "Ab Crunch Machine")
+        #expect(added.defaultSets == 3)
+        #expect(added.defaultReps == 10)
+        #expect(added.order == 3, "orders are normalised, never left with gaps")
+        #expect(env.template.syncStatus == .pending)
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("A removal drops the exercise and renumbers the survivors")
+    func removalRenumbers() async throws {
+        let env = try makeEnv()
+        let middle = try #require(env.template.exercises.first { $0.order == 1 })
+
+        let change = TemplateChange.removedExercise(.init(
+            sourceTemplateExerciseId: middle.id,
+            exerciseId: env.exercises[1].id,
+            name: "Split Squat with Dumbbells"
+        ))
+        try await env.applier.apply([change], from: env.changeSet, capturedRevision: env.template.lastModified)
+
+        let remaining = env.template.exercises.sorted { $0.order < $1.order }
+        #expect(remaining.count == 2)
+        #expect(remaining.map(\.order) == [0, 1])
+        #expect(remaining.allSatisfy { $0.exercise?.name != "Split Squat with Dumbbells" })
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("A reorder applies the workout's order and keeps unmentioned exercises")
+    func reorderKeepsUnmentioned() async throws {
+        let env = try makeEnv()
+        let sorted = env.template.exercises.sorted { $0.order < $1.order }
+        // Only the first two are mentioned, swapped.
+        let change = TemplateChange.reordered(.init(
+            sourceTemplateExerciseIds: [sorted[1].id, sorted[0].id],
+            names: ["Split Squat with Dumbbells", "Trap Bar Deadlift"]
+        ))
+
+        try await env.applier.apply([change], from: env.changeSet, capturedRevision: env.template.lastModified)
+
+        let after = env.template.exercises.sorted { $0.order < $1.order }
+        #expect(after.count == 3, "an exercise the workout never mentioned must not vanish")
+        #expect(after[0].exercise?.name == "Split Squat with Dumbbells")
+        #expect(after[1].exercise?.name == "Trap Bar Deadlift")
+        #expect(after[2].exercise?.name == "Seated Leg Curl")
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("Set count and cue changes are applied to the right exercise")
+    func setCountAndCueApplied() async throws {
+        let env = try makeEnv()
+        let target = try #require(env.template.exercises.first { $0.order == 2 })
+
+        try await env.applier.apply(
+            [
+                .setCountChanged(.init(
+                    sourceTemplateExerciseId: target.id,
+                    name: "Seated Leg Curl",
+                    from: 3,
+                    to: 4
+                )),
+                .cueChanged(.init(
+                    sourceTemplateExerciseId: target.id,
+                    name: "Seated Leg Curl",
+                    from: nil,
+                    to: "Ankle 4; Seat 4; Pivot 1"
+                )),
+            ],
+            from: env.changeSet,
+            capturedRevision: env.template.lastModified
+        )
+
+        #expect(target.defaultSets == 4)
+        #expect(target.notes == "Ankle 4; Seat 4; Pivot 1")
+        #expect(env.template.exercises.first { $0.order == 0 }?.defaultSets == 3)
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("A template changed since the workout started is refused, not overwritten")
+    func conflictIsRefused() async throws {
+        let env = try makeEnv()
+        let captured = env.template.lastModified
+        env.template.lastModified = Date(timeIntervalSinceNow: 120)
+        let removal = try #require(env.template.exercises.first)
+
+        await #expect(throws: TemplateChangeApplyError.conflict) {
+            try await env.applier.apply(
+                [.removedExercise(.init(
+                    sourceTemplateExerciseId: removal.id,
+                    exerciseId: env.exercises[0].id,
+                    name: "Trap Bar Deadlift"
+                ))],
+                from: env.changeSet,
+                capturedRevision: captured
+            )
+        }
+        #expect(env.template.exercises.count == 3, "nothing applied")
+        #expect(env.templateRepo.savedTemplates.isEmpty)
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("An unresolvable addition aborts before anything is written")
+    func unresolvableAdditionAbortsWholeApply() async throws {
+        let env = try makeEnv()
+        let removal = try #require(env.template.exercises.first { $0.order == 0 })
+
+        // A valid removal alongside an addition that cannot resolve. The
+        // removal must not land on its own.
+        await #expect(throws: TemplateChangeApplyError.unresolvedExercise("Ghost Machine")) {
+            try await env.applier.apply(
+                [
+                    .removedExercise(.init(
+                        sourceTemplateExerciseId: removal.id,
+                        exerciseId: env.exercises[0].id,
+                        name: "Trap Bar Deadlift"
+                    )),
+                    .addedExercise(.init(
+                        exerciseId: UUID(),
+                        externalId: "Ghost_Machine",
+                        name: "Ghost Machine",
+                        order: 3,
+                        sets: 3,
+                        reps: 10,
+                        restSeconds: 90
+                    )),
+                ],
+                from: env.changeSet,
+                capturedRevision: env.template.lastModified
+            )
+        }
+
+        #expect(env.template.exercises.count == 3, "all or nothing")
+        #expect(env.templateRepo.savedTemplates.isEmpty)
+        withExtendedLifetime(env.container) {}
+    }
+
+    @Test("A missing template is reported without crashing")
+    func missingTemplateIsReported() async throws {
+        let env = try makeEnv()
+        env.templateRepo.templates = []
+
+        await #expect(throws: TemplateChangeApplyError.templateNotFound) {
+            try await env.applier.apply(
+                [.cueChanged(.init(
+                    sourceTemplateExerciseId: UUID(),
+                    name: "Gone",
+                    from: nil,
+                    to: "x"
+                ))],
+                from: env.changeSet,
+                capturedRevision: nil
+            )
+        }
+        withExtendedLifetime(env.container) {}
+    }
+}

--- a/ClaudeLifterTests/ServiceTests/TemplateChangeDetectorTests.swift
+++ b/ClaudeLifterTests/ServiceTests/TemplateChangeDetectorTests.swift
@@ -1,0 +1,362 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import ClaudeLifter
+
+/// #129. The rules here are the product, so they are tested directly rather
+/// than through a ViewModel: what counts as a deliberate change to a template,
+/// and — more importantly — what does not.
+@Suite("TemplateChangeDetector Tests")
+@MainActor
+struct TemplateChangeDetectorTests {
+
+    private struct Scenario {
+        let container: ModelContainer
+        let workout: Workout
+        let template: WorkoutTemplate
+        let baseline: WorkoutTemplateBaseline
+        var entries: [WorkoutExerciseBaseline]
+    }
+
+    /// Builds a workout that started from a template of `plan`, with every
+    /// planned exercise present and its sets completed. Individual tests then
+    /// deviate from it — that deviation is what is under test.
+    private func makeScenario(
+        plan: [(name: String, sets: Int, reps: Int, notes: String?)] = [
+            ("Trap Bar Deadlift", 3, 5, nil),
+            ("Split Squat with Dumbbells", 2, 8, nil),
+            ("Seated Leg Curl", 3, 12, nil),
+        ]
+    ) throws -> Scenario {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let template = WorkoutTemplate(name: "Lower B")
+        context.insert(template)
+        let workout = Workout(name: "Lower B", startedAt: .now, templateId: template.id)
+        context.insert(workout)
+
+        let baseline = WorkoutTemplateBaseline(
+            workoutId: workout.id,
+            templateId: template.id,
+            templateRevision: template.lastModified,
+            templateName: template.name
+        )
+        context.insert(baseline)
+
+        var entries: [WorkoutExerciseBaseline] = []
+        for (index, planned) in plan.enumerated() {
+            let exercise = TestFixtures.makeExercise(name: planned.name)
+            exercise.externalId = planned.name.replacingOccurrences(of: " ", with: "_")
+            context.insert(exercise)
+
+            let te = TemplateExercise(
+                order: index,
+                exercise: exercise,
+                defaultSets: planned.sets,
+                defaultReps: planned.reps,
+                notes: planned.notes
+            )
+            context.insert(te)
+            template.exercises.append(te)
+
+            let we = WorkoutExercise(order: index, exercise: exercise, notes: planned.notes)
+            context.insert(we)
+            for i in 0..<planned.sets {
+                let set = WorkoutSet(
+                    order: i,
+                    weight: 50,
+                    weightUnit: .kg,
+                    reps: planned.reps,
+                    isCompleted: true,
+                    completedAt: .now
+                )
+                context.insert(set)
+                we.sets.append(set)
+            }
+            workout.exercises.append(we)
+
+            entries.append(WorkoutExerciseBaseline(
+                workoutId: workout.id,
+                workoutExerciseId: we.id,
+                sourceTemplateExerciseId: te.id,
+                exerciseId: exercise.id,
+                exerciseExternalId: exercise.externalId,
+                exerciseName: exercise.name,
+                plannedOrder: index,
+                plannedSets: planned.sets,
+                plannedReps: planned.reps,
+                plannedRestSeconds: 90,
+                plannedNotes: planned.notes
+            ))
+        }
+        for entry in entries { context.insert(entry) }
+        try context.save()
+
+        return Scenario(
+            container: container,
+            workout: workout,
+            template: template,
+            baseline: baseline,
+            entries: entries
+        )
+    }
+
+    private func detect(_ s: Scenario) -> TemplateChangeSet {
+        TemplateChangeDetector().detect(
+            workout: s.workout,
+            baseline: s.baseline,
+            entries: s.entries,
+            template: s.template
+        )
+    }
+
+    // MARK: - The null case
+
+    @Test("A workout performed exactly as planned proposes nothing")
+    func workoutAsPlannedProposesNothing() throws {
+        let s = try makeScenario()
+        let result = detect(s)
+        #expect(result.isEmpty, "changes: \(result.changes.map(\.id))")
+        #expect(result.hasConflict == false)
+        withExtendedLifetime(s.container) {}
+    }
+
+    // MARK: - The rules that keep it quiet
+
+    @Test("A skipped exercise alone produces no change — not finishing is not removing")
+    func skippedExerciseProducesNothing() throws {
+        let s = try makeScenario()
+        // Barbell Ab Rollout on 2026-08-19: present, untouched, zero completed.
+        let skipped = try #require(s.workout.exercises.first { $0.order == 2 })
+        for set in skipped.sets {
+            set.isCompleted = false
+            set.completedAt = nil
+        }
+
+        let result = detect(s)
+
+        #expect(result.isEmpty, "changes: \(result.changes.map(\.id))")
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("Logged weights and reps are never diffed against the template")
+    func loggedValuesAreNeverDiffed() throws {
+        let s = try makeScenario()
+        // Auto-fill pre-populates from history, so this is what a normal
+        // session looks like — heavier than planned, different rep counts.
+        for we in s.workout.exercises {
+            for set in we.sets {
+                set.weight = 137.5
+                set.reps = 3
+            }
+        }
+
+        let result = detect(s)
+
+        #expect(result.isEmpty, "performance is not a template target")
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("An exercise added but never trained is not proposed")
+    func untrainedAdditionIsNotProposed() throws {
+        let s = try makeScenario()
+        let context = s.container.mainContext
+        let extra = TestFixtures.makeExercise(name: "Ab Crunch Machine")
+        context.insert(extra)
+        let we = WorkoutExercise(order: 3, exercise: extra)
+        context.insert(we)
+        let set = WorkoutSet(order: 0, weightUnit: .kg)
+        context.insert(set)
+        we.sets.append(set)
+        s.workout.exercises.append(we)
+
+        let result = detect(s)
+
+        #expect(result.isEmpty, "adding an exercise and not doing it is not a plan")
+        withExtendedLifetime(s.container) {}
+    }
+
+    // MARK: - Additions
+
+    @Test("The 2026-08-19 Lower B case: one addition, zero removals")
+    func lowerBAcceptanceCase() throws {
+        let s = try makeScenario()
+        let context = s.container.mainContext
+
+        // Ab Rollout was present and untouched — a skip, not a removal.
+        let rollout = try #require(s.workout.exercises.first { $0.order == 2 })
+        for set in rollout.sets {
+            set.isCompleted = false
+            set.completedAt = nil
+        }
+
+        // Ab Crunch Machine was added mid-workout and trained, in every
+        // session, and has never made it into the template.
+        let crunch = TestFixtures.makeExercise(name: "Ab Crunch Machine")
+        crunch.externalId = "Ab_Crunch_Machine"
+        context.insert(crunch)
+        let we = WorkoutExercise(order: 4, exercise: crunch)
+        context.insert(we)
+        for i in 0..<3 {
+            let set = WorkoutSet(order: i, weight: 50, weightUnit: .kg, reps: 10, isCompleted: true, completedAt: .now)
+            context.insert(set)
+            we.sets.append(set)
+        }
+        s.workout.exercises.append(we)
+
+        let result = detect(s)
+
+        #expect(result.changes.count == 1)
+        guard case .addedExercise(let added) = try #require(result.changes.first) else {
+            Issue.record("expected an addition, got \(result.changes)")
+            return
+        }
+        #expect(added.name == "Ab Crunch Machine")
+        #expect(added.externalId == "Ab_Crunch_Machine")
+        #expect(added.sets == 3)
+        #expect(added.reps == 10)
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("The 2026-08-07 Upper A case: two additions, zero removals")
+    func upperAAcceptanceCase() throws {
+        let s = try makeScenario(plan: [
+            ("Barbell Bench Press", 3, 8, nil),
+            ("Lat Pulldown", 3, 10, nil),
+            ("Seated Cable Row", 3, 10, nil),
+            ("Dumbbell Curl", 3, 12, nil),
+            ("Triceps Pushdown", 3, 12, nil),
+            ("Lateral Raise", 3, 15, nil),
+        ])
+        let context = s.container.mainContext
+
+        // Six planned exercises left incomplete.
+        for we in s.workout.exercises {
+            for set in we.sets {
+                set.isCompleted = false
+                set.completedAt = nil
+            }
+        }
+
+        for (index, name) in ["Leverage Chest Press", "Leverage Shoulder Press"].enumerated() {
+            let exercise = TestFixtures.makeExercise(name: name)
+            context.insert(exercise)
+            let we = WorkoutExercise(order: 6 + index, exercise: exercise)
+            context.insert(we)
+            let set = WorkoutSet(order: 0, weight: 40, weightUnit: .kg, reps: 10, isCompleted: true, completedAt: .now)
+            context.insert(set)
+            we.sets.append(set)
+            s.workout.exercises.append(we)
+        }
+
+        let result = detect(s)
+
+        let additions = result.changes.filter { if case .addedExercise = $0 { return true }; return false }
+        let removals = result.changes.filter { if case .removedExercise = $0 { return true }; return false }
+        #expect(additions.count == 2)
+        #expect(removals.isEmpty, "six incomplete exercises must not become removals")
+        withExtendedLifetime(s.container) {}
+    }
+
+    // MARK: - Removals, reorders, set counts, cues
+
+    @Test("An explicitly removed exercise is proposed as a removal")
+    func explicitRemovalIsProposed() throws {
+        let s = try makeScenario()
+        let removed = try #require(s.workout.exercises.first { $0.order == 1 })
+        s.workout.exercises.removeAll { $0.id == removed.id }
+
+        let result = detect(s)
+
+        #expect(result.changes.count == 1)
+        guard case .removedExercise(let removal) = try #require(result.changes.first) else {
+            Issue.record("expected a removal, got \(result.changes)")
+            return
+        }
+        #expect(removal.name == "Split Squat with Dumbbells")
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("Reordering the planned exercises is proposed once")
+    func reorderIsProposed() throws {
+        let s = try makeScenario()
+        // Seated Leg Curl was performed before Split Squat — the actual
+        // 2026-08-19 ordering.
+        let sorted = s.workout.exercises.sorted { $0.order < $1.order }
+        sorted[1].order = 2
+        sorted[2].order = 1
+
+        let result = detect(s)
+
+        let reorders = result.changes.filter { if case .reordered = $0 { return true }; return false }
+        #expect(reorders.count == 1)
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("Adding a set row changes the planned set count; leaving one unticked does not")
+    func setCountChangeIsExplicit() throws {
+        let s = try makeScenario()
+        let context = s.container.mainContext
+        let we = try #require(s.workout.exercises.first { $0.order == 1 })
+        let extra = WorkoutSet(order: 2, weight: 50, weightUnit: .kg, reps: 8)
+        context.insert(extra)
+        we.sets.append(extra)
+
+        let result = detect(s)
+
+        #expect(result.changes.count == 1)
+        guard case .setCountChanged(let change) = try #require(result.changes.first) else {
+            Issue.record("expected a set-count change, got \(result.changes)")
+            return
+        }
+        #expect(change.from == 2)
+        #expect(change.to == 3)
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("A rewritten cue is proposed; clearing one is not")
+    func cueChangeIsProposed() throws {
+        let s = try makeScenario(plan: [
+            ("Seated Leg Curl", 3, 12, "Ankle 3"),
+            ("Trap Bar Deadlift", 3, 5, "Grip bar is down."),
+        ])
+        let first = try #require(s.workout.exercises.first { $0.order == 0 })
+        first.notes = "Ankle 4; Seat 4; Pivot 1"
+        let second = try #require(s.workout.exercises.first { $0.order == 1 })
+        second.notes = nil
+
+        let result = detect(s)
+
+        #expect(result.changes.count == 1, "a cleared cue is not a template change")
+        guard case .cueChanged(let change) = try #require(result.changes.first) else {
+            Issue.record("expected a cue change, got \(result.changes)")
+            return
+        }
+        #expect(change.from == "Ankle 3")
+        #expect(change.to == "Ankle 4; Seat 4; Pivot 1")
+        withExtendedLifetime(s.container) {}
+    }
+
+    // MARK: - Conflict
+
+    @Test("A template edited since the workout started raises a conflict")
+    func templateEditedSinceStartConflicts() throws {
+        let s = try makeScenario()
+        // Someone edited the template while the workout ran — the Coach, the
+        // MCP inbox, or the template editor.
+        s.template.lastModified = Date(timeIntervalSinceNow: 60)
+
+        let result = detect(s)
+
+        #expect(result.hasConflict, "applying over a newer template would silently overwrite it")
+        withExtendedLifetime(s.container) {}
+    }
+
+    @Test("An unchanged template does not raise a conflict")
+    func unchangedTemplateHasNoConflict() throws {
+        let s = try makeScenario()
+        #expect(detect(s).hasConflict == false)
+        withExtendedLifetime(s.container) {}
+    }
+}

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -1784,4 +1784,136 @@ extension ActiveWorkoutViewModelTests {
         await vm.awaitPendingSave()
         withExtendedLifetime(container) {}
     }
+
+    // MARK: - Template provenance (#128)
+    //
+    // The plan the workout started from, frozen before the user touches
+    // anything. Without it a finished workout cannot be compared to what was
+    // intended: mutations erase the evidence, and the logged values say nothing
+    // about intent because auto-fill pre-populates them from history.
+
+    @Test("Starting from a template captures the plan as a baseline")
+    func startFromTemplateCapturesBaseline() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        exercise.externalId = "Split_Squat_with_Dumbbells"
+        let te = TemplateExercise(
+            order: 0,
+            exercise: exercise,
+            defaultSets: 2,
+            defaultReps: 8,
+            defaultWeight: 12,
+            defaultRestSeconds: 120,
+            notes: "Rear foot on the bench"
+        )
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let baselineRepo = MockTemplateBaselineRepository()
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: baselineRepo
+        )
+        await vm.startWorkout()
+
+        let workout = try #require(vm.workout)
+        let baseline = try #require(baselineRepo.baselines.first)
+        #expect(baseline.workoutId == workout.id)
+        #expect(baseline.templateId == template.id)
+        #expect(baseline.templateRevision == template.lastModified)
+        #expect(baseline.templateName == "Push Day")
+
+        let entries = try await baselineRepo.fetchEntries(workoutId: workout.id)
+        #expect(entries.count == 1)
+        let entry = try #require(entries.first)
+        #expect(entry.sourceTemplateExerciseId == te.id)
+        #expect(entry.plannedOrder == 0)
+        #expect(entry.plannedSets == 2)
+        #expect(entry.plannedReps == 8)
+        #expect(entry.plannedRestSeconds == 120)
+        #expect(entry.plannedNotes == "Rear foot on the bench")
+        #expect(entry.exerciseExternalId == "Split_Squat_with_Dumbbells")
+        #expect(entry.workoutExerciseId == workout.exercises.first?.id)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("An ad-hoc workout captures no baseline — there was no plan")
+    func adHocWorkoutCapturesNoBaseline() async throws {
+        let container = try makeTestContainer()
+        let baselineRepo = MockTemplateBaselineRepository()
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: baselineRepo
+        )
+        await vm.startWorkout()
+
+        #expect(baselineRepo.baselines.isEmpty)
+        #expect(baselineRepo.saveCallCount == 0)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("An exercise added mid-workout gets no baseline entry — that absence is the signal")
+    func midWorkoutAdditionHasNoBaselineEntry() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 2, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        let added = TestFixtures.makeExercise(name: "Ab Crunch Machine")
+        context.insert(added)
+        try context.save()
+
+        let baselineRepo = MockTemplateBaselineRepository()
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: baselineRepo
+        )
+        await vm.startWorkout()
+        let workout = try #require(vm.workout)
+
+        vm.addExercise(added)
+
+        let entries = try await baselineRepo.fetchEntries(workoutId: workout.id)
+        #expect(entries.count == 1, "the baseline is frozen at start and never grows")
+        #expect(entries.first?.exerciseId == exercise.id)
+        #expect(workout.exercises.count == 2)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("A failing baseline write does not stop the workout starting")
+    func baselineFailureDoesNotBlockStart() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let baselineRepo = MockTemplateBaselineRepository()
+        baselineRepo.errorToThrow = NSError(domain: "test", code: 128)
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: baselineRepo
+        )
+        await vm.startWorkout()
+
+        // Provenance is a nicety; being able to train is not. Losing the
+        // baseline costs a post-workout suggestion, nothing more.
+        #expect(vm.workout != nil)
+        #expect(vm.workout?.exercises.count == 1)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -1718,4 +1718,70 @@ extension ActiveWorkoutViewModelTests {
         withExtendedLifetime(container) {}
         _ = template
     }
+
+    // MARK: - Set completion stamps one set only (#139)
+    //
+    // The 2026-08-19 session had set timestamps 0.68s and 5.9s apart, which
+    // read like retroactive bulk completion. There is no batch-complete path
+    // anywhere in the app — `completedAt` is written one set at a time here
+    // and in LogSetTool — and the real explanation was the user working
+    // through the card list out of order. This pins that, so the next person
+    // reading odd timestamps in the mirror does not have to re-derive it.
+
+    @Test("Completing a set stamps that set and no other")
+    func completingSetStampsOnlyThatSet() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 3, defaultReps: 8, defaultWeight: 60)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService()
+        )
+        await vm.startWorkout()
+        let we = try #require(vm.workout?.exercises.first)
+        let sorted = we.sets.sorted(by: { $0.order < $1.order })
+        #expect(sorted.count == 3)
+
+        vm.completeSet(sorted[1])
+
+        #expect(sorted[0].completedAt == nil)
+        #expect(sorted[1].completedAt != nil)
+        #expect(sorted[2].completedAt == nil)
+        #expect(sorted.filter(\.isCompleted).count == 1)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("Un-completing a set clears only that set's stamp")
+    func unCompletingSetClearsOnlyThatSet() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 2, defaultReps: 8, defaultWeight: 60)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService()
+        )
+        await vm.startWorkout()
+        let we = try #require(vm.workout?.exercises.first)
+        let sorted = we.sets.sorted(by: { $0.order < $1.order })
+        vm.completeSet(sorted[0])
+        vm.completeSet(sorted[1])
+
+        vm.completeSet(sorted[0])   // second tap un-completes
+
+        #expect(sorted[0].completedAt == nil)
+        #expect(sorted[1].completedAt != nil)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -2067,4 +2067,112 @@ extension ActiveWorkoutViewModelTests {
         await vm.awaitPendingSave()
         withExtendedLifetime(container) {}
     }
+
+    // MARK: - Post-workout template review, end to end (#129/#130)
+
+    @Test("Finishing a workout with a mid-workout addition offers it for the template")
+    func finishingSurfacesTemplateChanges() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        let added = TestFixtures.makeExercise(name: "Ab Crunch Machine")
+        added.externalId = "Ab_Crunch_Machine"
+        context.insert(added)
+        try context.save()
+
+        let templateRepo = MockTemplateRepository()
+        templateRepo.templates = [template]
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            templateRepository: templateRepo,
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        vm.completeSet(try #require(vm.workout?.exercises.first?.sets.first))
+
+        vm.addExercise(added)
+        let addedWE = try #require(vm.workout?.exercises.first { $0.exercise?.id == added.id })
+        for set in addedWE.sets { vm.completeSet(set) }
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        guard case .finished(let summary) = vm.completionState else {
+            Issue.record("expected a finished workout, got \(vm.completionState)")
+            return
+        }
+        let changeSet = try #require(summary?.templateChangeSet)
+        #expect(changeSet.changes.count == 1)
+        #expect(changeSet.templateId == template.id)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("A workout performed as planned offers nothing — the card must not appear")
+    func finishingAsPlannedOffersNothing() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let templateRepo = MockTemplateRepository()
+        templateRepo.templates = [template]
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            templateRepository: templateRepo,
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        vm.completeSet(try #require(vm.workout?.exercises.first?.sets.first))
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        guard case .finished(let summary) = vm.completionState else {
+            Issue.record("expected a finished workout")
+            return
+        }
+        #expect(summary?.templateChangeSet == nil, "nil, not empty — the card has one condition")
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("An ad-hoc workout never offers a template update")
+    func adHocWorkoutOffersNoTemplateUpdate() async throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let exercise = TestFixtures.makeExercise(name: "Bench Press")
+        context.insert(exercise)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        vm.addExercise(exercise)
+        let we = try #require(vm.workout?.exercises.first)
+        for set in we.sets { vm.completeSet(set) }
+
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+
+        guard case .finished(let summary) = vm.completionState else {
+            Issue.record("expected a finished workout")
+            return
+        }
+        #expect(summary?.templateChangeSet == nil)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -1421,4 +1421,152 @@ extension ActiveWorkoutViewModelTests {
         await vm.awaitPendingSave()
         withExtendedLifetime(container) {}
     }
+
+    // MARK: - Per-exercise notes (#136)
+    //
+    // The machine settings ("Ankle 4; Seat 4; Pivot 1") live on
+    // TemplateExercise.notes and were never copied into the session, so they
+    // vanished exactly where they are needed — standing at the machine.
+
+    @Test("startFromTemplate copies per-exercise notes into the session")
+    func startFromTemplateCopiesNotes() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(
+            order: 0,
+            exercise: exercise,
+            defaultSets: 1,
+            defaultReps: 8,
+            defaultWeight: 60,
+            notes: "Ankle 4; Seat 4; Pivot 1"
+        )
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService()
+        )
+        await vm.startWorkout()
+
+        let we = try #require(vm.workout?.exercises.first)
+        #expect(we.notes == "Ankle 4; Seat 4; Pivot 1")
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("startFromTemplate leaves notes nil when the template has none")
+    func startFromTemplateLeavesNotesNilWhenAbsent() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8, defaultWeight: 60)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService()
+        )
+        await vm.startWorkout()
+
+        #expect(vm.workout?.exercises.first?.notes == nil)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("updateExerciseNotes writes the note onto the exercise, not the session")
+    func updateExerciseNotesWritesToExercise() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8, defaultWeight: 60)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let exerciseRepo = MockExerciseRepository()
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            exerciseRepository: exerciseRepo
+        )
+        await vm.startWorkout()
+        let we = try #require(vm.workout?.exercises.first)
+
+        await vm.updateExerciseNotes(we, notes: "Ankle 4; Seat 4; Pivot 1")
+
+        // The note belongs to the machine, so it lands on the library
+        // exercise and every future workout using it inherits it.
+        #expect(exercise.notes == "Ankle 4; Seat 4; Pivot 1")
+        #expect(exerciseRepo.savedExercises.contains { $0.id == exercise.id })
+        // Bundled exercises never sync, so the session copy is the one that
+        // reaches the server and the Coach.
+        #expect(we.notes == "Ankle 4; Seat 4; Pivot 1")
+        #expect(vm.workout?.syncStatus == .pending)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("updateExerciseNotes stores an emptied note as nil, not as empty text")
+    func updateExerciseNotesClearsToNil() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        exercise.notes = "Ankle 4"
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8, defaultWeight: 60)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            exerciseRepository: MockExerciseRepository()
+        )
+        await vm.startWorkout()
+        let we = try #require(vm.workout?.exercises.first)
+
+        await vm.updateExerciseNotes(we, notes: "   ")
+
+        #expect(exercise.notes == nil)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("updateExerciseNotes after finish still saves — the note is not workout data")
+    func updateExerciseNotesAfterFinishStillSaves() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8, defaultWeight: 60)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            exerciseRepository: MockExerciseRepository()
+        )
+        await vm.startWorkout()
+        let we = try #require(vm.workout?.exercises.first)
+        vm.completeSet(try #require(we.sets.first))
+        let workout = try #require(vm.workout)
+        await vm.finishWorkout()
+        await vm.awaitPostCommitWork()
+        workout.syncStatus = .synced
+
+        await vm.updateExerciseNotes(we, notes: "late note")
+
+        #expect(exercise.notes == "late note")
+        // The finished workout record stays authoritative — the note write
+        // must not re-open it for a draft save (#124).
+        #expect(workout.syncStatus == .synced)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -1569,4 +1569,153 @@ extension ActiveWorkoutViewModelTests {
         await vm.awaitPendingSave()
         withExtendedLifetime(container) {}
     }
+
+    // MARK: - Reps adoption (#137)
+    //
+    // "It should auto-fill with the previous reps automatically if not
+    // specified." An exercise added mid-workout got three empty sets and the
+    // ghosts were display-only, so sets reached Cosmos with no reps at all.
+    //
+    // Reps only, never weight: `WorkoutSet.weight == nil` already means
+    // bodyweight, so adopting a previous weight logs 80kg for a bodyweight
+    // set. That bug was found and cut once already — see
+    // "Ghost adoption was built and deliberately cut" in HANDOFF.md. A nil
+    // rep count carries no such meaning.
+
+    @Test("Adopting reps never adopts weight — an untouched bodyweight set stays bodyweight")
+    func adoptingRepsLeavesWeightNil() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let workoutRepo = MockWorkoutRepository()
+        let autoFill = MockAutoFillService()
+        // Last time this exercise was loaded: 80kg × 8.
+        autoFill.resultByExerciseId[exercise.id] = AutoFillResult(
+            weight: 80.0, weightUnit: .kg, reps: 8, date: .now
+        )
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: workoutRepo,
+            autoFillService: autoFill
+        )
+        await vm.startWorkout()
+
+        vm.addExercise(exercise)
+        await vm.awaitPreviousValuesLoad()
+
+        let we = try #require(vm.workout?.exercises.first)
+        for set in we.sets {
+            #expect(set.reps == 8, "reps should adopt the previous session")
+            #expect(set.weight == nil, "weight must stay nil — nil means bodyweight")
+        }
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+        _ = template
+    }
+
+    @Test("An exercise added mid-workout fills its reps from the previous session")
+    func addExerciseAdoptsPreviousReps() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let autoFill = MockAutoFillService()
+        autoFill.valuesByExerciseId[exercise.id] = [
+            AutoFillResult(weight: 30, weightUnit: .kg, reps: 10, date: .now),
+            AutoFillResult(weight: 40, weightUnit: .kg, reps: 9, date: .now),
+            AutoFillResult(weight: 45, weightUnit: .kg, reps: 8, date: .now),
+        ]
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: autoFill
+        )
+        await vm.startWorkout()
+
+        vm.addExercise(exercise)
+        await vm.awaitPreviousValuesLoad()
+
+        let we = try #require(vm.workout?.exercises.first)
+        let sorted = we.sets.sorted(by: { $0.order < $1.order })
+        // Per-set-index, the same shape as the template start path (#82).
+        #expect(sorted.map(\.reps) == [10, 9, 8])
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+        _ = template
+    }
+
+    @Test("Reps the user cleared are not silently re-filled")
+    func clearedRepsAreNotReadopted() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let autoFill = MockAutoFillService()
+        autoFill.resultByExerciseId[exercise.id] = AutoFillResult(
+            weight: 30, weightUnit: .kg, reps: 10, date: .now
+        )
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: autoFill
+        )
+        await vm.startWorkout()
+        vm.addExercise(exercise)
+        let we = try #require(vm.workout?.exercises.first)
+        let first = try #require(we.sets.sorted(by: { $0.order < $1.order }).first)
+
+        // Explicitly cleared, before the ghost load lands.
+        vm.updateSetReps(first, reps: nil)
+        await vm.awaitPreviousValuesLoad()
+
+        #expect(first.reps == nil, "an explicit clear is a decision, not an absence")
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+        _ = template
+    }
+
+    @Test("Reps the user entered are never overwritten by adoption")
+    func enteredRepsAreNotOverwritten() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let autoFill = MockAutoFillService()
+        autoFill.resultByExerciseId[exercise.id] = AutoFillResult(
+            weight: 30, weightUnit: .kg, reps: 10, date: .now
+        )
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: autoFill
+        )
+        await vm.startWorkout()
+        vm.addExercise(exercise)
+        let we = try #require(vm.workout?.exercises.first)
+        let first = try #require(we.sets.sorted(by: { $0.order < $1.order }).first)
+
+        vm.updateSetReps(first, reps: 3)
+        await vm.awaitPreviousValuesLoad()
+
+        #expect(first.reps == 3)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+        _ = template
+    }
+
+    @Test("A completed set is never re-filled by adoption")
+    func completedSetIsNotReadopted() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let autoFill = MockAutoFillService()
+        autoFill.resultByExerciseId[exercise.id] = AutoFillResult(
+            weight: 30, weightUnit: .kg, reps: 10, date: .now
+        )
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: autoFill
+        )
+        await vm.startWorkout()
+        vm.addExercise(exercise)
+        let we = try #require(vm.workout?.exercises.first)
+        let first = try #require(we.sets.sorted(by: { $0.order < $1.order }).first)
+
+        // Logged as a bodyweight set with no reps recorded — deliberate.
+        vm.completeSet(first)
+        await vm.awaitPreviousValuesLoad()
+
+        #expect(first.reps == nil, "a logged set is a record, not a draft")
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+        _ = template
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ActiveWorkoutViewModelTests.swift
@@ -1916,4 +1916,155 @@ extension ActiveWorkoutViewModelTests {
         await vm.awaitPendingSave()
         withExtendedLifetime(container) {}
     }
+
+    // MARK: - Target reps on screen (#144)
+    //
+    // PREVIOUS shows what you did last time, and since #137 the reps field is
+    // prefilled from last time too — so nothing on screen was the plan, and
+    // drift compounded silently: template 8, last session 12, this session
+    // prefills 12, next session's "previous" is 12.
+
+    @Test("A template-started workout exposes the planned target per exercise")
+    func exposesPlannedTarget() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(
+            order: 0,
+            exercise: exercise,
+            defaultSets: 2,
+            defaultReps: 8,
+            defaultWeight: 12,
+            defaultRestSeconds: 120
+        )
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        await vm.awaitPlannedTargetsLoad()
+
+        let we = try #require(vm.workout?.exercises.first)
+        let target = try #require(vm.plannedTarget(for: we))
+        #expect(target.sets == 2)
+        #expect(target.reps == 8)
+        #expect(target.restSeconds == 120)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("An exercise added mid-workout has no target — none is invented")
+    func addedExerciseHasNoTarget() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 2, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        let added = TestFixtures.makeExercise(name: "Ab Crunch Machine")
+        context.insert(added)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        await vm.awaitPlannedTargetsLoad()
+        vm.addExercise(added)
+
+        let addedWE = try #require(vm.workout?.exercises.first { $0.exercise?.id == added.id })
+        #expect(vm.plannedTarget(for: addedWE) == nil)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("An ad-hoc workout has no targets at all")
+    func adHocWorkoutHasNoTargets() async throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let exercise = TestFixtures.makeExercise(name: "Bench Press")
+        context.insert(exercise)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            adHocName: "Quick Workout",
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        vm.addExercise(exercise)
+        await vm.awaitPlannedTargetsLoad()
+
+        let we = try #require(vm.workout?.exercises.first)
+        #expect(vm.plannedTarget(for: we) == nil)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("Last session's reps are flagged as drifted when they miss the target")
+    func lastSessionDriftIsFlagged() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 2, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let autoFill = MockAutoFillService()
+        // Last session drifted: 12 reps against a target of 8.
+        autoFill.valuesByExerciseId[exercise.id] = [
+            AutoFillResult(weight: 12, weightUnit: .kg, reps: 12, date: .now),
+            AutoFillResult(weight: 14, weightUnit: .kg, reps: 8, date: .now),
+        ]
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: autoFill,
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        await vm.awaitPlannedTargetsLoad()
+
+        let we = try #require(vm.workout?.exercises.first)
+        let sets = we.sets.sorted(by: { $0.order < $1.order })
+        // Flagged on the PREVIOUS value — the thing you can still act on
+        // while choosing what to do this session.
+        #expect(vm.previousDriftedFromTarget(sets[0], in: we) == true)
+        #expect(vm.previousDriftedFromTarget(sets[1], in: we) == false)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("No previous session means no drift flag — absence is not disagreement")
+    func noPreviousMeansNoDrift() async throws {
+        let (container, exercise, template) = try makeSetup()
+        let context = container.mainContext
+        let te = TemplateExercise(order: 0, exercise: exercise, defaultSets: 1, defaultReps: 8)
+        context.insert(te)
+        template.exercises.append(te)
+        try context.save()
+
+        let vm = ActiveWorkoutViewModel(
+            template: template,
+            workoutRepository: MockWorkoutRepository(),
+            autoFillService: MockAutoFillService(),
+            baselineRepository: MockTemplateBaselineRepository()
+        )
+        await vm.startWorkout()
+        await vm.awaitPlannedTargetsLoad()
+
+        let we = try #require(vm.workout?.exercises.first)
+        let set = try #require(we.sets.first)
+        #expect(vm.previousDriftedFromTarget(set, in: we) == false)
+        await vm.awaitPendingSave()
+        withExtendedLifetime(container) {}
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/HistoryViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/HistoryViewModelTests.swift
@@ -196,4 +196,96 @@ struct HistoryViewModelTests {
         #expect(vm.completedWorkouts.count == 1, "Empty workouts should be filtered from history")
         #expect(vm.completedWorkouts.first?.name == "Push Day")
     }
+
+    // MARK: - Editing a past workout (#117)
+    //
+    // The detail view wrote `set.weight` straight to the model on every
+    // keystroke, so the edit persisted locally but never re-queued the parent
+    // workout for sync — history silently diverged from the mirror. It also
+    // could not clear a value, because `Double("")` is nil and the write was
+    // behind `if let`.
+
+    @MainActor
+    private func makeEditableWorkout() throws -> (ModelContainer, Workout, WorkoutSet, MockWorkoutRepository) {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let exercise = TestFixtures.makeExercise(name: "Bench Press")
+        context.insert(exercise)
+        let workout = TestFixtures.makeWorkout(name: "Push Day")
+        context.insert(workout)
+        let we = TestFixtures.makeWorkoutExercise(exercise: exercise, in: context)
+        workout.exercises.append(we)
+        try context.save()
+        workout.syncStatus = .synced
+        let set = we.sets.sorted(by: { $0.order < $1.order })[0]
+        return (container, workout, set, MockWorkoutRepository())
+    }
+
+    @Test("Editing a past set re-queues the workout for sync")
+    func editingPastSetRequeuesForSync() async throws {
+        let (container, workout, set, repo) = try makeEditableWorkout()
+        let vm = HistoryViewModel(workoutRepository: repo)
+        let before = workout.lastModified
+
+        await vm.updateSet(set, weight: 72.5, in: workout)
+
+        #expect(set.weight == 72.5)
+        #expect(workout.syncStatus == .pending, "an edit the server never hears about is a silent divergence")
+        #expect(workout.lastModified > before)
+        #expect(repo.savedWorkouts.contains { $0.id == workout.id })
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("A cleared weight becomes nil, which is how bodyweight is recorded")
+    func clearingWeightStoresNil() async throws {
+        let (container, workout, set, repo) = try makeEditableWorkout()
+        let vm = HistoryViewModel(workoutRepository: repo)
+
+        await vm.updateSet(set, weight: nil, in: workout)
+
+        #expect(set.weight == nil)
+        #expect(workout.syncStatus == .pending)
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("Editing reps re-queues the workout, and reps can be cleared")
+    func editingRepsRequeuesAndClears() async throws {
+        let (container, workout, set, repo) = try makeEditableWorkout()
+        let vm = HistoryViewModel(workoutRepository: repo)
+
+        await vm.updateSet(set, reps: 12, in: workout)
+        #expect(set.reps == 12)
+        #expect(workout.syncStatus == .pending)
+
+        workout.syncStatus = .synced
+        await vm.updateSet(set, reps: nil, in: workout)
+        #expect(set.reps == nil)
+        #expect(workout.syncStatus == .pending)
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("An unchanged value does not re-queue the workout")
+    func unchangedValueDoesNotRequeue() async throws {
+        let (container, workout, set, repo) = try makeEditableWorkout()
+        let vm = HistoryViewModel(workoutRepository: repo)
+        let existing = set.weight
+
+        await vm.updateSet(set, weight: existing, in: workout)
+
+        #expect(workout.syncStatus == .synced, "a no-op edit must not churn sync state")
+        #expect(repo.savedWorkouts.isEmpty)
+        withExtendedLifetime(container) {}
+    }
+
+    @Test("A failing save surfaces an error instead of failing silently")
+    func failingSaveSurfacesError() async throws {
+        let (container, workout, set, repo) = try makeEditableWorkout()
+        repo.errorToThrow = NSError(domain: "test", code: 117)
+        let vm = HistoryViewModel(workoutRepository: repo)
+
+        await vm.updateSet(set, weight: 80, in: workout)
+
+        #expect(vm.errorMessage != nil)
+        withExtendedLifetime(container) {}
+    }
 }

--- a/ClaudeLifterTests/ViewModelTests/ReportListViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ReportListViewModelTests.swift
@@ -1,0 +1,148 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import ClaudeLifter
+
+/// The report backlog's filter and counts (#146).
+///
+/// The bug this suite pins: `acknowledged` rendered as done (green resolution
+/// text) while counting as open, and the only filter keyed on `resolved` — a
+/// state nothing in the app or the write path ever produced. Six reports, three
+/// of them answered, and the card still said "6 open reports".
+@Suite("ReportListViewModel — status filter")
+@MainActor
+struct ReportListFilterTests {
+
+    @MainActor
+    private struct Env {
+        let container: ModelContainer
+        let context: ModelContext
+        let repository: SwiftDataExerciseReportRepository
+        let vm: ReportListViewModel
+
+        init() throws {
+            container = try makeTestContainer()
+            context = container.mainContext
+            repository = SwiftDataExerciseReportRepository(context: context)
+            vm = ReportListViewModel(repository: repository)
+        }
+
+        @discardableResult
+        func seed(_ status: ReportStatus, detail: String) throws -> ExerciseReport {
+            let report = ExerciseReport(category: .bug, detail: detail)
+            report.status = status
+            context.insert(report)
+            try context.save()
+            return report
+        }
+
+        /// One of each, which is the shape of the real backlog.
+        func seedOneOfEach() throws {
+            try seed(.open, detail: "still open")
+            try seed(.acknowledged, detail: "fix written, not installed")
+            try seed(.resolved, detail: "done")
+        }
+    }
+
+    @Test("The default filter is the live backlog: open and acknowledged, not resolved")
+    func defaultFilterIsBacklog() async throws {
+        let env = try Env()
+        try env.seedOneOfEach()
+
+        await env.vm.load()
+
+        #expect(env.vm.statusFilter == .backlog)
+        #expect(env.vm.visibleReports.count == 2)
+        #expect(env.vm.visibleReports.allSatisfy { $0.status != .resolved })
+    }
+
+    @Test("Acknowledged is filterable on its own")
+    func acknowledgedIsItsOwnFilter() async throws {
+        let env = try Env()
+        try env.seedOneOfEach()
+        await env.vm.load()
+
+        env.vm.statusFilter = .acknowledged
+
+        #expect(env.vm.visibleReports.count == 1)
+        #expect(env.vm.visibleReports.first?.detail == "fix written, not installed")
+    }
+
+    @Test("Every filter selects exactly its own status", arguments: [
+        (ReportStatusFilter.open, "still open"),
+        (ReportStatusFilter.acknowledged, "fix written, not installed"),
+        (ReportStatusFilter.resolved, "done"),
+    ])
+    func singleStatusFilters(filter: ReportStatusFilter, expected: String) async throws {
+        let env = try Env()
+        try env.seedOneOfEach()
+        await env.vm.load()
+
+        env.vm.statusFilter = filter
+
+        #expect(env.vm.visibleReports.map(\.detail) == [expected])
+    }
+
+    @Test("The all filter hides nothing")
+    func allFilterShowsEverything() async throws {
+        let env = try Env()
+        try env.seedOneOfEach()
+        await env.vm.load()
+
+        env.vm.statusFilter = .all
+
+        #expect(env.vm.visibleReports.count == 3)
+    }
+
+    /// The home card's number. It said 6 when three of the six carried a
+    /// written resolution, because it counted everything not `resolved`.
+    @Test("openCount counts only reports nobody has answered")
+    func openCountExcludesAcknowledged() async throws {
+        let env = try Env()
+        try env.seedOneOfEach()
+
+        await env.vm.load()
+
+        #expect(env.vm.openCount == 1)
+        #expect(env.vm.acknowledgedCount == 1)
+    }
+
+    @Test("A filter selecting nothing is empty rather than falling back to everything")
+    func emptyFilterStaysEmpty() async throws {
+        let env = try Env()
+        try env.seed(.open, detail: "only an open one")
+        await env.vm.load()
+
+        env.vm.statusFilter = .resolved
+
+        #expect(env.vm.visibleReports.isEmpty)
+    }
+
+    @Test("Acknowledging a report moves it out of the open count without hiding it")
+    func acknowledgingKeepsItInTheBacklog() async throws {
+        let env = try Env()
+        let report = try env.seed(.open, detail: "will be acknowledged")
+        await env.vm.load()
+
+        await env.vm.setStatus(.acknowledged, for: report)
+
+        #expect(env.vm.openCount == 0)
+        #expect(env.vm.acknowledgedCount == 1)
+        #expect(env.vm.visibleReports.count == 1)
+    }
+
+    /// The escape hatch #136 needed: a fix that turns out to be inert must be
+    /// reopenable, or the backlog quietly loses a real complaint.
+    @Test("A resolved report can be reopened")
+    func resolvedCanBeReopened() async throws {
+        let env = try Env()
+        let report = try env.seed(.resolved, detail: "fix did nothing")
+        await env.vm.load()
+
+        await env.vm.setStatus(.open, for: report)
+
+        #expect(env.vm.openCount == 1)
+        env.vm.statusFilter = .backlog
+        #expect(env.vm.visibleReports.count == 1)
+    }
+}

--- a/ClaudeLifterTests/ViewModelTests/ReportSheetViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ReportSheetViewModelTests.swift
@@ -174,7 +174,9 @@ struct ReportListViewModelTests {
 
         #expect(vm.openCount == 1)
         #expect(vm.visibleReports.count == 1)
-        vm.showsResolved = true
+        // `showsResolved` became a status filter in #146 — the old boolean
+        // keyed on a state nothing ever produced.
+        vm.statusFilter = .all
         #expect(vm.visibleReports.count == 2)
     }
 

--- a/ClaudeLifterTests/ViewModelTests/ReportSheetViewModelTests.swift
+++ b/ClaudeLifterTests/ViewModelTests/ReportSheetViewModelTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import ClaudeLifter
+
+/// Retains the container alongside the context — a context outliving its
+/// container traps message-lessly on iOS 26.
+@MainActor
+private struct ReportEnv {
+    let container: ModelContainer
+    let repository: SwiftDataExerciseReportRepository
+
+    init() throws {
+        container = try makeTestContainer()
+        repository = SwiftDataExerciseReportRepository(context: container.mainContext)
+    }
+}
+
+@Suite("ReportSheetViewModel Tests")
+@MainActor
+struct ReportSheetViewModelTests {
+
+    @Test("Submitting stores the captured context, not just the typed text")
+    func submitPersistsCapturedContext() async throws {
+        let env = try ReportEnv()
+        let workoutId = UUID()
+        let context = ReportContext(
+            exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip",
+            exerciseName: "Barbell Bench Press",
+            workoutId: workoutId,
+            workoutExerciseId: UUID(),
+            templateId: UUID(),
+            contextSummary: "Push Day · Barbell Bench Press · 60kg×8 ✓"
+        )
+        let vm = ReportSheetViewModel(context: context, repository: env.repository)
+        vm.category = .wrongExercise
+        vm.detail = "This is really the iso-lateral press"
+        vm.suggestedReplacement = "Hammer Strength Iso-Lateral Press"
+
+        let saved = await vm.submit()
+
+        #expect(saved)
+        let stored = try #require(try await env.repository.fetchAll().first)
+        #expect(stored.category == .wrongExercise)
+        #expect(stored.detail == "This is really the iso-lateral press")
+        #expect(stored.exerciseExternalId == "Barbell_Bench_Press_-_Medium_Grip")
+        #expect(stored.workoutId == workoutId)
+        #expect(stored.contextSummary == "Push Day · Barbell Bench Press · 60kg×8 ✓")
+        #expect(stored.suggestedReplacement == "Hammer Strength Iso-Lateral Press")
+        #expect(stored.appVersion != nil)
+        #expect(stored.status == .open)
+        #expect(stored.syncStatus == .pending)
+    }
+
+    @Test("An empty complaint cannot be submitted")
+    func blankDetailBlocksSubmit() async throws {
+        let env = try ReportEnv()
+        let vm = ReportSheetViewModel(
+            context: ReportContext(exerciseName: "Squat"),
+            repository: env.repository
+        )
+        vm.detail = "   \n "
+
+        #expect(!vm.canSubmit)
+        #expect(await vm.submit() == false)
+        #expect(try await env.repository.fetchAll().isEmpty)
+    }
+
+    @Test("A replacement typed then hidden by a category change is not stored")
+    func replacementIgnoredForCategoriesThatDoNotAskForIt() async throws {
+        let env = try ReportEnv()
+        let vm = ReportSheetViewModel(
+            context: ReportContext(exerciseName: "Squat"),
+            repository: env.repository
+        )
+        vm.category = .swapRequest
+        vm.suggestedReplacement = "Leg press"
+        vm.category = .bug
+        vm.detail = "The set wouldn't tick off"
+
+        #expect(!vm.showsReplacementField)
+        #expect(await vm.submit())
+        let stored = try #require(try await env.repository.fetchAll().first)
+        #expect(stored.suggestedReplacement == nil)
+    }
+
+    @Test("The starting category matches how the sheet was opened")
+    func defaultCategoryDependsOnEntryPoint() throws {
+        let env = try ReportEnv()
+        let fromExercise = ReportSheetViewModel(
+            context: ReportContext(exerciseName: "Squat"),
+            repository: env.repository
+        )
+        let fromWorkout = ReportSheetViewModel(
+            context: ReportContext(workoutId: UUID()),
+            repository: env.repository
+        )
+
+        #expect(fromExercise.category == .swapRequest)
+        #expect(fromWorkout.category == .bug)
+    }
+
+    @Test("Exercise context captures externalId and the set state, never the local UUID")
+    func exerciseContextCapturesExternalIdAndSets() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+        let exercise = Exercise(
+            name: "Barbell Bench Press",
+            externalId: "Barbell_Bench_Press_-_Medium_Grip"
+        )
+        context.insert(exercise)
+        let workoutExercise = WorkoutExercise(order: 0, exercise: exercise)
+        workoutExercise.sets = [
+            WorkoutSet(order: 0, weight: 60, reps: 8, isCompleted: true),
+            WorkoutSet(order: 1, weight: 60, reps: 6)
+        ]
+        let workout = Workout(
+            name: "Push Day", startedAt: .now, templateId: UUID()
+        )
+        workout.exercises = [workoutExercise]
+        context.insert(workout)
+
+        let reportContext = ReportContext.forExercise(workoutExercise, in: workout)
+
+        #expect(reportContext.exerciseExternalId == "Barbell_Bench_Press_-_Medium_Grip")
+        #expect(reportContext.exerciseName == "Barbell Bench Press")
+        #expect(reportContext.workoutId == workout.id)
+        #expect(reportContext.templateId == workout.templateId)
+        let summary = try #require(reportContext.contextSummary)
+        #expect(summary.contains("Push Day"))
+        #expect(summary.contains("60kg×8 ✓"))
+        #expect(summary.contains("60kg×6"))
+        _ = container
+    }
+
+    @Test("Workout context carries no exercise and still summarizes the session")
+    func workoutContextHasNoExercise() throws {
+        let container = try makeTestContainer()
+        let workout = Workout(name: "Leg Day", startedAt: .now)
+        let exercise = Exercise(name: "Back Squat")
+        container.mainContext.insert(exercise)
+        let workoutExercise = WorkoutExercise(order: 0, exercise: exercise)
+        workoutExercise.sets = [WorkoutSet(order: 0, weight: 100, reps: 5, isCompleted: true)]
+        workout.exercises = [workoutExercise]
+        container.mainContext.insert(workout)
+
+        let reportContext = ReportContext.forWorkout(workout)
+
+        #expect(reportContext.exerciseExternalId == nil)
+        #expect(reportContext.subject == "This workout")
+        let summary = try #require(reportContext.contextSummary)
+        #expect(summary.contains("Leg Day"))
+        #expect(summary.contains("1 sets completed"))
+        _ = container
+    }
+}
+
+@Suite("ReportListViewModel Tests")
+@MainActor
+struct ReportListViewModelTests {
+
+    @Test("Open count and visible list exclude resolved reports")
+    func resolvedReportsLeaveTheBacklog() async throws {
+        let env = try ReportEnv()
+        try await env.repository.save(
+            ExerciseReport(category: .bug, detail: "open")
+        )
+        let resolved = ExerciseReport(category: .bug, detail: "done")
+        resolved.status = .resolved
+        try await env.repository.save(resolved)
+
+        let vm = ReportListViewModel(repository: env.repository)
+        await vm.load()
+
+        #expect(vm.openCount == 1)
+        #expect(vm.visibleReports.count == 1)
+        vm.showsResolved = true
+        #expect(vm.visibleReports.count == 2)
+    }
+
+    @Test("Resolving locally re-queues the report for sync")
+    func resolvingLocallyMarksPending() async throws {
+        let env = try ReportEnv()
+        let report = ExerciseReport(
+            category: .bug, detail: "open", syncStatus: .synced
+        )
+        try await env.repository.save(report)
+
+        let vm = ReportListViewModel(repository: env.repository)
+        await vm.load()
+        await vm.setStatus(.resolved, for: report)
+
+        #expect(vm.openCount == 0)
+        #expect(report.status == .resolved)
+        #expect(report.syncStatus == .pending)
+    }
+}

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -22,11 +22,11 @@ What is left is the gym: the probes below all need a human at a machine.
    Sanity-check the Settings footer reads `1.4.1 (6)` anyway.
 2. Run the gym probes in the table below.
 3. Resolve the three acknowledged reports once the probes pass.
-4. ~~Approve the pending Lower B edit~~ — **applied** at 04:01 UTC, op
-   `43593a49-…`; Lower B now reads Split Squat 2 × 8. One thing to confirm:
-   that operation was `requiresApproval: true` and went straight to `applied`.
-   If you did **not** see an approval prompt, the guardrail has a hole and is
-   worth an issue. Report `990C04B4` stays open until you train it.
+4. ~~Approve the pending Lower B edit~~ — **approved on the phone** and applied
+   at 04:01 UTC, op `43593a49-…`; Lower B now reads Split Squat 2 × 8. The
+   approval guardrail fired correctly (screenshot confirms the prompt), but the
+   prompt showed no diff — **#147**. Report `990C04B4` stays open until you
+   train it.
 
 ## The probes, in the gym
 
@@ -178,6 +178,12 @@ The unit suite is the hard gate: deterministic and green.
 - **#142** search the library from the report sheet
 - **#143** the mirror cannot distinguish a draft from a finished workout
 - **#144** target reps on the workout screen + drift marker
+- **#146** `acknowledged` reports read as done but count as open, and *Show
+  resolved* can never do anything — no report ever reaches `resolved`. Live
+  data confirms: 3 acknowledged, 3 open, **0 resolved**
+- **#147** *Review Change* shows no change — the inbox approval prompt is a
+  `confirmationDialog` whose whole message is an exercise **count**, so a
+  one-number edit is indistinguishable from a full rewrite
 
 ---
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,17 +1,16 @@
 # HANDOFF — Exercise reports (#135), ready to install
 
-Updated 2026-08-18, end of evening session. Branch **`feat/exercise-reports`**,
-two commits, **not pushed**, branched off `docs/fix-stale-build-recipes`.
+Updated 2026-08-19. Branch **`feat/exercise-reports`**, four commits,
+**not pushed**, branched off `docs/fix-stale-build-recipes`.
 
 ## Do this first in the morning
 
-1. **Decide the version number** (see "The version bump is unresolved" below) —
-   this is the one thing I could not settle without you.
-2. Install to the phone. The interesting part is not the feature, it is the
+1. Install to the phone — version is set to **1.2.0 (build 2)**. The interesting
+   part is not the feature, it is the
    **V2→V3 schema migration against your real data**. A new `@Model` is exactly
    the change that has crashed on-device before. The migration is additive and
    lightweight, and the simulator's empty store proves nothing about it.
-3. If the migration is fine, file a report from a real exercise mid-workout and
+2. If the migration is fine, file a report from a real exercise mid-workout and
    check it survives a sync. Full end-to-end needs the Azure deploy below.
 
 ## What landed
@@ -39,19 +38,15 @@ the network await — a create landing mid-request was absent from the payload
 **#94** constant-time API key compare. **#93** the three force-unwrapped
 `Calendar.date` calls.
 
-## The version bump is unresolved — your call
+## Version: 1.2.0 (build 2)
 
-Memory says the convention is 3-part semver from 1.1.0, bumped in six pbxproj
-spots before every device install. **The repo does not match that.**
-`generate_project.py` hardcodes `MARKETING_VERSION = '1.0'` and
-`CURRENT_PROJECT_VERSION = '1'`, and it *regenerates* `project.pbxproj` — so any
-bump made directly in the pbxproj is wiped the next time a file is added and the
-generator runs (which happened several times tonight). Either the convention
-lapsed, or bumps were being made in a file that does not survive.
+Settled 2026-08-19 — the phone was on 1.1.0, and #135 is a feature, so minor.
 
-I did not guess a number: I cannot see what is installed on the phone, and
-picking 1.1.0 could be a *downgrade*. Decide the number, then change it in
-**`generate_project.py`** (not the pbxproj) so it survives regeneration.
+`generate_project.py` now owns it: `APP_VERSION` and `BUILD_NUMBER` at the top,
+referenced by all three targets. **Never bump `project.pbxproj` directly** — the
+generator rewrites that file whenever a Swift file is added, silently discarding
+the bump. That is why the repo had drifted back to `1.0` despite the convention.
+Now recorded in CLAUDE.md's Key Conventions, which is always read.
 
 ## Azure deploy is required for the MCP half
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,4 +1,4 @@
-# HANDOFF — 1.4.1 is installed and the migration held
+# HANDOFF — 1.5.0 is built; 1.4.1 is installed and its migration held
 
 Updated 2026-08-20. Branch **`feat/exercise-reports`**, **PR #145**. `main`
 untouched. **Version 1.4.1 (6) is on the phone** — Release build, installed
@@ -184,6 +184,27 @@ The unit suite is the hard gate: deterministic and green.
 - **#147** *Review Change* shows no change — the inbox approval prompt is a
   `confirmationDialog` whose whole message is an exercise **count**, so a
   one-number edit is indistinguishable from a full rewrite
+
+## 1.5.0 (7) — built, not installed
+
+**#146 is fixed** and the server half is deployed. Not on the phone yet.
+
+- The reports list filter is now Outstanding / Open / Acknowledged / Resolved /
+  All — the same vocabulary `list_exercise_reports` uses, so the phone and the
+  AI agree about what is left. Default is Outstanding (open + acknowledged).
+- The home card counts only `.open`, with acknowledged shown beside it:
+  "3 open · 3 awaiting install" rather than "6 open reports".
+- **Reopening works end to end** — MCP tool, Functions validation, inbox
+  applier. All three had refused it deliberately; #136's inert fix is what
+  changed the call. Swipe a report for Resolve / Acknowledge / Reopen.
+- `resolve_exercise_report` takes `ids` for a batch, validated all-or-nothing.
+
+No schema change — nothing here adds a stored property. Nutrition still takes V5.
+
+**Litter I made:** inbox op `f4c9187b` is a validation probe with a bogus report
+id, now terminal in `failed` alongside the three July `deleteTemplate` ones. It
+will never reach the phone. There is no way to delete an inbox operation, which
+is arguably worth an issue of its own.
 
 ---
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,31 +1,117 @@
-# HANDOFF — Finish reliability (Phase 1)
+# HANDOFF — Exercise reports (#135), ready to install
 
-Updated 2026-08-07. The usability sprint's 6 commits are **pushed**. Phase 1 of
-`WORKOUT_RELIABILITY_AND_TEMPLATE_PLAN.md` is on `fix/finish-reliability`.
+Updated 2026-08-18, end of evening session. Branch **`feat/exercise-reports`**,
+two commits, **not pushed**, branched off `docs/fix-stale-build-recipes`.
 
-## The test baseline — read this before judging any run
+## Do this first in the morning
 
-**`xcodebuild test` exits 0 on `fix/finish-reliability`:** 681 Swift Testing
-(671 + 10 new), zero XCUITest failures, on iPhone 13 Pro Max / iOS 26.5.
+1. **Decide the version number** (see "The version bump is unresolved" below) —
+   this is the one thing I could not settle without you.
+2. Install to the phone. The interesting part is not the feature, it is the
+   **V2→V3 schema migration against your real data**. A new `@Model` is exactly
+   the change that has crashed on-device before. The migration is additive and
+   lightweight, and the simulator's empty store proves nothing about it.
+3. If the migration is fine, file a report from a real exercise mid-workout and
+   check it survives a sync. Full end-to-end needs the Azure deploy below.
 
-The previous note that "a non-zero exit is now a real regression" was **wrong
-for the first ~10 days of any month**, and cost a full investigation on
-2026-08-07. `calendarHeatmap` seeded workouts at `today - 10 days` while
-`CalendarViewModel.loadMonth()` fetches only the *current* month, so the light
-workout fell into the previous month and vanished. The 2026-07-29 green run
-happened on the 29th, which is why nobody saw it. Fixed in #131; the fixture is
-now anchored to fixed days of the current month.
+## What landed
 
-With that fixed the claim finally holds: **a non-zero exit is a real
-regression.** The other traps still apply: never pipe `xcodebuild` through
-`tail` without `set -o pipefail` (a background wrapper reported "exit code 0"
-while xcodebuild had returned 65), and XCUITest failures print
-`Test Case '-[...]' failed`, not Swift Testing's `✘`.
+**#135 — in-workout exercise reports.** A flag in the exercise card's overflow
+menu, in the active-workout toolbar, and in exercise detail. Pick a category
+chip, type a sentence, Send. Everything else — `exerciseExternalId`, workout,
+template, the set state at that moment, app and iOS version — is captured, not
+asked for. Reports mirror to Cosmos with the rest of the snapshot and are
+readable over MCP as `list_exercise_reports`, closed out with
+`resolve_exercise_report`.
 
-**Device runs need the phone unlocked.** A locked screen produces
-`Waiting for the destination to become ready` and `** BUILD INTERRUPTED **`
-before the build even starts — it looks like a toolchain problem and isn't.
-The full device UI suite takes over 10 minutes; run it in the background.
+The design decision worth remembering: **there is no target picker.** Context is
+something the app knows, not something you choose in a gym. The category chip is
+the only input, and it tells the reader which captured context matters.
+
+**#104 — custom exercises were never pushed.** `Exercise` is the one mirrored
+type with no per-record `syncStatus`, so `hasPendingChanges` could not see it; a
+custom exercise sat unpushed until some unrelated change triggered a snapshot.
+Now signalled from the repository. The durable marker also became a pair of
+generation counters, because the old boolean was cleared unconditionally after
+the network await — a create landing mid-request was absent from the payload
+*and* had its only signal wiped.
+
+**#94** constant-time API key compare. **#93** the three force-unwrapped
+`Calendar.date` calls.
+
+## The version bump is unresolved — your call
+
+Memory says the convention is 3-part semver from 1.1.0, bumped in six pbxproj
+spots before every device install. **The repo does not match that.**
+`generate_project.py` hardcodes `MARKETING_VERSION = '1.0'` and
+`CURRENT_PROJECT_VERSION = '1'`, and it *regenerates* `project.pbxproj` — so any
+bump made directly in the pbxproj is wiped the next time a file is added and the
+generator runs (which happened several times tonight). Either the convention
+lapsed, or bumps were being made in a file that does not survive.
+
+I did not guess a number: I cannot see what is installed on the phone, and
+picking 1.1.0 could be a *downgrade*. Decide the number, then change it in
+**`generate_project.py`** (not the pbxproj) so it survives regeneration.
+
+## Azure deploy is required for the MCP half
+
+The app half works offline. The MCP half does not, until:
+
+- **Bicep** — new Cosmos container `exerciseReports` (`infra/modules/cosmos.bicep`)
+- **Functions** — new `GET /api/reports`, plus snapshot v3 and the new inbox op
+- **MCP server** — `npm run build` in `infra/mcp` for the two new tools
+
+Until the container exists, a v3 push will report a failure for that collection
+and the client will keep retrying — it will not corrupt anything.
+
+Wire contract v3 **accepts v2 pushes on purpose**: the server deploys
+independently of the app, and a phone still on the old build knows nothing about
+reports. Reading its push as "there are no reports" would delete the whole
+backlog. Absent from the contract means untouched, not empty. So deploy order
+does not matter.
+
+## Test state — and a correction to the previous baseline claim
+
+| Suite | Result |
+|---|---|
+| Swift unit (`-only-testing:ClaudeLifterTests`) | **717 tests, 94 suites, exit 0** |
+| Azure Functions (jest) | **172 pass** |
+| MCP server (vitest) | **60 pass** |
+| XCUITest | **flaky — see below** |
+
+**The previous handoff's claim that "a non-zero exit is a real regression" does
+not hold for the UI suite tonight.** Three runs on this machine:
+
+- Full suite, my tree: 8 UI failures
+- 15-test subset, **unmodified HEAD**: 1 failure (`testLongExerciseNameDoesNotBreakLayout`)
+- Same subset, my tree: 2 failures — and `testLongExerciseNameDoesNotBreakLayout` **passed**
+
+The failing sets do not overlap across runs on either tree, and most failures are
+`Failed to synthesize event: Neither element nor any descendant has keyboard
+focus`. That is flakiness in this environment, not a regression from these
+commits. **Do not treat a UI-suite failure as a regression without running the
+same subset against a clean worktree** — that comparison is what settled it, and
+it takes about five minutes.
+
+The unit suite remains a hard gate: it is deterministic and green.
+
+## Notes for whoever picks this up
+
+- **Schema V3 is taken.** #110 (nutrition) planned to use V3 and now needs V4
+  plus its own `MigrationStage`. I commented on the issue.
+- The wire/model field is `detail`, not `body` as issue #135 wrote it — `body`
+  reads badly next to SwiftUI's `View.body`.
+- `ReportStatus.acknowledged` deliberately counts as **open**. Acknowledged work
+  is still outstanding; only `.resolved` leaves the backlog, in the repository,
+  the Home count, and the server's default query.
+- Reports can be resolved from the app (swipe on the Reports list) as well as
+  over MCP. A backlog you can only clear from another device is one you stop
+  trusting.
+- **#127 is not superseded by this.** That is the heavy evidence path — sealed
+  local diagnostic bundles, depends on #126. This is the lightweight synced
+  channel. They meet at `.bug`: a report could later carry a #127 bundle ID.
+
+## Older material, still true
 
 **`app.keyboards` is empty on Evan's iPhone even with the keyboard onscreen.**
 Resolved 2026-08-07; four `KeyboardDismissalTests` had been failing on device
@@ -128,22 +214,22 @@ weight. Revisiting this needs an explicit touched/cleared state or a bodyweight
 control — and must be checked against the ChatTools write paths, which bypass
 the ViewModel.
 
-## Open follow-ups from this sprint
+## Open follow-ups
 
 - **#117** — `WorkoutDetailView.swift:135-144` writes `set.weight` directly to
   the model, bypassing the mutation API, so **history edits never sync**; also
   can't clear a value, and parses with non-locale `Double(String)`. Fix this
   before or with #122, which restyles the same row.
-- **#122** — extend the new set-row visual language to History and Home (the
-  Phase 3 that was cut).
+- **#122** — extend the set-row visual language to History and Home.
 - **#120** — Coach `end_workout` can't reach the screen-owned `RestTimerSession`,
   so a Coach-ended workout still chimes and stays onscreen.
 - **#121** — `persistMutation()` is documented as debounced but has no delay or
-  cancellation check.
+  cancellation check. (Untouched tonight — the ordering half was done in Phase 1.)
+- **#132** — `HistoryListView` loads behind `if vm == nil`; the History tab
+  serves a stale list until pull-to-refresh.
 - **#118** Live Activities · **#119** app-wide accessibility.
-- **#86** stays open: only three silent-failure items were taken (insight
-  dismissal, photo attach, exercise save). Keychain, auth comparison, Bicep
-  outputs and stale docs are untouched.
+- **#86** stays open: only three silent-failure items were taken. #94's auth
+  comparison is now done; keychain, Bicep outputs and stale docs are untouched.
 
 ## Gotchas worth keeping
 
@@ -157,3 +243,5 @@ the ViewModel.
   over the device name — CLAUDE.md's string contains a typographic apostrophe
   that a straight quote will not match.
 - Static typechecks are not a test run.
+- The UI suite is flaky on this machine (2026-08-18). Compare against a clean
+  `git worktree` before calling a UI failure a regression.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,25 +1,32 @@
-# HANDOFF — 1.4.1 is built, reviewed, and not installed
+# HANDOFF — 1.4.1 is installed and the migration held
 
 Updated 2026-08-20. Branch **`feat/exercise-reports`**, **PR #145**. `main`
-untouched. **Version 1.4.1 (6) — not on the phone.** The device is still
-running 1.2.0 (2), so every user-visible fix below is unverified on hardware.
+untouched. **Version 1.4.1 (6) is on the phone** — Release build, installed
+2026-08-20 06:00 local and launched.
 
-1.4.1 adds #140's sync half to the 1.4.0 batch: bundled-exercise notes and
-photos now travel to the mirror as overlays, keyed by `externalId`. The Cosmos
-container was created through Bicep. The Functions app is **deployed
-and verified at v4**; the Cosmos container was created through Bicep.
+**The schema V4 migration succeeded on real data.** Proof is not that the app
+opened — a quarantined store opens fine, empty. It is that the phone synced
+after launch and the mirror went revision **378 → 380 with counts intact**: 17
+workouts, 5 templates, 6 reports, 2320 body-weight entries. A quarantine would
+have pushed an empty snapshot and wiped the mirror instead.
+
+Also settled on launch: the Functions app is deployed and verified at wire v4,
+the Cosmos `exerciseOverlays` container exists (created through Bicep), and the
+**Lower B Split Squat edit applied** — the template now reads 2 × 8.
+
+What is left is the gym: the probes below all need a human at a machine.
 
 ## Do this first
 
-1. **Install 1.4.1 (6).** The Settings footer showing `1.4.1 (6)` is the proof.
-   This build carries a **schema V4 migration** — watch the first launch. If the
-   store quarantines instead of opening, that is the one serious risk in this
-   batch (see #128 below), and the fix is to reinstall from a backup.
-2. Run the four gym probes in the table below.
+1. ~~Install 1.4.1 (6)~~ — **done**, and the V4 migration held (see above).
+   Sanity-check the Settings footer reads `1.4.1 (6)` anyway.
+2. Run the gym probes in the table below.
 3. Resolve the three acknowledged reports once the probes pass.
-4. **Approve the pending Lower B edit.** Split Squat 10 → 8 is enqueued in the
-   inbox (op `43593a49-…`) and the phone will ask on next sync. Report
-   `990C04B4` stays open until you confirm it on the device.
+4. ~~Approve the pending Lower B edit~~ — **applied** at 04:01 UTC, op
+   `43593a49-…`; Lower B now reads Split Squat 2 × 8. One thing to confirm:
+   that operation was `requiresApproval: true` and went straight to `applied`.
+   If you did **not** see an approval prompt, the guardrail has a hole and is
+   worth an issue. Report `990C04B4` stays open until you train it.
 
 ## The probes, in the gym
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,9 +6,8 @@ running 1.2.0 (2), so every user-visible fix below is unverified on hardware.
 
 1.4.1 adds #140's sync half to the 1.4.0 batch: bundled-exercise notes and
 photos now travel to the mirror as overlays, keyed by `externalId`. The Cosmos
-container was created through Bicep. **The Functions app still needs
-publishing** — see *Blocked* below; the client degrades to v3 on its own, so
-this does not gate the install.
+container was created through Bicep. The Functions app is **deployed
+and verified at v4**; the Cosmos container was created through Bicep.
 
 ## Do this first
 
@@ -29,7 +28,7 @@ this does not gate the install.
 | **#136** Seated Leg Curl → ⋯ → *Add a note…* → `Ankle 4; Seat 4; Pivot 1` | The note appears on the card, and on **every** future workout containing that exercise, whichever template |
 | **#137** Add Ab Crunch Machine mid-workout | Its sets arrive with reps prefilled from last session and **weight empty**. Empty weight is the fix working |
 | **#144** Any Lower B exercise | A `Target 2 × 8 · 90s rest` line under the name, and last session's PREVIOUS marked orange where it missed the target |
-| **#140** Note a bundled exercise, then Settings → sync | After the Functions publish, the note appears in the `exerciseOverlays` container. Before it, sync still succeeds — silently at v3 |
+| **#140** Note a bundled exercise, then Settings → sync | The note appears in the `exerciseOverlays` Cosmos container, keyed by `externalId` (e.g. `Seated_Leg_Curl`). The server side is already verified; this probe tests the phone half |
 | **#129/#130** Finish a Lower B with Ab Crunch Machine added | The summary offers *Update Lower B?* → Review → Apply. Ab Rollout, if skipped, must **not** be offered for removal |
 
 ## What changed, and the three things worth knowing
@@ -97,26 +96,32 @@ before Split Squat (order 1), and there is no batch-completion path anywhere:
 `completedAt` is written one set at a time, in exactly two places. Pinned with
 tests.
 
-## Blocked — needs you, and I did not route around it
+## Blocked — nothing, as of 2026-08-20
 
-**One action, and it is smaller than it was.** `func azure functionapp publish`
-is refused by the permission classifier. The Functions **source** is at wire
-version 4 and green (180 tests), but the **deployed** app still only knows v3:
+**Nothing.** Both actions that were blocked are done.
 
-```bash
-cd infra/functions && npm run build
-func azure functionapp publish func-workout-prod --javascript
-curl -sf https://func-workout-prod.azurewebsites.net/api/health
-```
-
-Until you run that, overlays do not reach the mirror. **Nothing else breaks** —
-the client sends v4, the server answers 400, and the client retries once at v3,
-which is the contract the deployed server already speaks. So installing 1.4.1
-before publishing costs you the overlays and nothing more. Verify afterwards by
-editing a note on a bundled exercise and checking `exerciseOverlays` in Cosmos.
-
-The Cosmos container **is created**, through Bicep rather than an ad-hoc `az`
+The Functions app is **deployed and verified at wire version 4**, and the
+Cosmos container was created **through Bicep** rather than an ad-hoc `az`
 command, so the repo still describes reality.
+
+Verified against production, read-only — a real push would have reconciled the
+live mirror, so the version checks used bodies that fail validation, which runs
+before any write:
+
+| Probe | Result |
+|---|---|
+| `GET /api/health` | 200 |
+| `GET /api/sync/snapshot` | revision **378**, and the mirror now returns an `exerciseOverlays` collection (empty — no phone has pushed one yet) |
+| `POST` schemaVersion 9 | `Expected one of 2, 3, 4` — v4 is live |
+| `POST` schemaVersion 4, no overlays key | rejected *by name* — v4 dispatch reaches the overlay collection |
+| `POST` schemaVersion 3 | still a known version — back-compat intact for the phone on 1.2.0 |
+
+Mirror contents unchanged throughout: 17 workouts, 5 templates, 2319
+body-weight entries, 6 reports.
+
+The client's degrade-to-v3 path stays in regardless. It is now belt and
+braces rather than load-bearing, and it means the next wire bump can ship in
+either order.
 
 ### On deploying with Bicep — read this before you try
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,17 +1,26 @@
-# HANDOFF — 1.4.0 is built, reviewed, and not installed
+# HANDOFF — 1.4.1 is built, reviewed, and not installed
 
-Updated 2026-08-19, late. Branch **`feat/exercise-reports`**, pushed, **PR #145**.
-`main` untouched. **Version 1.4.0 (5) — not on the phone.** The device is still
+Updated 2026-08-20. Branch **`feat/exercise-reports`**, **PR #145**. `main`
+untouched. **Version 1.4.1 (6) — not on the phone.** The device is still
 running 1.2.0 (2), so every user-visible fix below is unverified on hardware.
+
+1.4.1 adds #140's sync half to the 1.4.0 batch: bundled-exercise notes and
+photos now travel to the mirror as overlays, keyed by `externalId`. The Cosmos
+container was created through Bicep. **The Functions app still needs
+publishing** — see *Blocked* below; the client degrades to v3 on its own, so
+this does not gate the install.
 
 ## Do this first
 
-1. **Install 1.4.0 (5).** The Settings footer showing `1.4.0 (5)` is the proof.
+1. **Install 1.4.1 (6).** The Settings footer showing `1.4.1 (6)` is the proof.
    This build carries a **schema V4 migration** — watch the first launch. If the
    store quarantines instead of opening, that is the one serious risk in this
    batch (see #128 below), and the fix is to reinstall from a backup.
 2. Run the four gym probes in the table below.
 3. Resolve the three acknowledged reports once the probes pass.
+4. **Approve the pending Lower B edit.** Split Squat 10 → 8 is enqueued in the
+   inbox (op `43593a49-…`) and the phone will ask on next sync. Report
+   `990C04B4` stays open until you confirm it on the device.
 
 ## The probes, in the gym
 
@@ -20,6 +29,7 @@ running 1.2.0 (2), so every user-visible fix below is unverified on hardware.
 | **#136** Seated Leg Curl → ⋯ → *Add a note…* → `Ankle 4; Seat 4; Pivot 1` | The note appears on the card, and on **every** future workout containing that exercise, whichever template |
 | **#137** Add Ab Crunch Machine mid-workout | Its sets arrive with reps prefilled from last session and **weight empty**. Empty weight is the fix working |
 | **#144** Any Lower B exercise | A `Target 2 × 8 · 90s rest` line under the name, and last session's PREVIOUS marked orange where it missed the target |
+| **#140** Note a bundled exercise, then Settings → sync | After the Functions publish, the note appears in the `exerciseOverlays` container. Before it, sync still succeeds — silently at v3 |
 | **#129/#130** Finish a Lower B with Ab Crunch Machine added | The summary offers *Update Lower B?* → Review → Apply. Ab Rollout, if skipped, must **not** be offered for removal |
 
 ## What changed, and the three things worth knowing
@@ -89,36 +99,49 @@ tests.
 
 ## Blocked — needs you, and I did not route around it
 
-Two actions were refused by the permission classifier:
+**One action, and it is smaller than it was.** `func azure functionapp publish`
+is refused by the permission classifier. The Functions **source** is at wire
+version 4 and green (180 tests), but the **deployed** app still only knows v3:
 
-1. **Creating the Cosmos container for #140's sync half.**
-   ```bash
-   az cosmosdb sql container create \
-     --account-name cosmos-workout-prod --database-name workout-db \
-     --resource-group rg-workout-app-prod \
-     --name exerciseOverlays --partition-key-path "/id"
-   ```
-   The **backup half of #140 shipped** — a reinstall-and-restore no longer loses
-   your notes. The sync half is designed and written up on the issue but not
-   built, and **the client wire version is still 3**, so nothing was deployed
-   and the phone is unaffected. It needs its own container because
-   `reconcileContainer` deletes every id absent from the snapshot, so two
-   collections sharing `exercises` would wipe each other.
+```bash
+cd infra/functions && npm run build
+func azure functionapp publish func-workout-prod --javascript
+curl -sf https://func-workout-prod.azurewebsites.net/api/health
+```
 
-   A full `az deployment group create` is **not** the way to do it unattended:
-   `main.bicep` takes `apiKey` and `anthropicApiKey` as `@secure()` parameters,
-   and deploying without the real values breaks auth for the phone and MCP both.
+Until you run that, overlays do not reach the mirror. **Nothing else breaks** —
+the client sends v4, the server answers 400, and the client retries once at v3,
+which is the contract the deployed server already speaks. So installing 1.4.1
+before publishing costs you the overlays and nothing more. Verify afterwards by
+editing a note on a bundled exercise and checking `exerciseOverlays` in Cosmos.
 
-2. **The Split Squat 10 → 8 template edit** over MCP (`update_template` on
-   `B83E7341-…`, exercise `4DE7A259-…`). Still unmade. #144 at least makes the
-   disagreement visible while training.
+The Cosmos container **is created**, through Bicep rather than an ad-hoc `az`
+command, so the repo still describes reality.
+
+### On deploying with Bicep — read this before you try
+
+`what-if` earned its keep. Deploying `cosmos.bicep` as written would have made
+three changes nobody asked for: `enableAutomaticFailover` **off**,
+`minimalTlsVersion` **dropped**, and a database-throughput rewrite. The live
+account had all three set correctly and the template declared none of them, so
+the template was quietly proposing to weaken production. Two are now declared;
+the third was a false alarm (autoscale max 1000 already matches).
+
+**Do not deploy `main.bicep` whole without re-publishing the code after.**
+`functions.bicep`'s `appSettings` array is wholesale — ARM replaces the entire
+setting collection — and the live app carries `WEBSITE_RUN_FROM_PACKAGE`, a
+rotating SAS URL that cannot be expressed in Bicep. Deploying strips it and the
+API 404s until `func publish` runs. The runbook is in a comment at the top of
+that resource. For Cosmos-only work, deploy the module alone: no secrets, no
+Function App, `what-if` first.
 
 ## Test state
 
+
 | Suite | Result |
 |---|---|
-| Swift unit (`-only-testing:ClaudeLifterTests`) | **772 tests, 97 suites, exit 0** |
-| Azure Functions (jest) | **172 pass** |
+| Swift unit (`-only-testing:ClaudeLifterTests`) | **781 tests, 98 suites, exit 0** |
+| Azure Functions (jest) | **180 pass** |
 | MCP server (vitest) | **64 pass** (60 + 4 for the staleness guard) |
 | XCUITest | **not run** — flaky here; not a regression without a clean-worktree comparison |
 
@@ -138,7 +161,7 @@ The unit suite is the hard gate: deterministic and green.
 
 ## New issues filed this session
 
-- **#140** bundled-exercise user data excluded from sync and backup (backup half done)
+- **#140** bundled-exercise user data excluded from sync and backup — **both halves done**, pending the Functions publish
 - **#141** photo upload on exercise reports
 - **#142** search the library from the report sheet
 - **#143** the mirror cannot distinguish a draft from a finished workout

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,60 +1,77 @@
-# HANDOFF — First field feedback triaged (#136–#139)
+# HANDOFF — #136 fixed and ready to install; #137 is next
 
-Updated 2026-08-19 evening. Branch **`feat/exercise-reports`**.
-The #135 report channel is installed, working, and **has already paid for
-itself**: six reports came back from one gym session and four defects are now
-filed. No app code has been changed yet — this handoff is the triage, not a fix.
+Updated 2026-08-19 late evening. Branch **`feat/exercise-reports`**.
+**1.3.0 (build 3) is committed and unreleased — it is not on the phone yet.**
 
 ## Do this first
 
-1. **Restart Claude Code.** `infra/mcp/dist/` was rebuilt this session; the
-   report tools are not in the running server until it re-spawns. Probe:
-   `list_exercise_reports` returns six reports without a manual build first.
-2. Start on **#136** (notes) — it is the only P1 and the only data-integrity
-   item, and the user hit it twice in one session.
+1. **Install 1.3.0 to the phone and do a Lower B.** The Settings footer showing
+   `1.3.0 (3)` is the proof it landed. Nothing about #136 is verified on real
+   hardware yet — it is verified by 722 unit tests and a simulator build only.
+2. On the first Lower B, **add the Seated Leg Curl note by hand**: tap ⋯ →
+   *Add a note…* → `Ankle 4; Seat 4; Pivot 1` (recovered from the 2026-08-12
+   session). It should then appear on every future workout containing that
+   exercise. That is the acceptance probe for #136.
+3. Then **#137** — and read "The trap waiting in #137" below before touching it.
 
-## What happened
+## What #136 turned out to be
 
-The first real workout on 1.2.0 (build 2) — Lower B, 2026-08-19 — produced six
-reports through the #135 channel. All six are still `open` in the backlog.
+The issue's own proposed fix would not have worked, and the data is what
+settled it. Copying `TemplateExercise.notes` into the session is correct but
+inert here: **the Lower B template has no notes on any exercise.** The
+`"Ankle 4; Seat 4; Pivot 1"` note lived on the *2026-08-12 session*, and
+nothing in the app writes `WorkoutExercise.notes` — only `SyncMapper` and the
+MCP inbox do. It arrived from outside and died with that session. 08-05 had
+none; 08-19 had none.
 
-| Time | Category | Report | Outcome |
+So a session-scoped note typed at the machine would have vanished again the
+following week and produced the same report.
+
+**The note now lives on the library `Exercise`.** It describes the machine, so
+it follows the exercise into every workout whichever template that workout came
+from. Evan's words: *"if I make a new workout with the same exercise, I want the
+same note to appear with it."*
+
+- inline on `ExerciseCardView` — a note behind a tap is not read mid-set
+- edited from a **sheet**, deliberately not inline: the workout screen owns one
+  `@FocusState` keyed on `SetEntryFieldID` with a weight/reps accessory bar, and
+  a free-text field in that hierarchy would have to join or fight it
+- read-only section on `ExerciseDetailView`
+- the template→session copy is **kept** — a template note is a per-plan cue, a
+  different thing, and renders as its own line
+- `ActiveWorkoutViewModel` gained an optional `exerciseRepository`; all three
+  inits and all four construction sites pass it. **If it is nil the note is
+  written to the model and never saved** — that is the failure mode to look for
+  if a note does not stick.
+
+### The hole this leaves — #140
+
+The note is *also* stamped onto `WorkoutExercise.notes`, on purpose. Bundled
+exercises are excluded from sync (`SyncManager:331`, `:405`) **and** from backup
+(`BackupService:7-8`), so the library note is **device-local**: lost on
+reinstall, not restored by a backup restore, invisible to the Coach and MCP.
+The workout record is the copy that travels. #140 covers carrying user data on
+bundled exercises properly, and it is a `schemaVersion` 4 change — so
+**deploy the Functions app before installing that client** (see below).
+
+## Report backlog state
+
+Reports `CD42B832` (04:16) and `5B380FF1` (Seated Leg Curl) are now
+**acknowledged**, not resolved — the fix exists but is not on the phone.
+Acknowledged still counts as open. Resolve them after the install confirms it.
+
+The other four remain untouched and open:
+
+| Time | Category | Report | Where it goes |
 |---|---|---|---|
-| 04:16 | bug | "What happened to the notes section on the exercises?" | **#136** |
-| 04:46 | bug | Seated Leg Curl notes gone — "3 settings for this machine" | **#136** |
 | 04:49 | formOrSetup | Split squat 10→8 reps | preference, not a defect |
-| 04:54 | swapRequest | Ab Rollout → Machine Ab Crunch; "added it to the template and it didn't stick" | evidence on **#129/#130** |
-| 04:56 | other | Want photo upload on reports | **not filed** — see below |
-| 04:59 | other | Reps should auto-fill, not need ghost-text confirmation | **#137** |
+| 04:54 | swapRequest | Ab Rollout → Machine Ab Crunch | evidence on **#129/#130** |
+| 04:56 | other | Photo upload on reports | **not filed** — ask first |
+| 04:59 | other | Reps should auto-fill | **#137** |
 
-## The finding that matters most — #136
-
-Two independent defects produce one symptom, and the machine settings vanish
-exactly where they are needed: standing at the machine, mid-set.
-
-1. **`startFromTemplate` never copies `TemplateExercise.notes`.**
-   `ActiveWorkoutViewModel.swift:247` passes `order` / `exercise` /
-   `restSeconds` and nothing else.
-2. **No UI renders or edits per-exercise notes during a workout.**
-   `ExerciseCardView.swift` has zero references to notes.
-
-**Both are older than 1.2.0** — `git log -S"notes: templateExercise.notes"` and
-`git log -S"notes" -- …/ExerciseCardView.swift` are each empty, so neither line
-ever existed. Do not go looking for the commit that broke it; there isn't one.
-What changed is that the notes were previously arriving by another path (sync
-inbound / MCP inbox — `InboxApplier.swift:339` is the only writer of template
-notes) and no longer reach the session.
-
-The data settles that the user's memory is right, not nostalgic:
-
-- Lower B **2026-08-12** (`DCC20C31-…`): Trap Bar Deadlift `"Grip bar is down."`,
-  Seated Leg Curl `"Ankle 4; Seat 4; Pivot 1"` ← literally the "3 settings"
-- Lower B **2026-08-19** (`5743E0DD-…`): no notes on any exercise
-- **Upper A** template carries per-exercise notes on 7 of 9; **Lower B**
-  template has none — which is exactly why "other workouts have a notes section"
-
-`SyncMapper` maps the field faithfully in both directions
-(`:33` out, `:176` in), so this is a start-path and UI gap, never a sync bug.
+The 04:54 report is now corroborated: both the 08-05 and 08-12 Lower B sessions
+contain **Ab Crunch Machine at order 4**, and the template still does not. He
+has added it twice and it has never stuck. That is #129/#130's whole case.
 
 ## The trap waiting in #137
 
@@ -69,13 +86,10 @@ distinct states, and the red test must cover the bodyweight case first.
 
 `list_exercise_reports` shipped in `infra/mcp/src/` with commit `4d41c20`, but
 the MCP client runs `dist/src/server.js`, and `dist/` was a **stale build from
-before that commit** — no `reports.js`, tools absent from the advertised list.
-The feature looked shipped in the repo and did not exist in practice.
-
-Fixed with `npm run build` (exit 0). The general hazard is unfixed: nothing
-ties the running server to the committed source. This is the MCP-side analogue
-of the `generate_project.py` versioning trap already in CLAUDE.md — a build
-artifact whose staleness is invisible.
+before that commit**. The feature looked shipped in the repo and did not exist
+in practice. Fixed with `npm run build`; **verified this session** — a restarted
+client returned all six reports with no manual build. The general hazard is
+unfixed: nothing ties the running server to the committed source.
 
 ## Open question, not a conclusion — #139
 
@@ -87,13 +101,12 @@ would silently no-op if `completionState` could be `.finished` on a workout
 whose `completedAt` was never persisted.
 
 Same session, unexplained: set timestamps are not monotonic with exercise order,
-and two pairs are 0.68s and 5.9s apart — not real rest periods. Either the user
-caught up at the end, or completing one set stamps its siblings. **Unresolved.**
+and two pairs are 0.68s and 5.9s apart — not real rest periods. **Unresolved.**
 
 ## Deliberately not filed
 
-The two feature requests from the same session are real but are not regressions,
-and filing them was not what was asked:
+Both are real, both are feature requests rather than regressions, and filing
+them was not what was asked. **Ask before filing.**
 
 - **Photo upload on reports** (04:56) — would let the coach judge whether a
   machine matches the exercise description. Note it argues for *creating* a
@@ -101,14 +114,11 @@ and filing them was not what was asked:
 - **Search the exercise library from the report sheet** (inside the 04:54
   report) — the user could not name the replacement he wanted.
 
-Both are worth issues. Ask before filing.
-
 ## State of the tree
 
-No app code modified this session. The only change is
-`infra/mcp/dist/` (rebuilt, and `dist/` is generated — check whether it is
-tracked before committing). Branch `feat/exercise-reports` is otherwise as the
-previous handoff left it.
+Branch `feat/exercise-reports`, three commits ahead of where the triage left it:
+`14a3a6d` (triage recorded), `2b729e4` (#136 fix + version bump to 1.3.0/3).
+Unpushed. `infra/mcp/dist/` is rebuilt and untracked.
 
 ---
 
@@ -135,7 +145,7 @@ wire version.** The same trap is waiting for whoever bumps it to v4.
 
 | Suite | Result |
 |---|---|
-| Swift unit (`-only-testing:ClaudeLifterTests`) | **717 tests, 94 suites, exit 0** |
+| Swift unit (`-only-testing:ClaudeLifterTests`) | **722 tests, 94 suites, exit 0** (2026-08-19, with #136) |
 | Azure Functions (jest) | **172 pass** |
 | MCP server (vitest) | **60 pass** |
 | XCUITest | **flaky — see below** |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,66 +1,118 @@
-# HANDOFF — Exercise reports (#135), ready to install
+# HANDOFF — First field feedback triaged (#136–#139)
 
-Updated 2026-08-19. Branch **`feat/exercise-reports`**, four commits,
-**not pushed**, branched off `docs/fix-stale-build-recipes`.
+Updated 2026-08-19 evening. Branch **`feat/exercise-reports`**.
+The #135 report channel is installed, working, and **has already paid for
+itself**: six reports came back from one gym session and four defects are now
+filed. No app code has been changed yet — this handoff is the triage, not a fix.
 
-## Do this first in the morning
+## Do this first
 
-1. Install to the phone — version is set to **1.2.0 (build 2)**. The interesting
-   part is not the feature, it is the
-   **V2→V3 schema migration against your real data**. A new `@Model` is exactly
-   the change that has crashed on-device before. The migration is additive and
-   lightweight, and the simulator's empty store proves nothing about it.
-2. If the migration is fine, file a report from a real exercise mid-workout and
-   check it survives a sync. Full end-to-end needs the Azure deploy below.
+1. **Restart Claude Code.** `infra/mcp/dist/` was rebuilt this session; the
+   report tools are not in the running server until it re-spawns. Probe:
+   `list_exercise_reports` returns six reports without a manual build first.
+2. Start on **#136** (notes) — it is the only P1 and the only data-integrity
+   item, and the user hit it twice in one session.
 
-## What landed
+## What happened
 
-**#135 — in-workout exercise reports.** A flag in the exercise card's overflow
-menu, in the active-workout toolbar, and in exercise detail. Pick a category
-chip, type a sentence, Send. Everything else — `exerciseExternalId`, workout,
-template, the set state at that moment, app and iOS version — is captured, not
-asked for. Reports mirror to Cosmos with the rest of the snapshot and are
-readable over MCP as `list_exercise_reports`, closed out with
-`resolve_exercise_report`.
+The first real workout on 1.2.0 (build 2) — Lower B, 2026-08-19 — produced six
+reports through the #135 channel. All six are still `open` in the backlog.
 
-The design decision worth remembering: **there is no target picker.** Context is
-something the app knows, not something you choose in a gym. The category chip is
-the only input, and it tells the reader which captured context matters.
+| Time | Category | Report | Outcome |
+|---|---|---|---|
+| 04:16 | bug | "What happened to the notes section on the exercises?" | **#136** |
+| 04:46 | bug | Seated Leg Curl notes gone — "3 settings for this machine" | **#136** |
+| 04:49 | formOrSetup | Split squat 10→8 reps | preference, not a defect |
+| 04:54 | swapRequest | Ab Rollout → Machine Ab Crunch; "added it to the template and it didn't stick" | evidence on **#129/#130** |
+| 04:56 | other | Want photo upload on reports | **not filed** — see below |
+| 04:59 | other | Reps should auto-fill, not need ghost-text confirmation | **#137** |
 
-**#104 — custom exercises were never pushed.** `Exercise` is the one mirrored
-type with no per-record `syncStatus`, so `hasPendingChanges` could not see it; a
-custom exercise sat unpushed until some unrelated change triggered a snapshot.
-Now signalled from the repository. The durable marker also became a pair of
-generation counters, because the old boolean was cleared unconditionally after
-the network await — a create landing mid-request was absent from the payload
-*and* had its only signal wiped.
+## The finding that matters most — #136
 
-**#94** constant-time API key compare. **#93** the three force-unwrapped
-`Calendar.date` calls.
+Two independent defects produce one symptom, and the machine settings vanish
+exactly where they are needed: standing at the machine, mid-set.
 
-## Version: 1.2.0 (build 2)
+1. **`startFromTemplate` never copies `TemplateExercise.notes`.**
+   `ActiveWorkoutViewModel.swift:247` passes `order` / `exercise` /
+   `restSeconds` and nothing else.
+2. **No UI renders or edits per-exercise notes during a workout.**
+   `ExerciseCardView.swift` has zero references to notes.
 
-Settled 2026-08-19 — the phone was on 1.1.0, and #135 is a feature, so minor.
+**Both are older than 1.2.0** — `git log -S"notes: templateExercise.notes"` and
+`git log -S"notes" -- …/ExerciseCardView.swift` are each empty, so neither line
+ever existed. Do not go looking for the commit that broke it; there isn't one.
+What changed is that the notes were previously arriving by another path (sync
+inbound / MCP inbox — `InboxApplier.swift:339` is the only writer of template
+notes) and no longer reach the session.
 
-`generate_project.py` now owns it: `APP_VERSION` and `BUILD_NUMBER` at the top,
-referenced by all three targets. **Never bump `project.pbxproj` directly** — the
-generator rewrites that file whenever a Swift file is added, silently discarding
-the bump. That is why the repo had drifted back to `1.0` despite the convention.
-Now recorded in CLAUDE.md's Key Conventions, which is always read.
+The data settles that the user's memory is right, not nostalgic:
 
-## Deployed and verified 2026-08-19
+- Lower B **2026-08-12** (`DCC20C31-…`): Trap Bar Deadlift `"Grip bar is down."`,
+  Seated Leg Curl `"Ankle 4; Seat 4; Pivot 1"` ← literally the "3 settings"
+- Lower B **2026-08-19** (`5743E0DD-…`): no notes on any exercise
+- **Upper A** template carries per-exercise notes on 7 of 9; **Lower B**
+  template has none — which is exactly why "other workouts have a notes section"
 
-Installed 1.2.0 (build 2) to the phone; **the V2→V3 migration opened the real
-store cleanly** — that was the one genuinely risky part and it is now settled.
+`SyncMapper` maps the field faithfully in both directions
+(`:33` out, `:176` in), so this is a start-path and UI gap, never a sync bug.
 
-Azure is deployed: Cosmos container `exerciseReports` (created with
-`az cosmosdb sql container create`, `throughput: null` so it shares the
-database autoscale and costs nothing), and the Functions app republished with
-`GET /api/reports`, snapshot v3, and the `resolveExerciseReport` inbox op.
+## The trap waiting in #137
 
-Verified after deploy: mirror revision advanced **352 → 353** twenty-five
-seconds after relaunch, with all 16 workouts, 5 templates and 2,319 body-weight
-entries intact.
+The reps request looks like a one-line revert of `9e2213c`. It is not.
+**Adopt-on-empty was deliberately cut** because `nil` weight already means
+bodyweight, so adopting the previous value logged 80kg for a bodyweight set.
+Reinstating naive adoption reintroduces a data-corruption bug that was already
+paid for once. The fix needs unset / explicitly-empty / entered as three
+distinct states, and the red test must cover the bodyweight case first.
+
+## Why #135's own tooling nearly hid all of this — #138
+
+`list_exercise_reports` shipped in `infra/mcp/src/` with commit `4d41c20`, but
+the MCP client runs `dist/src/server.js`, and `dist/` was a **stale build from
+before that commit** — no `reports.js`, tools absent from the advertised list.
+The feature looked shipped in the repo and did not exist in practice.
+
+Fixed with `npm run build` (exit 0). The general hazard is unfixed: nothing
+ties the running server to the committed source. This is the MCP-side analogue
+of the `generate_project.py` versioning trap already in CLAUDE.md — a build
+artifact whose staleness is invisible.
+
+## Open question, not a conclusion — #139
+
+The 2026-08-19 session has **no `completedAt`**; all 16 other synced sessions
+have one. It may be nothing — walking away without tapping Finish is ordinary,
+and this is a single occurrence. It is filed because Finish has form (#123,
+#124, #125) and `finishWorkout` gained early-return paths in `0b17105` that
+would silently no-op if `completionState` could be `.finished` on a workout
+whose `completedAt` was never persisted.
+
+Same session, unexplained: set timestamps are not monotonic with exercise order,
+and two pairs are 0.68s and 5.9s apart — not real rest periods. Either the user
+caught up at the end, or completing one set stamps its siblings. **Unresolved.**
+
+## Deliberately not filed
+
+The two feature requests from the same session are real but are not regressions,
+and filing them was not what was asked:
+
+- **Photo upload on reports** (04:56) — would let the coach judge whether a
+  machine matches the exercise description. Note it argues for *creating* a
+  custom exercise rather than reusing an ill-fitting one.
+- **Search the exercise library from the report sheet** (inside the 04:54
+  report) — the user could not name the replacement he wanted.
+
+Both are worth issues. Ask before filing.
+
+## State of the tree
+
+No app code modified this session. The only change is
+`infra/mcp/dist/` (rebuilt, and `dist/` is generated — check whether it is
+tracked before committing). Branch `feat/exercise-reports` is otherwise as the
+previous handoff left it.
+
+---
+
+# Still true from the #135 install
 
 ### The deploy-order claim in the last handoff was WRONG — and it bit
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,178 +1,148 @@
-# HANDOFF — #136 and #137 fixed, unreleased; install is the next step
+# HANDOFF — 1.4.0 is built, reviewed, and not installed
 
-Updated 2026-08-19 late evening. Branch **`feat/exercise-reports`**.
-**1.3.0 (build 4) is committed and unreleased — it is not on the phone yet.**
-Both gym-feedback fixes are in this one build; build 3 was never installed.
+Updated 2026-08-19, late. Branch **`feat/exercise-reports`**, pushed, **PR #145**.
+`main` untouched. **Version 1.4.0 (5) — not on the phone.** The device is still
+running 1.2.0 (2), so every user-visible fix below is unverified on hardware.
 
 ## Do this first
 
-1. **Install 1.3.0 (4) and do a Lower B.** The Settings footer showing
-   `1.3.0 (4)` is the proof it landed. Neither fix is verified on real hardware
-   — only by 727 unit tests and a simulator build.
-2. **#136 probe** — on Seated Leg Curl, tap ⋯ → *Add a note…* →
-   `Ankle 4; Seat 4; Pivot 1` (recovered from the 2026-08-12 session). It
-   should then appear on every future workout containing that exercise,
-   including a Lower A or an ad-hoc one.
-3. **#137 probe** — add Ab Crunch Machine mid-workout (it is still not in the
-   template — see #129/#130). Its three sets should arrive with reps already
-   filled from last session and **weight empty**. Weight staying empty is the
-   fix working, not a bug.
-4. Then resolve the three acknowledged reports, and pick from
-   "What to look at next" below.
+1. **Install 1.4.0 (5).** The Settings footer showing `1.4.0 (5)` is the proof.
+   This build carries a **schema V4 migration** — watch the first launch. If the
+   store quarantines instead of opening, that is the one serious risk in this
+   batch (see #128 below), and the fix is to reinstall from a backup.
+2. Run the four gym probes in the table below.
+3. Resolve the three acknowledged reports once the probes pass.
 
-## What #136 turned out to be
+## The probes, in the gym
 
-The issue's own proposed fix would not have worked, and the data is what
-settled it. Copying `TemplateExercise.notes` into the session is correct but
-inert here: **the Lower B template has no notes on any exercise.** The
-`"Ankle 4; Seat 4; Pivot 1"` note lived on the *2026-08-12 session*, and
-nothing in the app writes `WorkoutExercise.notes` — only `SyncMapper` and the
-MCP inbox do. It arrived from outside and died with that session. 08-05 had
-none; 08-19 had none.
+| Probe | Expected |
+|---|---|
+| **#136** Seated Leg Curl → ⋯ → *Add a note…* → `Ankle 4; Seat 4; Pivot 1` | The note appears on the card, and on **every** future workout containing that exercise, whichever template |
+| **#137** Add Ab Crunch Machine mid-workout | Its sets arrive with reps prefilled from last session and **weight empty**. Empty weight is the fix working |
+| **#144** Any Lower B exercise | A `Target 2 × 8 · 90s rest` line under the name, and last session's PREVIOUS marked orange where it missed the target |
+| **#129/#130** Finish a Lower B with Ab Crunch Machine added | The summary offers *Update Lower B?* → Review → Apply. Ab Rollout, if skipped, must **not** be offered for removal |
 
-So a session-scoped note typed at the machine would have vanished again the
-following week and produced the same report.
+## What changed, and the three things worth knowing
 
-**The note now lives on the library `Exercise`.** It describes the machine, so
-it follows the exercise into every workout whichever template that workout came
-from. Evan's words: *"if I make a new workout with the same exercise, I want the
-same note to appear with it."*
+### #136 — the issue's own fix would have done nothing
 
-- inline on `ExerciseCardView` — a note behind a tap is not read mid-set
-- edited from a **sheet**, deliberately not inline: the workout screen owns one
-  `@FocusState` keyed on `SetEntryFieldID` with a weight/reps accessory bar, and
-  a free-text field in that hierarchy would have to join or fight it
-- read-only section on `ExerciseDetailView`
-- the template→session copy is **kept** — a template note is a per-plan cue, a
-  different thing, and renders as its own line
-- `ActiveWorkoutViewModel` gained an optional `exerciseRepository`; all three
-  inits and all four construction sites pass it. **If it is nil the note is
-  written to the model and never saved** — that is the failure mode to look for
-  if a note does not stick.
+Copying `TemplateExercise.notes` into the session is correct and inert: the
+**Lower B template has no notes on any exercise**. The `"Ankle 4; Seat 4;
+Pivot 1"` note lived on the *2026-08-12 session*, and nothing in the app writes
+that field — it arrived via sync and died with the session. A session-scoped
+note typed at the machine would have vanished again a week later and produced
+the same report.
 
-### The hole this leaves — #140
+The note now lives on the library `Exercise`, per Evan: *"if I make a new
+workout with the same exercise, I want the same note to appear with it."*
 
-The note is *also* stamped onto `WorkoutExercise.notes`, on purpose. Bundled
-exercises are excluded from sync (`SyncManager:331`, `:405`) **and** from backup
-(`BackupService:7-8`), so the library note is **device-local**: lost on
-reinstall, not restored by a backup restore, invisible to the Coach and MCP.
-The workout record is the copy that travels. #140 covers carrying user data on
-bundled exercises properly, and it is a `schemaVersion` 4 change — so
-**deploy the Functions app before installing that client** (see below).
+### #128 — this project cannot version a property-only schema change
 
-## Report backlog state
+The first attempt did exactly what the issue asked — provenance fields on
+`Workout` and `WorkoutExercise` — and died with:
 
-Three reports are now **acknowledged**, not resolved — `CD42B832` (04:16) and
-`5B380FF1` (Seated Leg Curl) for #136, and `79EEC980` (04:59) for #137. The
-fixes exist but are not on the phone. Acknowledged still counts as open;
-resolve them once the install confirms them.
+```
+NSInvalidArgumentException: Duplicate version checksums detected
+```
 
-The remaining three:
+The `VersionedSchema` model lists in `AppSchema.swift` name **live Swift
+types**, so they are not frozen history. Adding a property to `Workout` changes
+what V1, V2 and V3 mean as well as V4; all four then hash identically and
+SwiftData refuses to open the store. That is a hard crash on the first launch
+after an update, not a recoverable migration failure.
 
-| Time | Category | Report | Where it goes |
-|---|---|---|---|
-| 04:49 | formOrSetup | Split squat 10→8 reps | preference, not a defect |
-| 04:54 | swapRequest | Ab Rollout → Machine Ab Crunch | evidence on **#129/#130** |
-| 04:56 | other | Photo upload on reports | **#141** |
-| 04:59 | other | Reps should auto-fill | **#137 — fixed, acknowledged** |
+**With live types, a new schema version can only differ by its model LIST.** Any
+future property-only change faces this, and the only alternatives are freezing
+copies of every affected model, or adding a new model instead.
 
-The 04:54 report is now corroborated: both the 08-05 and 08-12 Lower B sessions
-contain **Ab Crunch Machine at order 4**, and the template still does not. He
-has added it twice and it has never stuck. That is #129/#130's whole case.
+Provenance therefore lives in two new models — `WorkoutTemplateBaseline` and
+`WorkoutExerciseBaseline` — referencing the workout by plain UUID rather than a
+`@Relationship`, because a relationship means a stored property on `Workout` and
+brings the crash straight back.
 
-## What #137 turned out to be
+**The on-disk migration test caught this. The in-memory containers the rest of
+the suite uses passed the entire time.** `TemplateProvenanceMigrationTests`
+builds a genuine V3 store and reopens it through `ModelContainerFactory` — copy
+that for any future migration.
 
-Not a revert of `9e2213c`, and not really about ghost text. The hole was
-**`addExercise`**: an exercise added mid-workout gets three sets with no values
-and a ghost map that is display-only, so nothing was ever written. The other
-two creation paths already pre-wrote values (`startFromTemplate` per set index,
-`addSet` from the last previous), which is why only mid-workout additions were
-affected — and Ab Crunch Machine is added mid-workout every single session.
+Consequence for **#110**: nutrition needs **V5**, and if it adds properties
+rather than models it hits the same wall.
 
-The second example in the issue is **not a bug**: Barbell Ab Rollout set 2 with
-`reps: 10` and no weight is correct. It is a bodyweight exercise.
+### #139 — a draft in the mirror, not a broken Finish
 
-`repsDecidedByUser: Set<UUID>` is the third state — *unset* (adopt) vs
-*decided-empty* (persist nil) vs *entered* (leave alone). It is recorded in
-`updateSetReps` even when the value is unchanged, because clearing an
-already-nil field is still a decision. Completed sets are never touched.
+Workout `5743E0DD` carries `completedAt: 2026-08-19T05:02:47.955Z`. The record's
+`_ts` advanced between two reads while the phone caught up on sync, so the state
+the issue was filed from was a **mid-workout draft push**.
 
-**Reps only. Weight is never adopted**, because `weight == nil` already means
-bodyweight — that is the cut-once bug, and it stays cut. The bodyweight case is
-the first test in the file.
+`SyncManager.pushSnapshot` pushes every workout with no `completedAt` filter and
+nothing labels a draft as one, so a draft is indistinguishable from a stranded
+session. That cost an issue, a triage and a handoff entry. Filed as **#143**.
 
-Known and deliberate: `repsDecidedByUser` is transient, so a crash/resume
-re-adopts reps on untouched empty sets. Conservative for reps; it would not be
-for weight. Making it durable costs a `schemaVersion` bump and is not worth it.
+Until it is fixed: **a workout with no `completedAt` in the mirror is more
+likely a draft than a bug.** Re-read the record before filing; a moving `_ts`
+means the phone is still catching up.
 
-## Why #135's own tooling nearly hid all of this — #138
+The timestamp oddity resolved too — Seated Leg Curl (order 2) was performed
+before Split Squat (order 1), and there is no batch-completion path anywhere:
+`completedAt` is written one set at a time, in exactly two places. Pinned with
+tests.
 
-`list_exercise_reports` shipped in `infra/mcp/src/` with commit `4d41c20`, but
-the MCP client runs `dist/src/server.js`, and `dist/` was a **stale build from
-before that commit**. The feature looked shipped in the repo and did not exist
-in practice. Fixed with `npm run build`; **verified this session** — a restarted
-client returned all six reports with no manual build. The general hazard is
-unfixed: nothing ties the running server to the committed source.
+## Blocked — needs you, and I did not route around it
 
-## Open question, not a conclusion — #139
+Two actions were refused by the permission classifier:
 
-The 2026-08-19 session has **no `completedAt`**; all 16 other synced sessions
-have one. It may be nothing — walking away without tapping Finish is ordinary,
-and this is a single occurrence. It is filed because Finish has form (#123,
-#124, #125) and `finishWorkout` gained early-return paths in `0b17105` that
-would silently no-op if `completionState` could be `.finished` on a workout
-whose `completedAt` was never persisted.
+1. **Creating the Cosmos container for #140's sync half.**
+   ```bash
+   az cosmosdb sql container create \
+     --account-name cosmos-workout-prod --database-name workout-db \
+     --resource-group rg-workout-app-prod \
+     --name exerciseOverlays --partition-key-path "/id"
+   ```
+   The **backup half of #140 shipped** — a reinstall-and-restore no longer loses
+   your notes. The sync half is designed and written up on the issue but not
+   built, and **the client wire version is still 3**, so nothing was deployed
+   and the phone is unaffected. It needs its own container because
+   `reconcileContainer` deletes every id absent from the snapshot, so two
+   collections sharing `exercises` would wipe each other.
 
-Same session, unexplained: set timestamps are not monotonic with exercise order,
-and two pairs are 0.68s and 5.9s apart — not real rest periods. **Unresolved.**
+   A full `az deployment group create` is **not** the way to do it unattended:
+   `main.bicep` takes `apiKey` and `anthropicApiKey` as `@secure()` parameters,
+   and deploying without the real values breaks auth for the phone and MCP both.
 
-## The two feature requests — now filed
+2. **The Split Squat 10 → 8 template edit** over MCP (`update_template` on
+   `B83E7341-…`, exercise `4DE7A259-…`). Still unmade. #144 at least makes the
+   disagreement visible while training.
 
-- **#141 photo upload on reports** (04:56) — lets the coach judge whether a
-  machine matches the exercise description. The second half of that report is
-  the real point: it argues for *creating* a custom exercise rather than
-  reusing an ill-fitting one. Offline capture is not optional; the gym is where
-  connectivity is worst, and a report that fails because an upload failed is
-  worse than one with no photo.
-- **#142 search the library from the report sheet** (inside the 04:54 report).
-  He wrote `"Machine Ab Crunch"`; the library exercise is **"Ab Crunch
-  Machine"**. A resolved `externalId` would make a swap request actionable by
-  #129/#130 instead of a name someone has to guess at.
+## Test state
 
-## What to look at next
+| Suite | Result |
+|---|---|
+| Swift unit (`-only-testing:ClaudeLifterTests`) | **772 tests, 97 suites, exit 0** |
+| Azure Functions (jest) | **172 pass** |
+| MCP server (vitest) | **64 pass** (60 + 4 for the staleness guard) |
+| XCUITest | **not run** — flaky here; not a regression without a clean-worktree comparison |
 
-Ranked by what the field data actually supports:
+The unit suite is the hard gate: deterministic and green.
 
-1. **#129/#130 — the template never learns.** Double-corroborated now: Ab
-   Crunch Machine appears at order 4 in **both** the 08-05 and 08-12 Lower B
-   sessions and is still not in the template. He has added it at least twice
-   and it has never stuck, which is also why #137 bit him at all. This is the
-   highest-value gap in the backlog.
-2. **#117 — history edits never sync.** `WorkoutDetailView.swift:135-144`
-   writes `set.weight` straight to the model, bypassing the mutation API, so
-   the record never re-queues as `.pending`. Data integrity, and it pairs with
-   #122 which restyles the same row.
-3. **#139 — the missing `completedAt`.** Still an open question, not a
-   conclusion. See below.
-4. **#140 — bundled-exercise user data never leaves the phone.** New this
-   session, and it now has real data behind it: every note he writes on a
-   bundled exercise is device-local.
-5. **#138 — nothing ties `infra/mcp/dist/` to the committed source.** A
-   `prepare`/`postinstall` build, or a CI check that rebuilds and diffs, closes
-   it cheaply. The staleness is invisible until a tool silently does not exist.
-6. **#132 — the History tab serves a stale list** until pull-to-refresh. Small,
-   known, and annoying immediately after finishing a workout.
+## Deferred deliberately
 
-Not a defect, but he asked for it: the 04:49 report says he moved **Split Squat
-10 → 8 reps** for strength. That is a template edit (`4DE7A259-…`,
-`defaultReps: 10`) nobody has made. **Ask before writing to his template.**
+- **#130's remembered policies** (Ask/Always/Never per category) and the
+  Settings → Workout & Templates screen. They configure a behaviour nobody has
+  lived with yet; use the review flow first, then decide what to remember.
+- **"Save as new template"** for ad-hoc workouts — they have no baseline, so
+  they never reach the review card at all.
+- **Target reps and rest in #129's detection.** No UI changes either
+  mid-workout — `WorkoutExercise.restSeconds` is written once at construction
+  and never mutated — so any difference would be noise rather than intent. When
+  such a control exists, `TemplateChangeDetector` is where it plugs in.
 
-## State of the tree
+## New issues filed this session
 
-Branch `feat/exercise-reports`, four commits ahead of where the triage left it:
-`14a3a6d` (triage recorded), `2b729e4` (#136), `fc1c37e` (handoff),
-`9a9b56b` (#137 + build 4). Unpushed. `infra/mcp/dist/` is rebuilt and
-untracked.
+- **#140** bundled-exercise user data excluded from sync and backup (backup half done)
+- **#141** photo upload on exercise reports
+- **#142** search the library from the report sheet
+- **#143** the mirror cannot distinguish a draft from a finished workout
+- **#144** target reps on the workout screen + drift marker
 
 ---
 
@@ -199,7 +169,7 @@ wire version.** The same trap is waiting for whoever bumps it to v4.
 
 | Suite | Result |
 |---|---|
-| Swift unit (`-only-testing:ClaudeLifterTests`) | **727 tests, 94 suites, exit 0** (2026-08-19, with #136 + #137) |
+| Swift unit | superseded — see the current table above |
 | Azure Functions (jest) | **172 pass** |
 | MCP server (vitest) | **60 pass** |
 | XCUITest | **flaky — see below** |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,18 +1,24 @@
-# HANDOFF — #136 fixed and ready to install; #137 is next
+# HANDOFF — #136 and #137 fixed, unreleased; install is the next step
 
 Updated 2026-08-19 late evening. Branch **`feat/exercise-reports`**.
-**1.3.0 (build 3) is committed and unreleased — it is not on the phone yet.**
+**1.3.0 (build 4) is committed and unreleased — it is not on the phone yet.**
+Both gym-feedback fixes are in this one build; build 3 was never installed.
 
 ## Do this first
 
-1. **Install 1.3.0 to the phone and do a Lower B.** The Settings footer showing
-   `1.3.0 (3)` is the proof it landed. Nothing about #136 is verified on real
-   hardware yet — it is verified by 722 unit tests and a simulator build only.
-2. On the first Lower B, **add the Seated Leg Curl note by hand**: tap ⋯ →
-   *Add a note…* → `Ankle 4; Seat 4; Pivot 1` (recovered from the 2026-08-12
-   session). It should then appear on every future workout containing that
-   exercise. That is the acceptance probe for #136.
-3. Then **#137** — and read "The trap waiting in #137" below before touching it.
+1. **Install 1.3.0 (4) and do a Lower B.** The Settings footer showing
+   `1.3.0 (4)` is the proof it landed. Neither fix is verified on real hardware
+   — only by 727 unit tests and a simulator build.
+2. **#136 probe** — on Seated Leg Curl, tap ⋯ → *Add a note…* →
+   `Ankle 4; Seat 4; Pivot 1` (recovered from the 2026-08-12 session). It
+   should then appear on every future workout containing that exercise,
+   including a Lower A or an ad-hoc one.
+3. **#137 probe** — add Ab Crunch Machine mid-workout (it is still not in the
+   template — see #129/#130). Its three sets should arrive with reps already
+   filled from last session and **weight empty**. Weight staying empty is the
+   fix working, not a bug.
+4. Then resolve the three acknowledged reports, and pick from
+   "What to look at next" below.
 
 ## What #136 turned out to be
 
@@ -56,31 +62,48 @@ bundled exercises properly, and it is a `schemaVersion` 4 change — so
 
 ## Report backlog state
 
-Reports `CD42B832` (04:16) and `5B380FF1` (Seated Leg Curl) are now
-**acknowledged**, not resolved — the fix exists but is not on the phone.
-Acknowledged still counts as open. Resolve them after the install confirms it.
+Three reports are now **acknowledged**, not resolved — `CD42B832` (04:16) and
+`5B380FF1` (Seated Leg Curl) for #136, and `79EEC980` (04:59) for #137. The
+fixes exist but are not on the phone. Acknowledged still counts as open;
+resolve them once the install confirms them.
 
-The other four remain untouched and open:
+The remaining three:
 
 | Time | Category | Report | Where it goes |
 |---|---|---|---|
 | 04:49 | formOrSetup | Split squat 10→8 reps | preference, not a defect |
 | 04:54 | swapRequest | Ab Rollout → Machine Ab Crunch | evidence on **#129/#130** |
-| 04:56 | other | Photo upload on reports | **not filed** — ask first |
-| 04:59 | other | Reps should auto-fill | **#137** |
+| 04:56 | other | Photo upload on reports | **#141** |
+| 04:59 | other | Reps should auto-fill | **#137 — fixed, acknowledged** |
 
 The 04:54 report is now corroborated: both the 08-05 and 08-12 Lower B sessions
 contain **Ab Crunch Machine at order 4**, and the template still does not. He
 has added it twice and it has never stuck. That is #129/#130's whole case.
 
-## The trap waiting in #137
+## What #137 turned out to be
 
-The reps request looks like a one-line revert of `9e2213c`. It is not.
-**Adopt-on-empty was deliberately cut** because `nil` weight already means
-bodyweight, so adopting the previous value logged 80kg for a bodyweight set.
-Reinstating naive adoption reintroduces a data-corruption bug that was already
-paid for once. The fix needs unset / explicitly-empty / entered as three
-distinct states, and the red test must cover the bodyweight case first.
+Not a revert of `9e2213c`, and not really about ghost text. The hole was
+**`addExercise`**: an exercise added mid-workout gets three sets with no values
+and a ghost map that is display-only, so nothing was ever written. The other
+two creation paths already pre-wrote values (`startFromTemplate` per set index,
+`addSet` from the last previous), which is why only mid-workout additions were
+affected — and Ab Crunch Machine is added mid-workout every single session.
+
+The second example in the issue is **not a bug**: Barbell Ab Rollout set 2 with
+`reps: 10` and no weight is correct. It is a bodyweight exercise.
+
+`repsDecidedByUser: Set<UUID>` is the third state — *unset* (adopt) vs
+*decided-empty* (persist nil) vs *entered* (leave alone). It is recorded in
+`updateSetReps` even when the value is unchanged, because clearing an
+already-nil field is still a decision. Completed sets are never touched.
+
+**Reps only. Weight is never adopted**, because `weight == nil` already means
+bodyweight — that is the cut-once bug, and it stays cut. The bodyweight case is
+the first test in the file.
+
+Known and deliberate: `repsDecidedByUser` is transient, so a crash/resume
+re-adopts reps on untouched empty sets. Conservative for reps; it would not be
+for weight. Making it durable costs a `schemaVersion` bump and is not worth it.
 
 ## Why #135's own tooling nearly hid all of this — #138
 
@@ -103,22 +126,53 @@ whose `completedAt` was never persisted.
 Same session, unexplained: set timestamps are not monotonic with exercise order,
 and two pairs are 0.68s and 5.9s apart — not real rest periods. **Unresolved.**
 
-## Deliberately not filed
+## The two feature requests — now filed
 
-Both are real, both are feature requests rather than regressions, and filing
-them was not what was asked. **Ask before filing.**
+- **#141 photo upload on reports** (04:56) — lets the coach judge whether a
+  machine matches the exercise description. The second half of that report is
+  the real point: it argues for *creating* a custom exercise rather than
+  reusing an ill-fitting one. Offline capture is not optional; the gym is where
+  connectivity is worst, and a report that fails because an upload failed is
+  worse than one with no photo.
+- **#142 search the library from the report sheet** (inside the 04:54 report).
+  He wrote `"Machine Ab Crunch"`; the library exercise is **"Ab Crunch
+  Machine"**. A resolved `externalId` would make a swap request actionable by
+  #129/#130 instead of a name someone has to guess at.
 
-- **Photo upload on reports** (04:56) — would let the coach judge whether a
-  machine matches the exercise description. Note it argues for *creating* a
-  custom exercise rather than reusing an ill-fitting one.
-- **Search the exercise library from the report sheet** (inside the 04:54
-  report) — the user could not name the replacement he wanted.
+## What to look at next
+
+Ranked by what the field data actually supports:
+
+1. **#129/#130 — the template never learns.** Double-corroborated now: Ab
+   Crunch Machine appears at order 4 in **both** the 08-05 and 08-12 Lower B
+   sessions and is still not in the template. He has added it at least twice
+   and it has never stuck, which is also why #137 bit him at all. This is the
+   highest-value gap in the backlog.
+2. **#117 — history edits never sync.** `WorkoutDetailView.swift:135-144`
+   writes `set.weight` straight to the model, bypassing the mutation API, so
+   the record never re-queues as `.pending`. Data integrity, and it pairs with
+   #122 which restyles the same row.
+3. **#139 — the missing `completedAt`.** Still an open question, not a
+   conclusion. See below.
+4. **#140 — bundled-exercise user data never leaves the phone.** New this
+   session, and it now has real data behind it: every note he writes on a
+   bundled exercise is device-local.
+5. **#138 — nothing ties `infra/mcp/dist/` to the committed source.** A
+   `prepare`/`postinstall` build, or a CI check that rebuilds and diffs, closes
+   it cheaply. The staleness is invisible until a tool silently does not exist.
+6. **#132 — the History tab serves a stale list** until pull-to-refresh. Small,
+   known, and annoying immediately after finishing a workout.
+
+Not a defect, but he asked for it: the 04:49 report says he moved **Split Squat
+10 → 8 reps** for strength. That is a template edit (`4DE7A259-…`,
+`defaultReps: 10`) nobody has made. **Ask before writing to his template.**
 
 ## State of the tree
 
-Branch `feat/exercise-reports`, three commits ahead of where the triage left it:
-`14a3a6d` (triage recorded), `2b729e4` (#136 fix + version bump to 1.3.0/3).
-Unpushed. `infra/mcp/dist/` is rebuilt and untracked.
+Branch `feat/exercise-reports`, four commits ahead of where the triage left it:
+`14a3a6d` (triage recorded), `2b729e4` (#136), `fc1c37e` (handoff),
+`9a9b56b` (#137 + build 4). Unpushed. `infra/mcp/dist/` is rebuilt and
+untracked.
 
 ---
 
@@ -145,7 +199,7 @@ wire version.** The same trap is waiting for whoever bumps it to v4.
 
 | Suite | Result |
 |---|---|
-| Swift unit (`-only-testing:ClaudeLifterTests`) | **722 tests, 94 suites, exit 0** (2026-08-19, with #136) |
+| Swift unit (`-only-testing:ClaudeLifterTests`) | **727 tests, 94 suites, exit 0** (2026-08-19, with #136 + #137) |
 | Azure Functions (jest) | **172 pass** |
 | MCP server (vitest) | **60 pass** |
 | XCUITest | **flaky — see below** |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -48,22 +48,36 @@ generator rewrites that file whenever a Swift file is added, silently discarding
 the bump. That is why the repo had drifted back to `1.0` despite the convention.
 Now recorded in CLAUDE.md's Key Conventions, which is always read.
 
-## Azure deploy is required for the MCP half
+## Deployed and verified 2026-08-19
 
-The app half works offline. The MCP half does not, until:
+Installed 1.2.0 (build 2) to the phone; **the V2→V3 migration opened the real
+store cleanly** — that was the one genuinely risky part and it is now settled.
 
-- **Bicep** — new Cosmos container `exerciseReports` (`infra/modules/cosmos.bicep`)
-- **Functions** — new `GET /api/reports`, plus snapshot v3 and the new inbox op
-- **MCP server** — `npm run build` in `infra/mcp` for the two new tools
+Azure is deployed: Cosmos container `exerciseReports` (created with
+`az cosmosdb sql container create`, `throughput: null` so it shares the
+database autoscale and costs nothing), and the Functions app republished with
+`GET /api/reports`, snapshot v3, and the `resolveExerciseReport` inbox op.
 
-Until the container exists, a v3 push will report a failure for that collection
-and the client will keep retrying — it will not corrupt anything.
+Verified after deploy: mirror revision advanced **352 → 353** twenty-five
+seconds after relaunch, with all 16 workouts, 5 templates and 2,319 body-weight
+entries intact.
 
-Wire contract v3 **accepts v2 pushes on purpose**: the server deploys
-independently of the app, and a phone still on the old build knows nothing about
-reports. Reading its push as "there are no reports" would delete the whole
-backlog. Absent from the contract means untouched, not empty. So deploy order
-does not matter.
+### The deploy-order claim in the last handoff was WRONG — and it bit
+
+I wrote "deploy order does not matter." It does. The v2/v3 compatibility is
+**one-directional**:
+
+- **New server, old phone** — fine. A v2 push is accepted and simply does not
+  reconcile `exerciseReports`, so an old client cannot wipe the backlog.
+- **New phone, old server** — **400 on every push.** The phone sends
+  `schemaVersion: 3`; a server pinned to 2 rejects it outright.
+
+Installing the app before deploying the server therefore stalls sync with
+`Server error 400`. Non-destructive — records stay `.pending` and retry — but
+it looks alarming in Settings and it is entirely avoidable.
+
+**Always deploy the Functions app before installing a client that bumps the
+wire version.** The same trap is waiting for whoever bumps it to v4.
 
 ## Test state — and a correction to the previous baseline claim
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,4 +1,4 @@
-# HANDOFF — 1.5.0 is built; 1.4.1 is installed and its migration held
+# HANDOFF — 1.5.0 is installed
 
 Updated 2026-08-20. Branch **`feat/exercise-reports`**, **PR #145**. `main`
 untouched. **Version 1.4.1 (6) is on the phone** — Release build, installed
@@ -181,13 +181,18 @@ The unit suite is the hard gate: deterministic and green.
 - **#146** `acknowledged` reports read as done but count as open, and *Show
   resolved* can never do anything — no report ever reaches `resolved`. Live
   data confirms: 3 acknowledged, 3 open, **0 resolved**
+- **#148** inbox operations cannot be deleted, so failed ones accumulate forever
 - **#147** *Review Change* shows no change — the inbox approval prompt is a
   `confirmationDialog` whose whole message is an exercise **count**, so a
   one-number edit is indistinguishable from a full rewrite
 
-## 1.5.0 (7) — built, not installed
+## 1.5.0 (7) — installed 2026-08-20
 
-**#146 is fixed** and the server half is deployed. Not on the phone yet.
+**#146 is fixed**, the server half is deployed, and the build is on the phone
+(Release, launched, data intact: mirror still revision 380 with all 17 workouts,
+5 templates and 6 reports). No schema migration in this one — a plain upgrade
+install. The mirror revision did **not** advance, which is correct: nothing was
+dirty, so no push was due.
 
 - The reports list filter is now Outstanding / Open / Acknowledged / Resolved /
   All — the same vocabulary `list_exercise_reports` uses, so the phone and the
@@ -203,8 +208,14 @@ No schema change — nothing here adds a stored property. Nutrition still takes 
 
 **Litter I made:** inbox op `f4c9187b` is a validation probe with a bogus report
 id, now terminal in `failed` alongside the three July `deleteTemplate` ones. It
-will never reach the phone. There is no way to delete an inbox operation, which
-is arguably worth an issue of its own.
+will never reach the phone, and it cannot be removed — filed as **#148**.
+
+### Check when you next open the app
+
+- Reports → the filter chip top-right reads **Outstanding**, and switching it to
+  Acknowledged shows exactly the three answered reports
+- The home card reads **3 open · 3 awaiting install**, not "6 open reports"
+- Swipe a report: Resolve / Acknowledge / Reopen / Delete
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -180,6 +180,21 @@ ProactiveInsight
 ├── isRead: Bool
 └── type: InsightType (.suggestion/.warning/.encouragement)
 
+ExerciseReport  (issue #135)
+├── id: UUID
+├── createdAt: Date
+├── category: ReportCategory (.bug/.swapRequest/.wrongExercise/.dataError/.formOrSetup/.other)
+├── detail: String                    (the complaint, in the user's words)
+├── exerciseExternalId: String?       (stable free-exercise-db id — NEVER Exercise.id)
+├── exerciseName: String?             (snapshot at file time, survives a swap)
+├── suggestedReplacement: String?
+├── workoutId / workoutExerciseId / templateId: UUID?
+├── contextSummary: String?           (set state when filed — the repro nobody typed)
+├── status: ReportStatus (.open/.acknowledged/.resolved)
+├── resolution: String?
+├── appVersion / iosVersion: String?
+└── syncStatus: SyncStatus
+
 TrainingPreference
 ├── id: UUID
 ├── key: String (e.g., "exercise_order", "injury", "training_style")
@@ -507,6 +522,8 @@ Write tools (`create_template`, `update_template`, `delete_template`, `create_pr
 | `get_exercise_history` | Get historical data for a specific exercise |
 | `get_stats` | Get summary statistics (PRs, volume trends, frequency) |
 | `get_calendar` | Get workout frequency data for a date range |
+| `list_exercise_reports` | Read the complaint backlog filed from the app (#135) |
+| `resolve_exercise_report` | Close a report out through the inbox (#135) |
 | `health` | Connectivity + auth diagnostic against the Functions API |
 
 ### Configuration (Claude Code)

--- a/generate_project.py
+++ b/generate_project.py
@@ -16,6 +16,19 @@ def pbxproj_path(name):
         return f'"{name}"'
     return name
 
+# ─── Version ────────────────────────────────────────────────────────────────
+# THE place to bump the version. Editing ClaudeLifter.xcodeproj/project.pbxproj
+# directly does nothing lasting: this script regenerates that file, so a bump
+# made there is wiped the next time a Swift file is added and the generator
+# runs. Both values below are written into all three targets.
+#
+# Three-part semver, per Evan's convention: patch for fixes, minor for
+# features, major for reshapes. The Settings footer shows it, and a bump is the
+# visible confirmation that the new build actually landed on the phone — so
+# bump BOTH before every device install.
+APP_VERSION = '1.2.0'      # was 1.1.0 on device; #135 exercise reports is a feature
+BUILD_NUMBER = '2'
+
 # Collect all Swift source files
 def collect_swift_files(root_dir):
     files = []
@@ -645,7 +658,7 @@ app_settings = {
     'CODE_SIGN_STYLE': 'Automatic',
     'CODE_SIGN_ENTITLEMENTS': 'ClaudeLifter/ClaudeLifter.entitlements',
     'DEVELOPMENT_TEAM': '738XNTWZ5K',
-    'CURRENT_PROJECT_VERSION': '1',
+    'CURRENT_PROJECT_VERSION': BUILD_NUMBER,
     'GENERATE_INFOPLIST_FILE': 'YES',
     'INFOPLIST_KEY_NSHealthShareUsageDescription': '"Reads body-weight entries from Health so weights logged elsewhere appear here."',
     'INFOPLIST_KEY_NSHealthUpdateUsageDescription': '"Writes body-weight entries you log here to Health."',
@@ -654,7 +667,7 @@ app_settings = {
     'INFOPLIST_KEY_UILaunchScreen_Generation': 'YES',
     'INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad': '"UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"',
     'INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone': '"UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"',
-    'MARKETING_VERSION': '1.0',
+    'MARKETING_VERSION': APP_VERSION,
     'PRODUCT_BUNDLE_IDENTIFIER': 'com.eddelord.ClaudeLifter',
     'PRODUCT_NAME': '"$(TARGET_NAME)"',
     'SWIFT_EMIT_LOC_STRINGS': 'YES',
@@ -666,9 +679,9 @@ test_settings = {
     'BUNDLE_LOADER': '"$(TEST_HOST)"',
     'CODE_SIGN_STYLE': 'Automatic',
     'DEVELOPMENT_TEAM': '738XNTWZ5K',
-    'CURRENT_PROJECT_VERSION': '1',
+    'CURRENT_PROJECT_VERSION': BUILD_NUMBER,
     'GENERATE_INFOPLIST_FILE': 'YES',
-    'MARKETING_VERSION': '1.0',
+    'MARKETING_VERSION': APP_VERSION,
     'PRODUCT_BUNDLE_IDENTIFIER': 'com.eddelord.ClaudeLifterTests',
     'PRODUCT_NAME': '"$(TARGET_NAME)"',
     'SWIFT_EMIT_LOC_STRINGS': 'NO',
@@ -680,9 +693,9 @@ test_settings = {
 uitest_settings = {
     'CODE_SIGN_STYLE': 'Automatic',
     'DEVELOPMENT_TEAM': '738XNTWZ5K',
-    'CURRENT_PROJECT_VERSION': '1',
+    'CURRENT_PROJECT_VERSION': BUILD_NUMBER,
     'GENERATE_INFOPLIST_FILE': 'YES',
-    'MARKETING_VERSION': '1.0',
+    'MARKETING_VERSION': APP_VERSION,
     'PRODUCT_BUNDLE_IDENTIFIER': 'com.eddelord.ClaudeLifterUITests',
     'PRODUCT_NAME': '"$(TARGET_NAME)"',
     'SWIFT_EMIT_LOC_STRINGS': 'NO',

--- a/generate_project.py
+++ b/generate_project.py
@@ -26,8 +26,8 @@ def pbxproj_path(name):
 # features, major for reshapes. The Settings footer shows it, and a bump is the
 # visible confirmation that the new build actually landed on the phone — so
 # bump BOTH before every device install.
-APP_VERSION = '1.3.0'      # #136 exercise notes: visible and editable at the machine
-BUILD_NUMBER = '3'
+APP_VERSION = '1.3.0'      # gym-feedback release: #136 exercise notes, #137 reps adoption
+BUILD_NUMBER = '4'         # build 3 was never installed; #137 folded into the same version
 
 # Collect all Swift source files
 def collect_swift_files(root_dir):

--- a/generate_project.py
+++ b/generate_project.py
@@ -26,8 +26,8 @@ def pbxproj_path(name):
 # features, major for reshapes. The Settings footer shows it, and a bump is the
 # visible confirmation that the new build actually landed on the phone — so
 # bump BOTH before every device install.
-APP_VERSION = '1.2.0'      # was 1.1.0 on device; #135 exercise reports is a feature
-BUILD_NUMBER = '2'
+APP_VERSION = '1.3.0'      # #136 exercise notes: visible and editable at the machine
+BUILD_NUMBER = '3'
 
 # Collect all Swift source files
 def collect_swift_files(root_dir):

--- a/generate_project.py
+++ b/generate_project.py
@@ -26,8 +26,8 @@ def pbxproj_path(name):
 # features, major for reshapes. The Settings footer shows it, and a bump is the
 # visible confirmation that the new build actually landed on the phone — so
 # bump BOTH before every device install.
-APP_VERSION = '1.4.1'
-BUILD_NUMBER = '6'
+APP_VERSION = '1.5.0'
+BUILD_NUMBER = '7'
 
 # Collect all Swift source files
 def collect_swift_files(root_dir):

--- a/generate_project.py
+++ b/generate_project.py
@@ -26,8 +26,8 @@ def pbxproj_path(name):
 # features, major for reshapes. The Settings footer shows it, and a bump is the
 # visible confirmation that the new build actually landed on the phone — so
 # bump BOTH before every device install.
-APP_VERSION = '1.3.0'      # gym-feedback release: #136 exercise notes, #137 reps adoption
-BUILD_NUMBER = '4'         # build 3 was never installed; #137 folded into the same version
+APP_VERSION = '1.4.0'      # #117 history edits, #128 schema V4 provenance, #129/#130
+BUILD_NUMBER = '5'         # template review, #140 backup overlays, #144 target reps
 
 # Collect all Swift source files
 def collect_swift_files(root_dir):

--- a/generate_project.py
+++ b/generate_project.py
@@ -26,8 +26,8 @@ def pbxproj_path(name):
 # features, major for reshapes. The Settings footer shows it, and a bump is the
 # visible confirmation that the new build actually landed on the phone — so
 # bump BOTH before every device install.
-APP_VERSION = '1.4.0'      # #117 history edits, #128 schema V4 provenance, #129/#130
-BUILD_NUMBER = '5'         # template review, #140 backup overlays, #144 target reps
+APP_VERSION = '1.4.1'
+BUILD_NUMBER = '6'
 
 # Collect all Swift source files
 def collect_swift_files(root_dir):

--- a/infra/MCP_WRITE_PATH.md
+++ b/infra/MCP_WRITE_PATH.md
@@ -59,9 +59,10 @@ New Cosmos container `inbox`, partition key `/id`. Excluded from
 interface InboxOperation {
   id: string;              // uuid, assigned by the Function (never the client)
   createdAt: string;       // ISO 8601, server clock
-  op: "createTemplate" | "updateTemplate" | "deleteTemplate" | "createCustomExercise";
+  op: "createTemplate" | "updateTemplate" | "deleteTemplate"
+    | "createCustomExercise" | "resolveExerciseReport";
   payload: object;         // op-specific, validated at enqueue
-  requiresApproval: boolean; // server-computed: false for creates, true for update/delete
+  requiresApproval: boolean; // server-computed: true only for update/deleteTemplate
   status: "pending" | "awaitingApproval" | "applied" | "rejected" | "failed";
   appliedAt?: string;
   error?: string;          // set when status === "failed"
@@ -135,6 +136,15 @@ remains unchanged.
 // createCustomExercise input — no externalId accepted from the producer.
 { name: string, equipment?: string, primaryMuscles?: string[],
   secondaryMuscles?: string[], instructions?: string[], notes?: string }
+
+// resolveExerciseReport (issue #135) — closes out a user-filed complaint.
+// Approval-free by design: the point of the status lifecycle is that the
+// backlog can be cleared without a second confirmation, and the write is
+// trivially reversible. `status` omitted means "resolved"; "open" is REJECTED
+// at the Function — an inbox operation exists to close a report, never to
+// reopen one behind the user's back.
+{ id: string /* report UUID from list_exercise_reports */,
+  status?: "resolved" | "acknowledged", resolution?: string }
 
 // Stored createCustomExercise payload — the Function adds this canonical id:
 // "custom:<ascii-name-slug>:<inbox-operation-uuid>"
@@ -222,6 +232,8 @@ Re-enabled / new:
 | `delete_template` | Enqueues `deleteTemplate`. Requires approval. |
 | `create_program` | N × `createTemplate` in one call, all-or-nothing validation. |
 | `create_custom_exercise` | Enqueues `createCustomExercise`. Auto-applies. |
+| `list_exercise_reports` | Reads the complaint backlog mirrored by snapshot sync (`GET /api/reports`). Not an inbox operation. |
+| `resolve_exercise_report` | Enqueues `resolveExerciseReport`. Auto-applies. |
 | `list_pending_writes` | Reads back queued/applied/failed operations — closes the loop so a write can be *verified*, not assumed. |
 
 ## Out of scope

--- a/infra/functions/src/functions/inbox.ts
+++ b/infra/functions/src/functions/inbox.ts
@@ -51,6 +51,7 @@ const OPERATION_TYPES: readonly InboxOperationType[] = [
   "updateTemplate",
   "deleteTemplate",
   "createCustomExercise",
+  "resolveExerciseReport",
 ];
 
 const OPERATION_STATUSES: readonly InboxOperationStatus[] = [
@@ -264,6 +265,28 @@ function validateCreateCustomExercise(
   return null;
 }
 
+const REPORT_RESOLVE_STATUSES = ["resolved", "acknowledged"];
+
+function validateResolveExerciseReport(
+  payload: Record<string, unknown>
+): HttpResponseInit | null {
+  if (!isNonEmptyString(payload["id"])) {
+    return badRequest("Malformed payload: id must be a non-empty string");
+  }
+  const status = payload["status"];
+  if (status !== undefined && !REPORT_RESOLVE_STATUSES.includes(status as string)) {
+    // "open" is rejected along with everything else: an inbox operation
+    // exists to close a report out, never to reopen one behind the user.
+    return badRequest(
+      `Malformed payload: status must be one of ${REPORT_RESOLVE_STATUSES.join(", ")}`
+    );
+  }
+  if (!isOptionalString(payload["resolution"])) {
+    return badRequest("Malformed payload: resolution must be a string");
+  }
+  return null;
+}
+
 /**
  * Validates the complete enqueue body before Cosmos is accessed. Top-level
  * id/requiresApproval fields are deliberately not read; the Function owns
@@ -308,6 +331,9 @@ function validateEnqueueBody(
       break;
     case "createCustomExercise":
       validationError = validateCreateCustomExercise(payload);
+      break;
+    case "resolveExerciseReport":
+      validationError = validateResolveExerciseReport(payload);
       break;
   }
   if (validationError) return { ok: false, error: validationError };

--- a/infra/functions/src/functions/inbox.ts
+++ b/infra/functions/src/functions/inbox.ts
@@ -265,7 +265,11 @@ function validateCreateCustomExercise(
   return null;
 }
 
-const REPORT_RESOLVE_STATUSES = ["resolved", "acknowledged"];
+// `open` is accepted since #146: a report closed on the strength of a fix
+// that turns out to be inert has to be able to come back, or the backlog
+// quietly loses a real complaint. Reopening surfaces a complaint rather than
+// hiding one, so it stays outside the approval gate like the other two.
+const REPORT_RESOLVE_STATUSES = ["resolved", "acknowledged", "open"];
 
 function validateResolveExerciseReport(
   payload: Record<string, unknown>
@@ -275,8 +279,6 @@ function validateResolveExerciseReport(
   }
   const status = payload["status"];
   if (status !== undefined && !REPORT_RESOLVE_STATUSES.includes(status as string)) {
-    // "open" is rejected along with everything else: an inbox operation
-    // exists to close a report out, never to reopen one behind the user.
     return badRequest(
       `Malformed payload: status must be one of ${REPORT_RESOLVE_STATUSES.join(", ")}`
     );

--- a/infra/functions/src/functions/reports.ts
+++ b/infra/functions/src/functions/reports.ts
@@ -1,0 +1,108 @@
+/**
+ * Read-only exercise-report endpoint (issue #135).
+ *
+ * GET /api/reports — the complaint backlog the phone has filed, filterable by
+ *   status, category, and exercise. Defaults to everything not yet resolved,
+ *   because that is the question worth asking almost every time.
+ *
+ * Reports reach Cosmos through snapshot sync like any other phone-owned
+ * collection; nothing writes them here. They are closed out through the inbox
+ * (`resolveExerciseReport`), which the phone drains — a direct write to the
+ * mirror would be erased by the next snapshot push.
+ */
+
+import {
+  app,
+  HttpRequest,
+  HttpResponseInit,
+  InvocationContext,
+} from "@azure/functions";
+import { authenticate } from "../shared/auth";
+import { getDatabase } from "../shared/cosmos";
+import { parseLimit } from "../shared/readHelpers";
+import { ExerciseReport, ExerciseReportListResponse } from "../shared/types";
+
+const CONTAINER = "exerciseReports";
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+const STATUSES = ["open", "acknowledged", "resolved"];
+
+function badRequest(message: string): HttpResponseInit {
+  return { status: 400, jsonBody: { error: message } };
+}
+
+app.http("reportsList", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  route: "reports",
+  handler: async (
+    request: HttpRequest,
+    context: InvocationContext
+  ): Promise<HttpResponseInit> => {
+    const authError = authenticate(request);
+    if (authError) return authError;
+
+    const status = request.query.get("status") ?? undefined;
+    if (status !== undefined && status !== "all" && !STATUSES.includes(status)) {
+      return badRequest(
+        `Unknown status: ${status}. Expected one of ${STATUSES.join(", ")}, or "all".`
+      );
+    }
+    const category = request.query.get("category") ?? undefined;
+    const exerciseExternalId =
+      request.query.get("exerciseExternalId") ?? undefined;
+    const limit = parseLimit(request, {
+      defaultValue: DEFAULT_LIMIT,
+      max: MAX_LIMIT,
+    });
+    if (!limit.ok) return limit.error;
+
+    const conditions: string[] = [];
+    const parameters: { name: string; value: string | number }[] = [];
+
+    if (status === undefined) {
+      // The useful default: acknowledged reports are still outstanding work,
+      // so "not resolved" is the backlog — not "status = open".
+      conditions.push("c.status != @resolved");
+      parameters.push({ name: "@resolved", value: "resolved" });
+    } else if (status !== "all") {
+      conditions.push("c.status = @status");
+      parameters.push({ name: "@status", value: status });
+    }
+    if (category !== undefined) {
+      conditions.push("c.category = @category");
+      parameters.push({ name: "@category", value: category });
+    }
+    if (exerciseExternalId !== undefined) {
+      conditions.push("c.exerciseExternalId = @exerciseExternalId");
+      parameters.push({
+        name: "@exerciseExternalId",
+        value: exerciseExternalId,
+      });
+    }
+    const where =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    parameters.push({ name: "@limit", value: limit.value });
+
+    try {
+      const { resources } = await getDatabase()
+        .container(CONTAINER)
+        .items.query({
+          query:
+            `SELECT * FROM c ${where} ORDER BY c.createdAt DESC ` +
+            `OFFSET 0 LIMIT @limit`,
+          parameters,
+        })
+        .fetchAll();
+
+      const response: ExerciseReportListResponse = {
+        reports: resources as ExerciseReport[],
+      };
+      return { jsonBody: response };
+    } catch (error) {
+      context.error("Report list failed:", error);
+      return { status: 500, jsonBody: { error: "Failed to list reports" } };
+    }
+  },
+});

--- a/infra/functions/src/functions/syncSnapshot.ts
+++ b/infra/functions/src/functions/syncSnapshot.ts
@@ -39,7 +39,7 @@ import { authenticate } from "../shared/auth";
 import { getDatabase } from "../shared/cosmos";
 import { readItemOrNull } from "../shared/readHelpers";
 import {
-  SNAPSHOT_SCHEMA_VERSION,
+  SUPPORTED_SNAPSHOT_SCHEMA_VERSIONS,
   SnapshotCollections,
   SnapshotContainerCounts,
   SnapshotCounts,
@@ -50,15 +50,38 @@ import {
 } from "../shared/types";
 
 /** Snapshot collection → Cosmos container mapping. */
-const SNAPSHOT_COLLECTIONS: {
+interface SnapshotCollectionMapping {
   field: keyof SnapshotCollections;
   container: string;
-}[] = [
+}
+
+const V2_COLLECTIONS: SnapshotCollectionMapping[] = [
   { field: "workouts", container: "workouts" },
   { field: "templates", container: "templates" },
   { field: "customExercises", container: "exercises" },
   { field: "bodyWeightEntries", container: "bodyWeightEntries" },
 ];
+
+const V3_COLLECTIONS: SnapshotCollectionMapping[] = [
+  ...V2_COLLECTIONS,
+  { field: "exerciseReports", container: "exerciseReports" },
+];
+
+/**
+ * Which collections a push of a given schemaVersion reconciles.
+ *
+ * A v2 client does not know reports exist, so its push must NOT be read as
+ * "there are no reports" — that would delete the whole container on the next
+ * sync from a phone still on the old build. Absent from the contract means
+ * untouched, not empty. Only a v3 push reconciles `exerciseReports`.
+ */
+const SNAPSHOT_COLLECTIONS_BY_VERSION: Record<number, SnapshotCollectionMapping[]> = {
+  2: V2_COLLECTIONS,
+  3: V3_COLLECTIONS,
+};
+
+/** Every container a read/restore should return, regardless of push version. */
+const SNAPSHOT_COLLECTIONS = V3_COLLECTIONS;
 
 const SYNC_META_CONTAINER = "syncMeta";
 const SYNC_META_ID = "snapshot";
@@ -93,17 +116,18 @@ function validateBody(body: SnapshotPushRequest): HttpResponseInit | null {
   if (body === null || typeof body !== "object") {
     return badRequest("Malformed body: expected a JSON object");
   }
-  if (body.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+  const collections = SNAPSHOT_COLLECTIONS_BY_VERSION[body.schemaVersion];
+  if (!collections) {
     return badRequest(
       `Unsupported schemaVersion: ${JSON.stringify(body.schemaVersion)}. ` +
-        `Expected ${SNAPSHOT_SCHEMA_VERSION}.`
+        `Expected one of ${SUPPORTED_SNAPSHOT_SCHEMA_VERSIONS.join(", ")}.`
     );
   }
   const snapshot = body.snapshot;
   if (snapshot === null || typeof snapshot !== "object") {
     return badRequest("Malformed body: missing snapshot object");
   }
-  for (const { field } of SNAPSHOT_COLLECTIONS) {
+  for (const { field } of collections) {
     const docs = snapshot[field];
     if (!Array.isArray(docs)) {
       // A missing array is NOT treated as "empty" — an empty array is an
@@ -252,10 +276,12 @@ app.http("syncSnapshotPush", {
     const counts = {} as SnapshotCounts;
 
     try {
-      for (const { field, container } of SNAPSHOT_COLLECTIONS) {
+      for (const { field, container } of SNAPSHOT_COLLECTIONS_BY_VERSION[
+        body.schemaVersion
+      ]) {
         counts[field] = await reconcileContainer(
           container,
-          body.snapshot[field],
+          body.snapshot[field] ?? [],
           failures
         );
       }

--- a/infra/functions/src/functions/syncSnapshot.ts
+++ b/infra/functions/src/functions/syncSnapshot.ts
@@ -67,6 +67,11 @@ const V3_COLLECTIONS: SnapshotCollectionMapping[] = [
   { field: "exerciseReports", container: "exerciseReports" },
 ];
 
+const V4_COLLECTIONS: SnapshotCollectionMapping[] = [
+  ...V3_COLLECTIONS,
+  { field: "exerciseOverlays", container: "exerciseOverlays" },
+];
+
 /**
  * Which collections a push of a given schemaVersion reconciles.
  *
@@ -78,10 +83,11 @@ const V3_COLLECTIONS: SnapshotCollectionMapping[] = [
 const SNAPSHOT_COLLECTIONS_BY_VERSION: Record<number, SnapshotCollectionMapping[]> = {
   2: V2_COLLECTIONS,
   3: V3_COLLECTIONS,
+  4: V4_COLLECTIONS,
 };
 
 /** Every container a read/restore should return, regardless of push version. */
-const SNAPSHOT_COLLECTIONS = V3_COLLECTIONS;
+const SNAPSHOT_COLLECTIONS = V4_COLLECTIONS;
 
 const SYNC_META_CONTAINER = "syncMeta";
 const SYNC_META_ID = "snapshot";

--- a/infra/functions/src/shared/auth.ts
+++ b/infra/functions/src/shared/auth.ts
@@ -1,4 +1,5 @@
 import { HttpRequest, HttpResponseInit } from "@azure/functions";
+import { secretsMatch } from "./secretCompare";
 
 /**
  * Validates the x-api-key header against the API_KEY environment variable.
@@ -14,7 +15,7 @@ export function authenticate(request: HttpRequest): HttpResponseInit | null {
   }
 
   const providedKey = request.headers.get("x-api-key");
-  if (!providedKey || providedKey !== apiKey) {
+  if (!providedKey || !secretsMatch(providedKey, apiKey)) {
     return {
       status: 401,
       jsonBody: { error: "Unauthorized: invalid or missing API key" },

--- a/infra/functions/src/shared/secretCompare.ts
+++ b/infra/functions/src/shared/secretCompare.ts
@@ -1,0 +1,24 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time comparison of two secrets (#94).
+ *
+ * `timingSafeEqual` throws on a length mismatch, so lengths are checked
+ * first and mismatches return early. That leaks the expected key's length,
+ * which is not worth protecting: the value is high-entropy, and an attacker
+ * who learns its length still has to guess it. What this does remove is the
+ * byte-by-byte early exit of `===`, which leaks how much of a guess was
+ * correct.
+ *
+ * Defence in depth rather than a live hole — a remote timing attack across
+ * network jitter is impractical (see the issue's own severity note).
+ *
+ * Lives in its own module because `shared/auth` is globally stubbed in the
+ * Jest config, so nothing inside it can be tested directly.
+ */
+export function secretsMatch(provided: string, expected: string): boolean {
+  const providedBuffer = Buffer.from(provided, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}

--- a/infra/functions/src/shared/types.ts
+++ b/infra/functions/src/shared/types.ts
@@ -37,17 +37,26 @@ export interface SyncPushResponse {
   results: SyncPushRecordResult[];
 }
 
-// ─── Snapshot sync (issue #78, wire contract v2) ─────────────────────────────
+// ─── Snapshot sync (issue #78, wire contract v2/v3) ──────────────────────────
 // The phone is authoritative; Azure is a read-mostly mirror. A push is always
 // the complete state of each collection — full-state replace, not deltas.
+//
+// v3 (issue #135) adds `exerciseReports`. v2 is still ACCEPTED: the server is
+// deployed independently of the app, so a v2 push from a phone that has not
+// updated yet must keep working. A v2 push simply does not mention reports,
+// and reconciliation therefore leaves that container alone rather than
+// wiping it — see SNAPSHOT_COLLECTIONS_BY_VERSION in syncSnapshot.ts.
 
-export const SNAPSHOT_SCHEMA_VERSION = 2;
+export const SNAPSHOT_SCHEMA_VERSION = 3;
+export const SUPPORTED_SNAPSHOT_SCHEMA_VERSIONS = [2, 3] as const;
 
 export interface SnapshotCollections {
   workouts: Record<string, unknown>[];
   templates: Record<string, unknown>[];
   customExercises: Record<string, unknown>[];
   bodyWeightEntries: Record<string, unknown>[];
+  /** Present only on schemaVersion 3 pushes. */
+  exerciseReports?: Record<string, unknown>[];
 }
 
 export interface SnapshotPushRequest {
@@ -65,6 +74,7 @@ export interface SnapshotCounts {
   templates: SnapshotContainerCounts;
   customExercises: SnapshotContainerCounts;
   bodyWeightEntries: SnapshotContainerCounts;
+  exerciseReports?: SnapshotContainerCounts;
 }
 
 export interface SnapshotPushResponse {
@@ -99,7 +109,8 @@ export type InboxOperationType =
   | "createTemplate"
   | "updateTemplate"
   | "deleteTemplate"
-  | "createCustomExercise";
+  | "createCustomExercise"
+  | "resolveExerciseReport";
 
 export type InboxOperationStatus =
   | "pending"
@@ -147,11 +158,24 @@ export interface CreateCustomExercisePayload {
   notes?: string;
 }
 
+/**
+ * Closes out a user-filed report (issue #135). Deliberately approval-free:
+ * the point of the status lifecycle is that the backlog can be cleared
+ * without a second confirmation, and the write is trivially reversible.
+ */
+export interface ResolveExerciseReportPayload {
+  id: string;
+  /** "resolved" (default) or "acknowledged". Reopening is not an operation. */
+  status?: "resolved" | "acknowledged";
+  resolution?: string;
+}
+
 export type InboxOperationPayload =
   | CreateTemplatePayload
   | UpdateTemplatePayload
   | DeleteTemplatePayload
-  | CreateCustomExercisePayload;
+  | CreateCustomExercisePayload
+  | ResolveExerciseReportPayload;
 
 export interface InboxOperation {
   id: string;
@@ -168,7 +192,8 @@ export type InboxEnqueueRequest =
   | { op: "createTemplate"; payload: CreateTemplatePayload }
   | { op: "updateTemplate"; payload: UpdateTemplatePayload }
   | { op: "deleteTemplate"; payload: DeleteTemplatePayload }
-  | { op: "createCustomExercise"; payload: CreateCustomExercisePayload };
+  | { op: "createCustomExercise"; payload: CreateCustomExercisePayload }
+  | { op: "resolveExerciseReport"; payload: ResolveExerciseReportPayload };
 
 export type InboxEnqueueResponse = InboxOperation;
 
@@ -358,4 +383,36 @@ export interface CalendarEntry {
   workoutCount: number;
   totalSets: number;
   totalVolume: number;
+}
+
+// ─── Exercise reports (issue #135) ──────────────────────────────────────────
+// User-filed complaints, mirrored from the phone by snapshot sync so the MCP
+// server can read the backlog. Exercises are referenced by `externalId` —
+// never by the per-install `Exercise.id` UUID (infra/MCP_WRITE_PATH.md).
+
+export type ExerciseReportStatus = "open" | "acknowledged" | "resolved";
+
+export interface ExerciseReport {
+  id: string;
+  createdAt: string;
+  /** bug | swapRequest | wrongExercise | dataError | formOrSetup | other. */
+  category: string;
+  detail: string;
+  exerciseExternalId?: string | null;
+  exerciseName?: string | null;
+  suggestedReplacement?: string | null;
+  workoutId?: string | null;
+  workoutExerciseId?: string | null;
+  templateId?: string | null;
+  contextSummary?: string | null;
+  status: string;
+  resolution?: string | null;
+  appVersion?: string | null;
+  iosVersion?: string | null;
+  photoURL?: string | null;
+  lastModified: string;
+}
+
+export interface ExerciseReportListResponse {
+  reports: ExerciseReport[];
 }

--- a/infra/functions/src/shared/types.ts
+++ b/infra/functions/src/shared/types.ts
@@ -41,14 +41,15 @@ export interface SyncPushResponse {
 // The phone is authoritative; Azure is a read-mostly mirror. A push is always
 // the complete state of each collection — full-state replace, not deltas.
 //
-// v3 (issue #135) adds `exerciseReports`. v2 is still ACCEPTED: the server is
+// v4 (issue #140) adds `exerciseOverlays`. v3 (issue #135) adds
+// `exerciseReports`. Every earlier version is still ACCEPTED: the server is
 // deployed independently of the app, so a v2 push from a phone that has not
 // updated yet must keep working. A v2 push simply does not mention reports,
 // and reconciliation therefore leaves that container alone rather than
 // wiping it — see SNAPSHOT_COLLECTIONS_BY_VERSION in syncSnapshot.ts.
 
-export const SNAPSHOT_SCHEMA_VERSION = 3;
-export const SUPPORTED_SNAPSHOT_SCHEMA_VERSIONS = [2, 3] as const;
+export const SNAPSHOT_SCHEMA_VERSION = 4;
+export const SUPPORTED_SNAPSHOT_SCHEMA_VERSIONS = [2, 3, 4] as const;
 
 export interface SnapshotCollections {
   workouts: Record<string, unknown>[];
@@ -57,6 +58,13 @@ export interface SnapshotCollections {
   bodyWeightEntries: Record<string, unknown>[];
   /** Present only on schemaVersion 3 pushes. */
   exerciseReports?: Record<string, unknown>[];
+  /**
+   * Present only on schemaVersion 4 pushes. User data layered onto *bundled*
+   * exercises — machine notes and photos. Keyed by the free-exercise-db
+   * `externalId`, NOT the local UUID: a reinstall mints fresh UUIDs for the
+   * same exercise, so a UUID key would strand every overlay (#140).
+   */
+  exerciseOverlays?: Record<string, unknown>[];
 }
 
 export interface SnapshotPushRequest {
@@ -75,6 +83,7 @@ export interface SnapshotCounts {
   customExercises: SnapshotContainerCounts;
   bodyWeightEntries: SnapshotContainerCounts;
   exerciseReports?: SnapshotContainerCounts;
+  exerciseOverlays?: SnapshotContainerCounts;
 }
 
 export interface SnapshotPushResponse {

--- a/infra/functions/tests/inbox.test.ts
+++ b/infra/functions/tests/inbox.test.ts
@@ -871,10 +871,25 @@ describe("POST /api/inbox — resolveExerciseReport (#135)", () => {
     expect(response.status).toBe(400);
   });
 
-  test("rejects reopening a report", async () => {
+  // Inverted by #146. Reopening was refused on the grounds that the inbox
+  // exists to close reports, not to reopen them behind the user. The case that
+  // changed it: #136 was acknowledged, its fix shipped, and the fix was inert
+  // — a real complaint had left the backlog with no way back.
+  test("accepts reopening a report that was closed too early", async () => {
     const response = await enqueue({
       op: "resolveExerciseReport",
       payload: { id: "8f2a0b0c-1111-4222-8333-444455556666", status: "open" },
+    });
+
+    // A successful enqueue omits an explicit status; 200 is the default.
+    expect(response.status ?? 200).toBe(200);
+    expect((response.jsonBody as { op: string }).op).toBe("resolveExerciseReport");
+  });
+
+  test("still rejects a status outside the lifecycle", async () => {
+    const response = await enqueue({
+      op: "resolveExerciseReport",
+      payload: { id: "8f2a0b0c-1111-4222-8333-444455556666", status: "wontfix" },
     });
 
     expect(response.status).toBe(400);

--- a/infra/functions/tests/inbox.test.ts
+++ b/infra/functions/tests/inbox.test.ts
@@ -832,3 +832,61 @@ describe("POST /api/inbox/ack — an illegal transition must not poison the batc
     );
   });
 });
+
+describe("POST /api/inbox — resolveExerciseReport (#135)", () => {
+  test("enqueues a valid resolve without requiring approval", async () => {
+    const response = await enqueue({
+      op: "resolveExerciseReport",
+      payload: {
+        id: "8f2a0b0c-1111-4222-8333-444455556666",
+        status: "resolved",
+        resolution: "Filed as #140",
+      },
+    });
+
+    expect(isOk(response.status)).toBe(true);
+    const operation = response.jsonBody as Doc;
+    expect(operation["op"]).toBe("resolveExerciseReport");
+    // Closing out a report is trivially reversible; a second confirmation
+    // step would defeat the point of letting the AI clear the backlog.
+    expect(operation["requiresApproval"]).toBe(false);
+    expect(operation["status"]).toBe("pending");
+  });
+
+  test("accepts a resolve with no status (server default applies on the phone)", async () => {
+    const response = await enqueue({
+      op: "resolveExerciseReport",
+      payload: { id: "8f2a0b0c-1111-4222-8333-444455556666" },
+    });
+
+    expect(isOk(response.status)).toBe(true);
+  });
+
+  test("rejects a resolve without an id", async () => {
+    const response = await enqueue({
+      op: "resolveExerciseReport",
+      payload: { resolution: "done" },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  test("rejects reopening a report", async () => {
+    const response = await enqueue({
+      op: "resolveExerciseReport",
+      payload: { id: "8f2a0b0c-1111-4222-8333-444455556666", status: "open" },
+    });
+
+    expect(response.status).toBe(400);
+    expect((response.jsonBody as { error: string }).error).toContain("status");
+  });
+
+  test("rejects a non-string resolution", async () => {
+    const response = await enqueue({
+      op: "resolveExerciseReport",
+      payload: { id: "8f2a0b0c-1111-4222-8333-444455556666", resolution: 42 },
+    });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/infra/functions/tests/reportsRead.test.ts
+++ b/infra/functions/tests/reportsRead.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the exercise-report read endpoint — issue #135.
+ *
+ * GET /api/reports — the complaint backlog the phone filed, filterable.
+ */
+
+import { app, HttpRequest, InvocationContext } from "@azure/functions";
+import { authenticate } from "../src/shared/auth";
+import { mockItems, mockFetchAll, resetCosmosDb } from "./__mocks__/cosmos";
+import "../src/functions/reports";
+
+const mockApp = app as unknown as { http: jest.Mock };
+const mockAuthenticate = authenticate as jest.Mock;
+
+type Handler = (
+  req: unknown,
+  ctx: InvocationContext
+) => Promise<{ status?: number; jsonBody?: unknown }>;
+
+function findHandler(name: string): Handler {
+  const call = mockApp.http.mock.calls.find(([n]: [string]) => n === name);
+  if (!call) throw new Error(`${name} handler was not registered with app.http()`);
+  return call[1].handler;
+}
+
+function findRegistration(name: string): Record<string, unknown> {
+  const call = mockApp.http.mock.calls.find(([n]: [string]) => n === name);
+  if (!call) throw new Error(`${name} was not registered with app.http()`);
+  return call[1];
+}
+
+function makeRequest(options?: { query?: Record<string, string> }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new (HttpRequest as any)(undefined, { "x-api-key": "test-key" }, options);
+}
+
+function lastQuery(): { query: string; parameters: { name: string; value: unknown }[] } {
+  const call = mockItems.query.mock.calls.at(-1);
+  if (!call) throw new Error("No Cosmos query was issued");
+  return call[0];
+}
+
+const sampleReport = {
+  id: "r-1",
+  createdAt: "2026-08-18T10:00:00Z",
+  category: "wrongExercise",
+  detail: "This is really the iso-lateral press",
+  exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip",
+  exerciseName: "Barbell Bench Press",
+  suggestedReplacement: "Hammer Strength Iso-Lateral Press",
+  status: "open",
+  lastModified: "2026-08-18T10:00:00Z",
+};
+
+beforeEach(() => {
+  mockItems.query.mockClear();
+  mockFetchAll.mockClear();
+  resetCosmosDb();
+  mockAuthenticate.mockReturnValue(null);
+});
+
+describe("GET /api/reports", () => {
+  test("registers with GET method and reports route", () => {
+    const reg = findRegistration("reportsList");
+    expect(reg.methods).toEqual(["GET"]);
+    expect(reg.route).toBe("reports");
+  });
+
+  test("requires authentication", async () => {
+    mockAuthenticate.mockReturnValue({ status: 401, jsonBody: { error: "no" } });
+    const res = await findHandler("reportsList")(
+      makeRequest(),
+      new InvocationContext()
+    );
+    expect(res.status).toBe(401);
+    expect(mockItems.query).not.toHaveBeenCalled();
+  });
+
+  test("returns the reports newest-first", async () => {
+    mockFetchAll.mockResolvedValue({ resources: [sampleReport] });
+
+    const res = await findHandler("reportsList")(
+      makeRequest(),
+      new InvocationContext()
+    );
+
+    expect(res.status ?? 200).toBe(200);
+    expect((res.jsonBody as { reports: unknown[] }).reports).toEqual([sampleReport]);
+    expect(lastQuery().query).toContain("ORDER BY c.createdAt DESC");
+  });
+
+  test("defaults to everything not yet resolved, not just status=open", async () => {
+    // Acknowledged reports are still outstanding work — dropping them would
+    // make the default view lie about the size of the backlog.
+    await findHandler("reportsList")(makeRequest(), new InvocationContext());
+
+    const { query, parameters } = lastQuery();
+    expect(query).toContain("c.status != @resolved");
+    expect(parameters).toContainEqual({ name: "@resolved", value: "resolved" });
+  });
+
+  test("filters by status, category, and exercise together", async () => {
+    await findHandler("reportsList")(
+      makeRequest({
+        query: {
+          status: "acknowledged",
+          category: "bug",
+          exerciseExternalId: "squat",
+        },
+      }),
+      new InvocationContext()
+    );
+
+    const { query, parameters } = lastQuery();
+    expect(query).toContain("c.status = @status");
+    expect(query).toContain("c.category = @category");
+    expect(query).toContain("c.exerciseExternalId = @exerciseExternalId");
+    expect(parameters).toContainEqual({ name: "@status", value: "acknowledged" });
+    expect(parameters).toContainEqual({ name: "@category", value: "bug" });
+    expect(parameters).toContainEqual({
+      name: "@exerciseExternalId",
+      value: "squat",
+    });
+  });
+
+  test("status=all drops the status filter entirely", async () => {
+    await findHandler("reportsList")(
+      makeRequest({ query: { status: "all" } }),
+      new InvocationContext()
+    );
+
+    const { query } = lastQuery();
+    expect(query).not.toContain("c.status");
+  });
+
+  test("rejects an unknown status without querying", async () => {
+    const res = await findHandler("reportsList")(
+      makeRequest({ query: { status: "closed" } }),
+      new InvocationContext()
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockItems.query).not.toHaveBeenCalled();
+  });
+
+  test("caps the limit", async () => {
+    await findHandler("reportsList")(
+      makeRequest({ query: { limit: "9000" } }),
+      new InvocationContext()
+    );
+
+    expect(lastQuery().parameters).toContainEqual({ name: "@limit", value: 500 });
+  });
+
+  test("returns 500 when Cosmos fails", async () => {
+    mockFetchAll.mockRejectedValue(new Error("cosmos down"));
+
+    const res = await findHandler("reportsList")(
+      makeRequest(),
+      new InvocationContext()
+    );
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/infra/functions/tests/secretCompare.test.ts
+++ b/infra/functions/tests/secretCompare.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for constant-time secret comparison — issue #94.
+ *
+ * These pin the behaviour, not the timing: timing cannot be asserted
+ * reliably in a unit test, and a test that tried would be flaky theatre.
+ */
+
+import { secretsMatch } from "../src/shared/secretCompare";
+
+describe("secretsMatch", () => {
+  test("accepts an exact match", () => {
+    expect(secretsMatch("s3cret-key-value", "s3cret-key-value")).toBe(true);
+  });
+
+  test("rejects a wrong key of the same length", () => {
+    expect(secretsMatch("s3cret-key-valuf", "s3cret-key-value")).toBe(false);
+  });
+
+  test("rejects a different length without throwing", () => {
+    // timingSafeEqual throws on mismatched buffer lengths — without the
+    // length guard, a short key would turn auth into a 500 instead of a 401.
+    expect(() => secretsMatch("short", "s3cret-key-value")).not.toThrow();
+    expect(secretsMatch("short", "s3cret-key-value")).toBe(false);
+  });
+
+  test("rejects a prefix of the real key", () => {
+    expect(secretsMatch("s3cret", "s3cret-key-value")).toBe(false);
+  });
+
+  test("rejects the empty string", () => {
+    expect(secretsMatch("", "s3cret-key-value")).toBe(false);
+  });
+
+  test("compares by bytes, not code units", () => {
+    // Multi-byte characters must not confuse the length guard.
+    expect(secretsMatch("kéy", "kéy")).toBe(true);
+    expect(secretsMatch("key", "kéy")).toBe(false);
+  });
+});

--- a/infra/functions/tests/syncSnapshot.test.ts
+++ b/infra/functions/tests/syncSnapshot.test.ts
@@ -592,12 +592,97 @@ describe("GET /api/sync/snapshot", () => {
     const body = res.jsonBody as ReadResponseBody;
     expect(body.revision).toBe(0);
     expect(Number.isNaN(Date.parse(body.serverTime))).toBe(false);
-    expect(body.snapshot).toEqual(emptySnapshot());
+    // A read always returns every mirrored collection, including the ones a
+    // v2 push never mentions.
+    expect(body.snapshot).toEqual({ ...emptySnapshot(), exerciseReports: [] });
   });
 
   test("returns 500 when a container read fails", async () => {
     container("templates").failQuery = true;
     const res = await read();
     expect(res.status).toBe(500);
+  });
+});
+
+// ─── Wire contract v3: exercise reports (issue #135) ─────────────────────────
+
+describe("schemaVersion 3 — exerciseReports", () => {
+  function v3Body(reports: Doc[], partial?: Record<string, Doc[]>) {
+    return {
+      schemaVersion: 3,
+      snapshot: { ...emptySnapshot(), ...partial, exerciseReports: reports },
+    };
+  }
+
+  test("reconciles the exerciseReports container like any other collection", async () => {
+    const reports = container("exerciseReports");
+    reports.seed({ id: "r-old" });
+    seedMeta(4);
+
+    const res = await push(v3Body([{ id: "r-1" }, { id: "r-2" }]));
+
+    expect(res.status ?? 200).toBe(200);
+    expect(reports.ids()).toEqual(["r-1", "r-2"]);
+    const counts = (res.jsonBody as { counts: Record<string, unknown> }).counts;
+    expect(counts["exerciseReports"]).toEqual({ upserted: 2, deleted: 1 });
+  });
+
+  test("rejects a v3 push that omits exerciseReports with 400", async () => {
+    const res = await push({ schemaVersion: 3, snapshot: emptySnapshot() });
+    expect(res.status).toBe(400);
+    expect(mockDatabase.container).not.toHaveBeenCalled();
+  });
+
+  test("an empty array wipes the reports container", async () => {
+    const reports = container("exerciseReports");
+    reports.seed({ id: "r-1" }, { id: "r-2" });
+
+    const res = await push(v3Body([]));
+
+    expect(res.status ?? 200).toBe(200);
+    expect(reports.ids()).toEqual([]);
+  });
+
+  test("a v2 push leaves existing reports alone instead of wiping them", async () => {
+    // The server deploys independently of the app. A phone still on the old
+    // build knows nothing about reports — reading its push as "there are no
+    // reports" would silently delete the whole backlog.
+    const reports = container("exerciseReports");
+    reports.seed({ id: "r-1" }, { id: "r-2" });
+
+    const res = await push(pushBody());
+
+    expect(res.status ?? 200).toBe(200);
+    expect(reports.ids()).toEqual(["r-1", "r-2"]);
+    expect(requestedContainerNames).not.toContain("exerciseReports");
+  });
+
+  test("rejects a v3 push whose exerciseReports is not an array", async () => {
+    const res = await push({
+      schemaVersion: 3,
+      snapshot: { ...emptySnapshot(), exerciseReports: { id: "r-1" } },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects an unsupported schemaVersion listing the ones accepted", async () => {
+    const res = await push({ schemaVersion: 4, snapshot: emptySnapshot() });
+    expect(res.status).toBe(400);
+    const body = res.jsonBody as { error: string };
+    expect(body.error).toContain("2, 3");
+  });
+
+  test("GET returns reports so a restore can rebuild them", async () => {
+    seedMeta(7);
+    container("exerciseReports").seed({ id: "r-1", detail: "mislabeled" });
+
+    const res = await read();
+
+    const body = res.jsonBody as {
+      snapshot: Record<string, Doc[]>;
+    };
+    expect(body.snapshot["exerciseReports"]).toEqual([
+      { id: "r-1", detail: "mislabeled" },
+    ]);
   });
 });

--- a/infra/functions/tests/syncSnapshot.test.ts
+++ b/infra/functions/tests/syncSnapshot.test.ts
@@ -594,7 +594,11 @@ describe("GET /api/sync/snapshot", () => {
     expect(Number.isNaN(Date.parse(body.serverTime))).toBe(false);
     // A read always returns every mirrored collection, including the ones a
     // v2 push never mentions.
-    expect(body.snapshot).toEqual({ ...emptySnapshot(), exerciseReports: [] });
+    expect(body.snapshot).toEqual({
+      ...emptySnapshot(),
+      exerciseReports: [],
+      exerciseOverlays: [],
+    });
   });
 
   test("returns 500 when a container read fails", async () => {
@@ -666,10 +670,10 @@ describe("schemaVersion 3 — exerciseReports", () => {
   });
 
   test("rejects an unsupported schemaVersion listing the ones accepted", async () => {
-    const res = await push({ schemaVersion: 4, snapshot: emptySnapshot() });
+    const res = await push({ schemaVersion: 9, snapshot: emptySnapshot() });
     expect(res.status).toBe(400);
     const body = res.jsonBody as { error: string };
-    expect(body.error).toContain("2, 3");
+    expect(body.error).toContain("2, 3, 4");
   });
 
   test("GET returns reports so a restore can rebuild them", async () => {
@@ -683,6 +687,125 @@ describe("schemaVersion 3 — exerciseReports", () => {
     };
     expect(body.snapshot["exerciseReports"]).toEqual([
       { id: "r-1", detail: "mislabeled" },
+    ]);
+  });
+});
+
+// ─── schemaVersion 4 — exerciseOverlays (issue #140) ─────────────────────────
+// User data added to *bundled* exercises: machine notes and photos. These
+// never reached the mirror at all, because only `isCustom` exercises were
+// synced — so a note typed at the machine died with the install.
+describe("schemaVersion 4 — exerciseOverlays", () => {
+  function v4Body(
+    overlays: Doc[],
+    partial: Record<string, Doc[]> = {}
+  ): Record<string, unknown> {
+    return {
+      schemaVersion: 4,
+      snapshot: {
+        ...emptySnapshot(),
+        ...partial,
+        exerciseReports: [],
+        exerciseOverlays: overlays,
+      },
+    };
+  }
+
+  test("reconciles the exerciseOverlays container like any other collection", async () => {
+    const overlays = container("exerciseOverlays");
+    overlays.seed({ id: "Barbell_Squat" });
+    seedMeta(11);
+
+    const res = await push(
+      v4Body([
+        { id: "Barbell_Bench_Press", notes: "seat 4" },
+        { id: "Leg_Curl", notes: "pin 7" },
+      ])
+    );
+
+    expect(res.status ?? 200).toBe(200);
+    expect(overlays.ids()).toEqual(["Barbell_Bench_Press", "Leg_Curl"]);
+    const counts = (res.jsonBody as { counts: Record<string, unknown> }).counts;
+    expect(counts["exerciseOverlays"]).toEqual({ upserted: 2, deleted: 1 });
+  });
+
+  test("a v4 push still reconciles every earlier collection", async () => {
+    const reports = container("exerciseReports");
+    reports.seed({ id: "r-old" });
+
+    const res = await push(v4Body([]));
+
+    expect(res.status ?? 200).toBe(200);
+    expect(reports.ids()).toEqual([]);
+  });
+
+  test("rejects a v4 push that omits exerciseOverlays with 400", async () => {
+    const res = await push({
+      schemaVersion: 4,
+      snapshot: { ...emptySnapshot(), exerciseReports: [] },
+    });
+    expect(res.status).toBe(400);
+    expect(mockDatabase.container).not.toHaveBeenCalled();
+  });
+
+  test("an empty array wipes the overlays container", async () => {
+    const overlays = container("exerciseOverlays");
+    overlays.seed({ id: "Barbell_Squat" }, { id: "Leg_Curl" });
+
+    const res = await push(v4Body([]));
+
+    expect(res.status ?? 200).toBe(200);
+    expect(overlays.ids()).toEqual([]);
+  });
+
+  test("a v3 push leaves existing overlays alone instead of wiping them", async () => {
+    // The same trap #135 set: a phone on the previous build does not know
+    // overlays exist, and its silence must not read as "the user deleted
+    // every machine note".
+    const overlays = container("exerciseOverlays");
+    overlays.seed({ id: "Barbell_Squat", notes: "safety bars at 3" });
+
+    const res = await push({
+      schemaVersion: 3,
+      snapshot: { ...emptySnapshot(), exerciseReports: [] },
+    });
+
+    expect(res.status ?? 200).toBe(200);
+    expect(overlays.ids()).toEqual(["Barbell_Squat"]);
+    expect(requestedContainerNames).not.toContain("exerciseOverlays");
+  });
+
+  test("a v2 push leaves overlays alone too", async () => {
+    const overlays = container("exerciseOverlays");
+    overlays.seed({ id: "Barbell_Squat" });
+
+    const res = await push(pushBody());
+
+    expect(res.status ?? 200).toBe(200);
+    expect(overlays.ids()).toEqual(["Barbell_Squat"]);
+  });
+
+  test("rejects a v4 push whose exerciseOverlays is not an array", async () => {
+    const res = await push({
+      schemaVersion: 4,
+      snapshot: {
+        ...emptySnapshot(),
+        exerciseReports: [],
+        exerciseOverlays: { id: "Leg_Curl" },
+      },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("GET returns overlays so a restore can rebuild them", async () => {
+    seedMeta(12);
+    container("exerciseOverlays").seed({ id: "Leg_Curl", notes: "pin 7" });
+
+    const res = await read();
+
+    const body = res.jsonBody as { snapshot: Record<string, Doc[]> };
+    expect(body.snapshot["exerciseOverlays"]).toEqual([
+      { id: "Leg_Curl", notes: "pin 7" },
     ]);
   });
 });

--- a/infra/mcp/README.md
+++ b/infra/mcp/README.md
@@ -44,6 +44,8 @@ slim build-time catalog before any write request is sent.
 | `delete_template` | Enqueue a template deletion for approval |
 | `create_program` | Validate all templates, then enqueue each |
 | `create_custom_exercise` | Enqueue a custom exercise |
+| `list_exercise_reports` | Read the complaint backlog filed from the app (defaults to unresolved) |
+| `resolve_exercise_report` | Enqueue a close-out for one report (`resolved` / `acknowledged`) |
 | `list_pending_writes` | List inbox operations by status |
 | `health` | Diagnostic: Functions API connectivity + auth status + base URL |
 
@@ -132,6 +134,7 @@ except health:
 | `/api/stats` | `startDate`, `endDate` (scan capped at 500 most recent workouts) |
 | `/api/calendar` | `startDate`, `endDate` (both required) |
 | `/api/sync/snapshot` | supplies `snapshot.customExercises` for catalog search |
+| `/api/reports` | `status` (open/acknowledged/resolved/all), `category`, `exerciseExternalId`, `limit` (default 100, max 500) |
 | `/api/inbox` | `GET ?status=` lists operations; `POST` enqueues one |
 | `/api/health` | — (anonymous) |
 

--- a/infra/mcp/package.json
+++ b/infra/mcp/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "main": "dist/src/server.js",
   "scripts": {
-    "build": "node scripts/build-catalog.mjs && tsc",
+    "build": "node scripts/build-catalog.mjs && tsc && node scripts/build-stamp.mjs",
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "pretest": "node scripts/build-catalog.mjs",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"

--- a/infra/mcp/scripts/build-stamp.mjs
+++ b/infra/mcp/scripts/build-stamp.mjs
@@ -1,0 +1,62 @@
+/**
+ * Records what the compiled server was built from — issue #138.
+ *
+ * `dist/` is gitignored and the server is launched as `node dist/src/server.js`,
+ * which runs no npm lifecycle script. So nothing ties the running server to the
+ * committed source, and a stale `dist/` is invisible: #135's report tools
+ * shipped in `src/` and simply did not exist in the running server.
+ *
+ * This writes the git HEAD and the newest source mtime at build time.
+ * `buildInfo()` compares that against the live source tree, and `health()`
+ * reports it — so `mcp__workout__health` answers "is this the committed
+ * source?" instead of nobody asking.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The compiled copy — tsc has already run by this point in `npm run build`,
+// so the stamp and the runtime check use literally the same code.
+import { newestSourceMtime } from "../dist/src/shared/source-mtime.js";
+
+const outputUrl = new URL("../dist/build-info.json", import.meta.url);
+const repoRoot = new URL("../../../", import.meta.url);
+
+function gitHead() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: fileURLToPath(repoRoot),
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    // A build outside a git checkout is legitimate; the mtime check still works.
+    return null;
+  }
+}
+
+function gitDirty() {
+  try {
+    const out = execFileSync("git", ["status", "--porcelain", "--", "infra/mcp/src"], {
+      cwd: fileURLToPath(repoRoot),
+      encoding: "utf8",
+    });
+    return out.trim().length > 0;
+  } catch {
+    return null;
+  }
+}
+
+const info = {
+  builtAt: new Date().toISOString(),
+  gitHead: gitHead(),
+  sourceDirtyAtBuild: gitDirty(),
+  newestSourceMtimeMs: await newestSourceMtime(),
+};
+
+await mkdir(dirname(fileURLToPath(outputUrl)), { recursive: true });
+await writeFile(fileURLToPath(outputUrl), JSON.stringify(info, null, 2) + "\n");
+console.error(
+  `build-stamp: ${info.gitHead ?? "(no git)"}${info.sourceDirtyAtBuild ? " (dirty)" : ""}`
+);

--- a/infra/mcp/src/registry.ts
+++ b/infra/mcp/src/registry.ts
@@ -280,25 +280,34 @@ export const TOOLS = [
   {
     name: "resolve_exercise_report",
     description:
-      "Close out a report once it has been dealt with, so it leaves the " +
-      "backlog. Use status 'acknowledged' when the work is known but not " +
-      "done (an issue was filed), 'resolved' when it is finished. Enqueues " +
-      "an inbox operation — the report is closed when the phone next syncs.",
+      "Set a report's status, so the backlog reflects reality. Use " +
+      "'acknowledged' when the work is known but not done (an issue was " +
+      "filed, or a fix is written but not installed), 'resolved' when it is " +
+      "finished, and 'open' to reopen one that was closed too early — a fix " +
+      "that turns out not to work must be able to come back. Pass 'ids' to " +
+      "answer several at once. Enqueues inbox operations: the change lands " +
+      "when the phone next syncs.",
     inputSchema: {
       type: "object" as const,
       properties: {
-        id: { type: "string", description: "Report UUID" },
+        id: { type: "string", description: "Report UUID. Use this or ids." },
+        ids: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Several report UUIDs, all set to the same status. Every id is " +
+            "validated before any is enqueued.",
+        },
         status: {
           type: "string",
-          enum: ["resolved", "acknowledged"],
-          description: "Defaults to resolved. Reports cannot be reopened here.",
+          enum: ["resolved", "acknowledged", "open"],
+          description: "Defaults to resolved",
         },
         resolution: {
           type: "string",
           description: "What was done — shown next to the report in the app",
         },
       },
-      required: ["id"],
     },
   },
   {

--- a/infra/mcp/src/registry.ts
+++ b/infra/mcp/src/registry.ts
@@ -7,6 +7,10 @@ import { getStats, getCalendar } from "./tools/stats.js";
 import { health } from "./tools/health.js";
 import { searchExercises } from "./tools/catalog.js";
 import {
+  listExerciseReports,
+  resolveExerciseReport,
+} from "./tools/reports.js";
+import {
   createCustomExercise,
   createProgram,
   createTemplate,
@@ -237,6 +241,67 @@ export const TOOLS = [
     },
   },
   {
+    name: "list_exercise_reports",
+    description:
+      "Read the complaint backlog filed from the app: mislabeled exercises, " +
+      "swap requests, app bugs, bad data. Each report carries the context " +
+      "captured when it was filed (exercise externalId, workout, set state, " +
+      "app version). Defaults to everything not yet resolved.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        status: {
+          type: "string",
+          enum: ["open", "acknowledged", "resolved", "all"],
+          description: "Defaults to open + acknowledged (the live backlog)",
+        },
+        category: {
+          type: "string",
+          enum: [
+            "bug",
+            "swapRequest",
+            "wrongExercise",
+            "dataError",
+            "formOrSetup",
+            "other",
+          ],
+        },
+        exerciseExternalId: {
+          type: "string",
+          description: "Filter to reports about one exercise",
+        },
+        limit: {
+          type: "number",
+          description: "Max results (default: 100, capped at 500)",
+        },
+      },
+    },
+  },
+  {
+    name: "resolve_exercise_report",
+    description:
+      "Close out a report once it has been dealt with, so it leaves the " +
+      "backlog. Use status 'acknowledged' when the work is known but not " +
+      "done (an issue was filed), 'resolved' when it is finished. Enqueues " +
+      "an inbox operation — the report is closed when the phone next syncs.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "string", description: "Report UUID" },
+        status: {
+          type: "string",
+          enum: ["resolved", "acknowledged"],
+          description: "Defaults to resolved. Reports cannot be reopened here.",
+        },
+        resolution: {
+          type: "string",
+          description: "What was done — shown next to the report in the app",
+        },
+      },
+      required: ["id"],
+    },
+  },
+  {
     name: "list_pending_writes",
     description:
       "List inbox operations by status, including failures and their errors",
@@ -371,6 +436,19 @@ export async function handleToolCall(
 
       case "create_custom_exercise":
         return textResult(await createCustomExercise(args));
+
+      case "list_exercise_reports":
+        return textResult(
+          await listExerciseReports({
+            status: optionalString(args, "status"),
+            category: optionalString(args, "category"),
+            exerciseExternalId: optionalString(args, "exerciseExternalId"),
+            limit: optionalNumber(args, "limit"),
+          })
+        );
+
+      case "resolve_exercise_report":
+        return textResult(await resolveExerciseReport(args));
 
       case "list_pending_writes":
         return textResult(

--- a/infra/mcp/src/server.ts
+++ b/infra/mcp/src/server.ts
@@ -17,6 +17,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { TOOLS, handleToolCall } from "./registry.js";
+import { buildFreshness } from "./shared/build-info.js";
 
 const server = new Server(
   { name: "workout", version: "2.0.0" },
@@ -36,6 +37,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function main() {
+  // #138: warn on stderr before serving a single request. This is the only
+  // check that runs on the real launch path — `node dist/src/server.js` runs
+  // no npm lifecycle script, and dist/ is gitignored so CI has nothing to
+  // diff. Warn rather than exit: a stale server that still answers is far
+  // better than an MCP client that cannot start at all, and the warning is
+  // visible in the client's server log.
+  const freshness = await buildFreshness();
+  if (freshness.stale) {
+    console.error(`workout-mcp: STALE BUILD — ${freshness.staleReason}`);
+  }
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/infra/mcp/src/shared/build-info.ts
+++ b/infra/mcp/src/shared/build-info.ts
@@ -1,0 +1,84 @@
+/**
+ * Is the running server the committed source? — issue #138.
+ *
+ * `dist/` is gitignored, so there is nothing to diff in CI, and the launch
+ * command (`node dist/src/server.js`) runs no npm script. The only place a
+ * stale build can be caught is at runtime, in the process that is actually
+ * serving. #135's report tools existed in `src/` and were absent from the
+ * running server for a whole day because nobody could see the difference.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { newestSourceMtime } from "./source-mtime.js";
+
+export interface BuildInfo {
+  builtAt: string | null;
+  gitHead: string | null;
+  sourceDirtyAtBuild: boolean | null;
+  newestSourceMtimeMs: number | null;
+}
+
+export interface BuildFreshness extends BuildInfo {
+  /** True when source has been touched since the build that is running. */
+  stale: boolean;
+  /** Human-readable reason, or null when the build is current. */
+  staleReason: string | null;
+}
+
+function infoPath(): string | null {
+  const candidates = [
+    // Compiled runtime: dist/src/shared/build-info.js -> dist/build-info.json
+    new URL("../../build-info.json", import.meta.url),
+    // Vitest source runtime: src/shared/build-info.ts -> dist/build-info.json
+    new URL("../../dist/build-info.json", import.meta.url),
+  ];
+  const found = candidates.find((c) => existsSync(fileURLToPath(c)));
+  return found ? fileURLToPath(found) : null;
+}
+
+export function readBuildInfo(): BuildInfo | null {
+  const path = infoPath();
+  if (!path) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as BuildInfo;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildFreshness(): Promise<BuildFreshness> {
+  const info = readBuildInfo();
+  if (!info) {
+    return {
+      builtAt: null,
+      gitHead: null,
+      sourceDirtyAtBuild: null,
+      newestSourceMtimeMs: null,
+      stale: true,
+      staleReason:
+        "No dist/build-info.json — this server was built before the staleness " +
+        "guard existed, or dist/ is incomplete. Run npm run build in infra/mcp.",
+    };
+  }
+
+  const newest = await newestSourceMtime();
+  const builtFrom = info.newestSourceMtimeMs ?? 0;
+  // One second of slack: mtimes have coarse granularity on some filesystems,
+  // and a build touching its own inputs should not report itself stale.
+  if (newest > builtFrom + 1000) {
+    const drift = Math.round((newest - builtFrom) / 1000);
+    return {
+      ...info,
+      stale: true,
+      staleReason:
+        `Source has changed since this build (newest source is ${drift}s ` +
+        `newer than what dist/ was built from). The running server does not ` +
+        `include those changes. Run npm run build in infra/mcp and restart ` +
+        `the MCP client.`,
+    };
+  }
+
+  return { ...info, stale: false, staleReason: null };
+}

--- a/infra/mcp/src/shared/source-mtime.ts
+++ b/infra/mcp/src/shared/source-mtime.ts
@@ -1,0 +1,53 @@
+/**
+ * Newest mtime across everything the compiled server is built from (#138).
+ *
+ * TypeScript rather than a plain .mjs so `tsc` actually emits it into `dist/` —
+ * a `.mjs` here compiles fine and then is silently absent at runtime, which is
+ * the same invisible-staleness failure this guard exists to catch.
+ *
+ * The build stamper imports the *compiled* copy of this module, so the mtime
+ * recorded at build time and the mtime checked at runtime come from one
+ * definition and cannot drift apart.
+ *
+ * Covers `src/` and the exercise catalog, which feeds `dist/catalog-index.json`
+ * and is just as capable of going stale.
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+function sourceRoots(): string[] {
+  // Resolved relative to this module, which sits at either
+  // src/shared/source-mtime.ts or dist/src/shared/source-mtime.js — both are
+  // two levels below the package root.
+  const packageRoot = new URL("../../", import.meta.url);
+  const fromDist = new URL("../../../", import.meta.url);
+  const roots = [
+    new URL("src", packageRoot),
+    new URL("src", fromDist),
+    new URL("../../ClaudeLifter/Resources/exercises.json", packageRoot),
+    new URL("../../../ClaudeLifter/Resources/exercises.json", fromDist),
+  ];
+  return roots.map((url) => fileURLToPath(url).replace(/\/$/, ""));
+}
+
+async function newestUnder(path: string): Promise<number> {
+  let info;
+  try {
+    info = await stat(path);
+  } catch {
+    return 0;
+  }
+  if (!info.isDirectory()) return info.mtimeMs;
+
+  const entries = await readdir(path, { withFileTypes: true });
+  const times = await Promise.all(
+    entries.map((entry) => newestUnder(`${path}/${entry.name}`))
+  );
+  return times.reduce((max, t) => (t > max ? t : max), 0);
+}
+
+export async function newestSourceMtime(): Promise<number> {
+  const times = await Promise.all(sourceRoots().map(newestUnder));
+  return times.reduce((max, t) => (t > max ? t : max), 0);
+}

--- a/infra/mcp/src/tools/health.ts
+++ b/infra/mcp/src/tools/health.ts
@@ -7,6 +7,7 @@
  */
 
 import { apiGet, ApiError } from "../shared/http.js";
+import { buildFreshness } from "../shared/build-info.js";
 
 export interface HealthReport {
   baseUrl: string;
@@ -15,6 +16,13 @@ export interface HealthReport {
   server?: { status: string; timestamp: string; version: string };
   authValid?: boolean;
   error?: string;
+  /** What this running server was built from, and whether it is current (#138). */
+  build?: {
+    builtAt: string | null;
+    gitHead: string | null;
+    stale: boolean;
+    staleReason: string | null;
+  };
 }
 
 function messageOf(err: unknown): string {
@@ -31,6 +39,17 @@ export async function health(): Promise<HealthReport> {
       : "(FUNCTIONS_BASE_URL not set)",
     apiKeyConfigured,
     reachable: false,
+  };
+
+  // Reported before the connectivity checks so it is answered even when the
+  // API is unreachable — "is the server stale?" is a question about this
+  // process, not about Azure.
+  const freshness = await buildFreshness();
+  report.build = {
+    builtAt: freshness.builtAt,
+    gitHead: freshness.gitHead,
+    stale: freshness.stale,
+    staleReason: freshness.staleReason,
   };
 
   if (!baseUrlRaw || !apiKeyConfigured) {

--- a/infra/mcp/src/tools/reports.ts
+++ b/infra/mcp/src/tools/reports.ts
@@ -1,0 +1,127 @@
+/**
+ * Exercise-report tools (issue #135).
+ *
+ * `list_exercise_reports` reads the complaint backlog the phone filed;
+ * `resolve_exercise_report` closes one out through the durable inbox. Both go
+ * through the Functions API — the mirror is a projection of the phone, so a
+ * direct write would be erased by the next snapshot push.
+ */
+
+import { apiGet, apiPost } from "../shared/http.js";
+
+export type ExerciseReportStatus = "open" | "acknowledged" | "resolved";
+
+export interface ExerciseReport {
+  id: string;
+  createdAt: string;
+  category: string;
+  detail: string;
+  exerciseExternalId?: string | null;
+  exerciseName?: string | null;
+  suggestedReplacement?: string | null;
+  workoutId?: string | null;
+  workoutExerciseId?: string | null;
+  templateId?: string | null;
+  contextSummary?: string | null;
+  status: string;
+  resolution?: string | null;
+  appVersion?: string | null;
+  iosVersion?: string | null;
+  photoURL?: string | null;
+  lastModified: string;
+}
+
+export interface InboxOperation {
+  id: string;
+  createdAt: string;
+  op: string;
+  payload: Record<string, unknown>;
+  requiresApproval: boolean;
+  status: string;
+}
+
+const LIST_STATUSES: readonly string[] = [
+  "open",
+  "acknowledged",
+  "resolved",
+  "all",
+];
+
+const CATEGORIES: readonly string[] = [
+  "bug",
+  "swapRequest",
+  "wrongExercise",
+  "dataError",
+  "formOrSetup",
+  "other",
+];
+
+const RESOLVE_STATUSES: readonly string[] = ["resolved", "acknowledged"];
+
+export async function listExerciseReports(
+  options: {
+    status?: string;
+    category?: string;
+    exerciseExternalId?: string;
+    limit?: number;
+  } = {}
+): Promise<ExerciseReport[]> {
+  if (options.status !== undefined && !LIST_STATUSES.includes(options.status)) {
+    throw new Error(
+      `Unknown report status: ${options.status}. ` +
+        `Expected one of ${LIST_STATUSES.join(", ")}.`
+    );
+  }
+  if (
+    options.category !== undefined &&
+    !CATEGORIES.includes(options.category)
+  ) {
+    throw new Error(
+      `Unknown report category: ${options.category}. ` +
+        `Expected one of ${CATEGORIES.join(", ")}.`
+    );
+  }
+
+  const { reports } = await apiGet<{ reports: ExerciseReport[] }>("reports", {
+    status: options.status,
+    category: options.category,
+    exerciseExternalId: options.exerciseExternalId,
+    limit: options.limit,
+  });
+  return reports;
+}
+
+/**
+ * Enqueues the close-out. The report is not actually closed until the phone
+ * next syncs and drains the inbox — this returns the queued operation, not a
+ * finished write, and saying otherwise would be a lie about a durable queue.
+ */
+export async function resolveExerciseReport(
+  args: unknown
+): Promise<InboxOperation> {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+    throw new Error("Arguments must be an object");
+  }
+  const input = args as Record<string, unknown>;
+
+  const id = input["id"];
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new Error("id must be a non-empty string");
+  }
+  const status = input["status"];
+  if (status !== undefined && !RESOLVE_STATUSES.includes(status as string)) {
+    throw new Error(
+      `status must be one of ${RESOLVE_STATUSES.join(", ")} — ` +
+        "a report cannot be reopened from here"
+    );
+  }
+  const resolution = input["resolution"];
+  if (resolution !== undefined && typeof resolution !== "string") {
+    throw new Error("resolution must be a string");
+  }
+
+  return apiPost<InboxOperation>("inbox", {
+    op: "resolveExerciseReport",
+    payload: { id, status, resolution },
+  });
+}

--- a/infra/mcp/src/tools/reports.ts
+++ b/infra/mcp/src/tools/reports.ts
@@ -56,7 +56,14 @@ const CATEGORIES: readonly string[] = [
   "other",
 ];
 
-const RESOLVE_STATUSES: readonly string[] = ["resolved", "acknowledged"];
+/// Every status the write path will set, reopening included (#146).
+///
+/// `open` was refused here until a real case forced the question: #136 was
+/// acknowledged, its fix shipped, and the fix turned out to be inert. With no
+/// route back, a genuine complaint had left the backlog permanently. Reopening
+/// is also the safe direction — it surfaces a complaint rather than hiding
+/// one, so it needs no approval gate.
+const RESOLVE_STATUSES: readonly string[] = ["resolved", "acknowledged", "open"];
 
 export async function listExerciseReports(
   options: {
@@ -92,27 +99,51 @@ export async function listExerciseReports(
 }
 
 /**
- * Enqueues the close-out. The report is not actually closed until the phone
- * next syncs and drains the inbox — this returns the queued operation, not a
- * finished write, and saying otherwise would be a lie about a durable queue.
+ * Sets a report's status through the durable inbox. The report is not actually
+ * changed until the phone next syncs and drains the inbox — this returns the
+ * queued operation(s), not a finished write, and saying otherwise would be a
+ * lie about a durable queue.
+ *
+ * Takes either `id` (returns one operation) or `ids` (returns an array, one
+ * per report). Closing out a gym session means answering several reports at
+ * once, and one call each is several round trips plus several chances to lose
+ * track of which are done.
+ *
+ * Every id is validated before any of them is enqueued: a batch that half
+ * applies is worse than one that is refused.
  */
 export async function resolveExerciseReport(
   args: unknown
-): Promise<InboxOperation> {
+): Promise<InboxOperation | InboxOperation[]> {
   if (args === null || typeof args !== "object" || Array.isArray(args)) {
     throw new Error("Arguments must be an object");
   }
   const input = args as Record<string, unknown>;
 
-  const id = input["id"];
-  if (typeof id !== "string" || id.trim().length === 0) {
-    throw new Error("id must be a non-empty string");
+  const rawId = input["id"];
+  const rawIds = input["ids"];
+  if (rawId !== undefined && rawIds !== undefined) {
+    throw new Error("Pass either id or ids, not both");
   }
+
+  const isBatch = rawIds !== undefined;
+  if (isBatch && !Array.isArray(rawIds)) {
+    throw new Error("ids must be an array of report UUIDs");
+  }
+  const ids = isBatch ? (rawIds as unknown[]) : [rawId];
+  if (ids.length === 0) {
+    throw new Error("ids must contain at least one report UUID");
+  }
+  for (const candidate of ids) {
+    if (typeof candidate !== "string" || candidate.trim().length === 0) {
+      throw new Error("id must be a non-empty string");
+    }
+  }
+
   const status = input["status"];
   if (status !== undefined && !RESOLVE_STATUSES.includes(status as string)) {
     throw new Error(
-      `status must be one of ${RESOLVE_STATUSES.join(", ")} — ` +
-        "a report cannot be reopened from here"
+      `status must be one of ${RESOLVE_STATUSES.join(", ")}`
     );
   }
   const resolution = input["resolution"];
@@ -120,8 +151,14 @@ export async function resolveExerciseReport(
     throw new Error("resolution must be a string");
   }
 
-  return apiPost<InboxOperation>("inbox", {
-    op: "resolveExerciseReport",
-    payload: { id, status, resolution },
-  });
+  const operations: InboxOperation[] = [];
+  for (const id of ids as string[]) {
+    operations.push(
+      await apiPost<InboxOperation>("inbox", {
+        op: "resolveExerciseReport",
+        payload: { id, status, resolution },
+      })
+    );
+  }
+  return isBatch ? operations : operations[0];
 }

--- a/infra/mcp/tests/buildInfo.test.ts
+++ b/infra/mcp/tests/buildInfo.test.ts
@@ -1,0 +1,55 @@
+/**
+ * #138 — the guard that answers "is the running server the committed source?"
+ *
+ * These assert the property that actually failed in practice: a build that is
+ * older than its source must report itself stale. A guard that never fires is
+ * indistinguishable from no guard, which is what we had.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync, utimesSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { readBuildInfo, buildFreshness } from "../src/shared/build-info.js";
+import { newestSourceMtime } from "../src/shared/source-mtime.js";
+
+const buildInfoPath = fileURLToPath(
+  new URL("../dist/build-info.json", import.meta.url)
+);
+
+describe("build info", () => {
+  it("is written by the build", () => {
+    expect(existsSync(buildInfoPath)).toBe(true);
+    const info = readBuildInfo();
+    expect(info).not.toBeNull();
+    expect(info?.builtAt).toBeTruthy();
+  });
+
+  it("sees the source tree", async () => {
+    const newest = await newestSourceMtime();
+    expect(newest).toBeGreaterThan(0);
+  });
+
+  it("reports stale when a source file is newer than the build", async () => {
+    // Push one source file into the future rather than rebuilding — the
+    // assertion is about the comparison, and this leaves dist/ alone.
+    const target = fileURLToPath(new URL("../src/registry.ts", import.meta.url));
+    const original = statSync(target);
+    const future = new Date(Date.now() + 60_000);
+    try {
+      utimesSync(target, future, future);
+      const freshness = await buildFreshness();
+      expect(freshness.stale).toBe(true);
+      expect(freshness.staleReason).toMatch(/npm run build/);
+    } finally {
+      utimesSync(target, original.atime, original.mtime);
+    }
+  });
+
+  it("reports fresh for a build newer than every source file", async () => {
+    const freshness = await buildFreshness();
+    // The suite runs against a just-built dist/; if this fails, run npm run build.
+    expect(freshness.stale).toBe(false);
+    expect(freshness.staleReason).toBeNull();
+  });
+});

--- a/infra/mcp/tests/registry.test.ts
+++ b/infra/mcp/tests/registry.test.ts
@@ -33,9 +33,11 @@ describe("tool listing", () => {
         "get_template",
         "get_workout",
         "health",
+        "list_exercise_reports",
         "list_pending_writes",
         "list_templates",
         "list_workouts",
+        "resolve_exercise_report",
         "search_exercises",
         "update_template",
       ].sort()

--- a/infra/mcp/tests/reports.test.ts
+++ b/infra/mcp/tests/reports.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the exercise-report tools — issue #135.
+ * Thin wrappers over the Functions API: a read and a durable inbox write.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockApiGet = vi.fn();
+const mockApiPost = vi.fn();
+
+vi.mock("../src/shared/http.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/shared/http.js")>();
+  return { ...actual, apiGet: mockApiGet, apiPost: mockApiPost };
+});
+
+const { listExerciseReports, resolveExerciseReport } = await import(
+  "../src/tools/reports.js"
+);
+
+const sampleReport = {
+  id: "r-1",
+  createdAt: "2026-08-18T10:00:00Z",
+  category: "wrongExercise",
+  detail: "This is really the iso-lateral press",
+  exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip",
+  exerciseName: "Barbell Bench Press",
+  suggestedReplacement: "Hammer Strength Iso-Lateral Press",
+  status: "open",
+  lastModified: "2026-08-18T10:00:00Z",
+};
+
+beforeEach(() => {
+  mockApiGet.mockReset();
+  mockApiPost.mockReset();
+});
+
+describe("listExerciseReports", () => {
+  it("returns the backlog and forwards every filter", async () => {
+    mockApiGet.mockResolvedValue({ reports: [sampleReport] });
+
+    const reports = await listExerciseReports({
+      status: "open",
+      category: "wrongExercise",
+      exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip",
+      limit: 25,
+    });
+
+    expect(reports).toEqual([sampleReport]);
+    expect(mockApiGet).toHaveBeenCalledWith("reports", {
+      status: "open",
+      category: "wrongExercise",
+      exerciseExternalId: "Barbell_Bench_Press_-_Medium_Grip",
+      limit: 25,
+    });
+  });
+
+  it("sends no status by default, letting the server pick the live backlog", async () => {
+    mockApiGet.mockResolvedValue({ reports: [] });
+
+    await listExerciseReports();
+
+    expect(mockApiGet).toHaveBeenCalledWith("reports", {
+      status: undefined,
+      category: undefined,
+      exerciseExternalId: undefined,
+      limit: undefined,
+    });
+  });
+
+  it("rejects an unknown status without calling the API", async () => {
+    await expect(listExerciseReports({ status: "closed" })).rejects.toThrow(
+      /Unknown report status/
+    );
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown category without calling the API", async () => {
+    await expect(
+      listExerciseReports({ category: "featureRequest" })
+    ).rejects.toThrow(/Unknown report category/);
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveExerciseReport", () => {
+  it("enqueues an inbox operation", async () => {
+    mockApiPost.mockResolvedValue({
+      id: "op-1",
+      op: "resolveExerciseReport",
+      status: "pending",
+      requiresApproval: false,
+    });
+
+    const operation = await resolveExerciseReport({
+      id: "r-1",
+      resolution: "Filed as #140",
+    });
+
+    expect(operation.status).toBe("pending");
+    expect(mockApiPost).toHaveBeenCalledWith("inbox", {
+      op: "resolveExerciseReport",
+      payload: { id: "r-1", status: undefined, resolution: "Filed as #140" },
+    });
+  });
+
+  it("accepts acknowledged for work that is known but not done", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-1" });
+
+    await resolveExerciseReport({ id: "r-1", status: "acknowledged" });
+
+    expect(mockApiPost).toHaveBeenCalledWith("inbox", {
+      op: "resolveExerciseReport",
+      payload: { id: "r-1", status: "acknowledged", resolution: undefined },
+    });
+  });
+
+  it("refuses to reopen a report", async () => {
+    await expect(
+      resolveExerciseReport({ id: "r-1", status: "open" })
+    ).rejects.toThrow(/cannot be reopened/);
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("requires an id", async () => {
+    await expect(resolveExerciseReport({ resolution: "done" })).rejects.toThrow(
+      /id must be a non-empty string/
+    );
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+});

--- a/infra/mcp/tests/reports.test.ts
+++ b/infra/mcp/tests/reports.test.ts
@@ -114,10 +114,88 @@ describe("resolveExerciseReport", () => {
     });
   });
 
-  it("refuses to reopen a report", async () => {
+  // Reopening was refused outright until #146. The case that changed it:
+  // #136's prescribed fix was acknowledged, shipped, and turned out to be
+  // inert. With no way back, a real complaint had left the backlog for good.
+  it("reopens a report that was closed too early", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-1" });
+
+    await resolveExerciseReport({
+      id: "r-1",
+      status: "open",
+      resolution: "Reopened — the fix did not touch this case",
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith("inbox", {
+      op: "resolveExerciseReport",
+      payload: {
+        id: "r-1",
+        status: "open",
+        resolution: "Reopened — the fix did not touch this case",
+      },
+    });
+  });
+
+  it("rejects a status that is not part of the lifecycle", async () => {
     await expect(
-      resolveExerciseReport({ id: "r-1", status: "open" })
-    ).rejects.toThrow(/cannot be reopened/);
+      resolveExerciseReport({ id: "r-1", status: "wontfix" })
+    ).rejects.toThrow(/status must be one of/);
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  // Closing out a gym session means answering several reports at once, and
+  // one call per report is three round trips plus three chances to lose track.
+  it("closes several reports in one call", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-n" });
+
+    const operations = await resolveExerciseReport({
+      ids: ["r-1", "r-2", "r-3"],
+      status: "acknowledged",
+      resolution: "All three fixed in 1.4.1",
+    });
+
+    expect(Array.isArray(operations)).toBe(true);
+    expect(operations).toHaveLength(3);
+    expect(mockApiPost).toHaveBeenCalledTimes(3);
+    expect(mockApiPost).toHaveBeenNthCalledWith(2, "inbox", {
+      op: "resolveExerciseReport",
+      payload: {
+        id: "r-2",
+        status: "acknowledged",
+        resolution: "All three fixed in 1.4.1",
+      },
+    });
+  });
+
+  it("a single id still returns one operation, not an array", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-1" });
+
+    const result = await resolveExerciseReport({ id: "r-1" });
+
+    expect(Array.isArray(result)).toBe(false);
+  });
+
+  it("rejects ids and id given together rather than guessing", async () => {
+    await expect(
+      resolveExerciseReport({ id: "r-1", ids: ["r-2"] })
+    ).rejects.toThrow(/either id or ids/);
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty ids array", async () => {
+    await expect(resolveExerciseReport({ ids: [] })).rejects.toThrow(
+      /at least one/
+    );
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("validates every id before enqueuing any of them", async () => {
+    mockApiPost.mockResolvedValue({ id: "op-1" });
+
+    await expect(
+      resolveExerciseReport({ ids: ["r-1", ""] })
+    ).rejects.toThrow(/non-empty string/);
+    // Nothing enqueued: a half-applied batch is worse than a refused one.
     expect(mockApiPost).not.toHaveBeenCalled();
   });
 

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -28,6 +28,12 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
       }
     ]
     capabilities: []
+    // Both of these already hold on the live account. They are declared here
+    // because they were not, and `what-if` therefore proposed turning them
+    // OFF on any deployment — silently weakening TLS and disabling failover
+    // as a side effect of adding a container (#140).
+    minimalTlsVersion: 'Tls12'
+    enableAutomaticFailover: true
     backupPolicy: {
       type: 'Periodic'
       // Two backup copies are free; copies = retention / interval, so keep the
@@ -97,6 +103,17 @@ var containers = [
   // from the phone so the MCP server can read the complaint backlog.
   {
     name: 'exerciseReports'
+    partitionKeyPath: '/id'
+  }
+  // Snapshot sync (issue #140): user data added to *bundled* exercises —
+  // notes and photos. Keyed by the free-exercise-db `externalId`, not the
+  // local UUID, because a reinstall mints new UUIDs for the same exercise.
+  // Deliberately its own container rather than a `kind` discriminator inside
+  // `exercises`: reconcileContainer deletes every doc absent from the
+  // snapshot, so two doc kinds sharing a container means each push wipes the
+  // other unless every read remembers to union them first.
+  {
+    name: 'exerciseOverlays'
     partitionKeyPath: '/id'
   }
   // MCP write path (issue #88): durable operations drained by the phone.

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -93,6 +93,12 @@ var containers = [
     name: 'syncMeta'
     partitionKeyPath: '/id'
   }
+  // Snapshot sync (issue #135): user-filed exercise/app reports, mirrored
+  // from the phone so the MCP server can read the complaint backlog.
+  {
+    name: 'exerciseReports'
+    partitionKeyPath: '/id'
+  }
   // MCP write path (issue #88): durable operations drained by the phone.
   // Deliberately separate from the snapshot-reconciled containers.
   {

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -50,6 +50,25 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2023-12-01' = {
   }
 }
 
+// DEPLOY HAZARD — read before running `az deployment group create` on main.bicep.
+//
+// `siteConfig.appSettings` below is declarative and WHOLESALE: ARM replaces the
+// app's entire setting collection with exactly this list. The live app also
+// carries `WEBSITE_RUN_FROM_PACKAGE` (a SAS URL written by `func azure
+// functionapp publish`) and `WEBSITE_MOUNT_ENABLED`, neither of which can be
+// declared here — the SAS is a secret and rotates on every publish.
+//
+// So a full deployment of this module UNDEPLOYS THE RUNNING CODE: the API
+// starts returning 404 for /api/* until you re-publish. If you must deploy it:
+//
+//   1. cd infra/functions && npm run build
+//   2. az deployment group create -g rg-workout-app-prod --template-file infra/main.bicep ...
+//   3. func azure functionapp publish func-workout-prod   <-- NOT optional
+//   4. curl -sf https://func-workout-prod.azurewebsites.net/api/health
+//
+// For Cosmos-only changes (adding a container, #140), deploy
+// `infra/modules/cosmos.bicep` on its own instead — it touches no secrets and
+// cannot affect the Function App. Always `what-if` first.
 resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
   name: functionAppName
   location: location


### PR DESCRIPTION
Everything from the first two field sessions through the #135 report channel, plus the follow-ups triaged from it. **Nothing is on the phone yet** — this is `1.4.0 (5)`, unreleased.

## What ships

| Issue | What changed |
|---|---|
| **#136** | Exercise notes attach to the library `Exercise`, render on the card, and are editable at the machine |
| **#137** | Untouched reps adopt the previous session; weight deliberately never does |
| **#117** | History edits sync, can be cleared, and parse in any locale |
| **#138** | A stale MCP `dist/` announces itself; repo's first CI |
| **#139** | Closed — not a Finish defect. Split into #143 |
| **#140** | Backup carries bundled-exercise notes; sync half blocked, see below |
| **#128** | Template provenance, schema V4 |
| **#129** | `TemplateChangeDetector` |
| **#130** | Post-workout review card and apply |
| **#144** | Target reps on screen, drift flagged on PREVIOUS |

## Three findings worth reading

**#136's prescribed fix would have done nothing.** Copying `TemplateExercise.notes` into the session is correct but inert: the Lower B template has no notes on any exercise. The `"Ankle 4; Seat 4; Pivot 1"` note lived on the *2026-08-12 session* and arrived via sync — nothing in the app writes that field. A session-scoped note would have vanished again a week later. The note now lives on the `Exercise`, so it follows the machine into every workout.

**#128 as written crashes the app on launch.** Putting provenance fields on `Workout`/`WorkoutExercise` produced `NSInvalidArgumentException: Duplicate version checksums detected`. The `VersionedSchema` model lists name **live** Swift types, so adding a property changes what V1–V3 mean as well as V4 and all four hash identically. **This project cannot version a property-only change at all** without freezing copies of every affected model. Provenance therefore lives in two new models referencing the workout by plain UUID. The on-disk migration test caught it; the in-memory containers the rest of the suite uses passed the whole time.

**#139 was a draft, not a bug.** The workout now carries `completedAt`; the record's `_ts` moved between two reads while the phone caught up. `pushSnapshot` pushes in-progress drafts with no filter and nothing labels them, so a draft in the mirror is indistinguishable from a stranded session — filed as **#143**.

## Blocked, not skipped

Two actions were refused by the permission classifier and I did not route around them:

1. **`az cosmosdb sql container create`** for #140's `exerciseOverlays` container. The sync half of #140 is designed and documented on the issue but not built, and the client wire version is **still 3** — the current phone is unaffected. The one command to unblock it is on #140.
2. **The Split Squat 10 → 8 template edit** over MCP. Still unmade; #144 now makes the disagreement visible on screen either way.

## Verification

- Swift unit: **772 tests, 97 suites, exit 0**
- Azure Functions (jest): **172 pass**
- MCP (vitest): **64 pass**
- Nothing deployed. No production data written.
- XCUITest not run — flaky on this machine, and per HANDOFF.md a failure there is not a regression without a clean-worktree comparison.

The real acceptance probes are in the gym and are listed in `HANDOFF.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)